### PR TITLE
Port `cider.nrepl.middleware.classpath`

### DIFF
--- a/src/orchard/classpath.clj
+++ b/src/orchard/classpath.clj
@@ -1,0 +1,44 @@
+(ns orchard.classpath
+  (:require [clojure.java.classpath :as cp]
+            [clojure.string :as str]
+            [orchard.classloader :as cl]
+            [orchard.misc :as u])
+  (:import java.io.File
+           java.util.jar.JarFile))
+
+(defn classpath
+  "Return a sequence of File objects of elements on the classpath.
+
+  Takes into account:
+
+  - Classpath trickery performed by Boot
+  - Java 9's boot classloader no longer being an instance of URLClassLoader"
+  ([]
+   (classpath (cl/class-loader)))
+  ([classloader]
+   (let [sep (re-pattern File/pathSeparator)
+         boot-classpath (u/boot-fake-classpath)
+         path (cond
+                boot-classpath (str/split boot-classpath sep)
+                (neg? (compare u/java-api-version "9")) (map str (cp/classpath classloader))
+                :else (-> (System/getProperty "java.class.path")
+                          (str/split sep)))]
+     (map #(File. %) path))))
+
+(defn classpath-directories
+  "Returns a sequence of File objects for the directories on classpath.
+
+  Uses `classpath` instead of `clojure.java.classpath/classpath`."
+  ([]
+   (classpath-directories (classpath)))
+  ([path]
+   (filter #(.isDirectory ^File %) path)))
+
+(defn classpath-jarfiles
+  "Returns a sequence of JarFile objects for the JAR files on classpath.
+
+  Uses `classpath` instead of `clojure.java.classpath/classpath`."
+  ([]
+   (classpath-jarfiles (classpath)))
+  ([path]
+   (map #(JarFile. ^File %) (filter cp/jar-file? path))))

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -1,11 +1,10 @@
 (ns orchard.namespace
   "Utilities for resolving and loading namespaces"
-  (:require [orchard.classloader :refer [class-loader]]
-            [clojure.java.classpath :as cp]
-            [clojure.tools.namespace
-             [file :as ns-file]
-             [find :as ns-find]]
-            [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [clojure.tools.namespace.file :as ns-file]
+            [clojure.tools.namespace.find :as ns-find]
+            [orchard.classloader :refer [class-loader]]
+            [orchard.classpath :as cp])
   (:import java.util.jar.JarFile))
 
 ;;; Namespace Loading

--- a/test/orchard/classpath_test.clj
+++ b/test/orchard/classpath_test.clj
@@ -1,0 +1,52 @@
+(ns orchard.classpath-test
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [orchard.classpath :as sut])
+  (:import java.io.File
+           java.nio.file.attribute.FileAttribute
+           java.nio.file.Files
+           java.util.jar.JarOutputStream
+           java.util.zip.ZipEntry))
+
+(deftest classpath-boot-test
+  (let [fake-paths [(System/getProperty "java.io.tmpdir")]
+        fake-classpath (str/join File/pathSeparator fake-paths)]
+    (testing "when fake.class.path is not set"
+      (is (not= fake-classpath (map str (sut/classpath)))))
+    (testing "when fake.class.path is set"
+      (try
+        (System/setProperty "fake.class.path" fake-classpath)
+        (is (= fake-paths (map str (sut/classpath))))
+        (finally
+          (System/clearProperty "fake.class.path"))))))
+
+(deftest classpath-test
+  (is (set/subset? (set (-> (System/getProperty "java.class.path")
+                            (str/split (re-pattern File/pathSeparator))))
+                   (set (map str (sut/classpath))))))
+
+(defn make-temp-dir
+  []
+  (-> (str (gensym))
+      (Files/createTempDirectory (into-array FileAttribute []))
+      .toFile))
+
+(defn make-temp-jar
+  []
+  (let [file (File/createTempFile (str (gensym)) ".jar")]
+    (with-open [out (JarOutputStream. (io/output-stream file))]
+      (.putNextEntry out (ZipEntry. (str (gensym)))))
+    file))
+
+(defn make-test-classpath
+  []
+  (shuffle (concat (repeatedly 2 make-temp-dir)
+                   (repeatedly 3 make-temp-jar))))
+
+(deftest classpath-directories-test
+  (is (= 2 (count (sut/classpath-directories (make-test-classpath))))))
+
+(deftest classpath-jarfiles-test
+  (is (= 3 (count (sut/classpath-jarfiles (make-test-classpath))))))


### PR DESCRIPTION
Per our discussion on clojure-emacs/cider-nrepl#486, we'll port the tool-independent portions of `cidernrepl.middleware.classpath` to Orchard.