### PR TITLE
Allow specific tests to be included/excluded based on JVM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
   - VERSION=1.8 TARGET=test
   - VERSION=1.9 TARGET=test
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
   - oraclejdk9
 matrix:
   include:
-    # Test OpenJDK against latest Clojure stable
+    # Test latest OpenJDK against latest Clojure stable
     - env: VERSION=1.9 TARGET=test
       jdk: openjdk8
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@
 
 VERSION ?= 1.9
 
+# Some tests need to be filtered based on JVM version.  This selector
+# will be mapped to a function in project.clj, and that function
+# determines which `deftest` to run based on their metadata.
+TEST_SELECTOR = :java$(shell lein version | cut -d " " -f 5 | cut -d "." -f 1-2)
+
 test:
-	lein with-profile +$(VERSION) test
+	lein with-profile +$(VERSION) test $(TEST_SELECTOR)
 
 # Eastwood can't handle orchard.java.parser at the moment, because
 # tools.jar isn't in the classpath when Eastwood runs.

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
                  [org.clojure/tools.namespace "0.3.0-alpha4"]]
   :exclusions [org.clojure/clojure] ; see versions matrix below
 
+  :test-selectors {:java9.0 (complement :java9-excluded)}
+
   :profiles {
              ;; Clojure versions matrix
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer :all])
   (:require [orchard.namespace :as n]))
 
-(deftest project-namespaces-test
+;; Temporarily exclude this test under Java 9
+;; See http://bit.ly/2DtfMMl for details
+(deftest ^:java9-excluded project-namespaces-test
   (is (contains? (into #{} (n/project-namespaces))
                  'orchard.namespace)))
 


### PR DESCRIPTION
Pull request #4 noted that there were tests failing only under Java 9.  @bbatsov recalled an upstream issue related to classloader changes to support modules in Java 9 that was probably the root cause.

For now, this set of changes implements a test selector (as in, `lein with-profile +1.8 test :java9.0`) which allows individual tests to be labeled with metadata and excluded from java9 test passes.  Same mechanism will work for future (or past) versions of Java if needs arise.

While debugging this, I noticed Travis CI doesn't support `oraclejdk7` any longer. They dropped support after Oracle dropped support. So along with the test filtering I've also reverted to `openjdk7` since that's the only Java 7 compatible JVM available in Travis CI.  I also checked and they don't yet support an `openjdk9`.