### PR TITLE
[Fix #9] auto publish snapshots to clojars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,12 @@ jdk:
   - openjdk7
   - oraclejdk8
   - oraclejdk9
-matrix:
+stages:
+  - name: test
+  - name: check
+  - name: deploy
+    if: branch = master
+jobs:
   include:
     # Test latest OpenJDK against latest Clojure stable
     - env: VERSION=1.9 TARGET=test
@@ -24,18 +29,28 @@ matrix:
     - env: VERSION=master TARGET=test
       jdk: oraclejdk8
 
-    # Eastwood linter
-    - env: VERSION=1.9 TARGET=eastwood
-      jdk: oraclejdk8
-
-    # Check cljfmt
-    - env: VERSION=1.9 TARGET=cljfmt
-      jdk: oraclejdk8
-
     # Coverage analysis
     - env: VERSION=1.9 TARGET=cloverage
       jdk: oraclejdk8
-      after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
+      after_success:
+      - >
+        test $TARGET = "cloverage" &&
+        bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
+
+    # Eastwood linter
+    - stage: check
+      env: VERSION=1.9 TARGET=eastwood
+      jdk: oraclejdk8
+
+    # Check cljfmt
+    - stage: check
+      env: VERSION=1.9 TARGET=cljfmt
+      jdk: oraclejdk8
+
+    # Deployment
+    - stage: deploy
+      env: TARGET=deploy-xxx-dont-actually
+      jdk: oraclejdk8
 
   fast_finish: true      # don't wait for allowed failures before build finish
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean test eastwood cljfmt cloverage
+.PHONY: clean test eastwood cljfmt cloverage release deploy
 
 VERSION ?= 1.9
 
@@ -28,6 +28,22 @@ cljfmt:
 cloverage:
 	lein with-profile +$(VERSION),+cloverage cloverage --codecov \
 	     -e "orchard.java.parser"
+
+# When releasing, the BUMP variable controls which field in the
+# version string will be incremented in the *next* snapshot
+# version. Typically this is either "major", "minor", or "patch".
+
+BUMP ?= patch
+
+release:
+	lein with-profile +$(VERSION) release $(BUMP)
+
+# Deploying requires the caller to set environment variables as
+# specified in project.clj, to provide a login and password to the
+# artifact repository
+
+deploy:
+	lein with-profile +$(VERSION) deploy clojars
 
 clean:
 	lein clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/clojure-emacs/orchard.png?branch=master)](https://travis-ci.org/clojure-emacs/orchard)
 [![Dependencies Status](https://versions.deps.co/clojure-emacs/orchard/status.svg)](https://versions.deps.co/clojure-emacs/orchard)
+[![Coverage](https://codecov.io/gh/clojure-emacs/orchard/branch/master/graph/badge.svg)](https://codecov.io/gh/clojure-emacs/orchard/)
+
 
 # orchard (alpha)
 

--- a/project.clj
+++ b/project.clj
@@ -14,6 +14,20 @@
 
   :test-selectors {:java9.0 (complement :java9-excluded)}
 
+  :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]}
+
+  :release-tasks [["vcs" "assert-committed"]
+                  ["bump-version" "release"]
+                  ["vcs" "commit" "Release %s"]
+                  ["vcs" "tag" "v" "--no-sign"]
+                  ["bump-version"]
+                  ["vcs" "commit" "Begin %s"]]
+
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                    :username :env/clojars_username
+                                    :password :env/clojars_password
+                                    :sign-releases false}]]
+
   :profiles {
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.9.0"]]}


### PR DESCRIPTION
This publish should achieve auto-publish to clojars for snapshots, and controlled publishes for releases too.

The changes are as follows.

(1) In `project.clj`, add a `:deploy-repositories` configuration for clojars.  Note that the clojars credentials do need to be set in the environment, but GPG signing is disabled because as of today there is no mechanism for unattended GPG signing in Leiningen (see https://github.com/technomancy/leiningen/pull/2279). Secure credentials set manually in the Travis CI "Settings" page will be elided from the build logs like this:
```
Setting environment variables from repository settings
$ export CLOJARS_USERNAME=[secure]
$ export CLOJARS_PASSWORD=[secure]
```

(2) In `project.clj` add a `:release-tasks` that performs manipulation of the project version string, adds a tag, and commits changes to git. After a `lein release` you'll see two new commits. First commit has the description "Release 0.1.0" and is tagged "v0.1.0". Second commit is "Begin 0.1.1-SNAPSHOT". Pushing these commits will cause Travis CI jobs to run, and it's in the Travis CI job where the actual deploys will be done.

```
$ lein release 
[9-auto-publish-snapshots 4a90d89] Release 0.1.0
 1 file changed, 1 insertion(+), 1 deletion(-)
[9-auto-publish-snapshots 2ee967c] Begin 0.1.1-SNAPSHOT
 1 file changed, 1 insertion(+), 1 deletion(-)
```

(3) In the `Makefile` add targets `make release` and `make deploy`.  These are equivalent to the Leiningen commands, used in the Travis CI config.

(4) `.travis.yml` is ported from "build matrix" to "build stages" which is a beta feature. In this new style of config the `stages:` map defines three sequential stages that will run only if the prior stages finish successfully. (*)It's worth noting the `allow_failures:` field still applies here and any jobs allowed to fail can fail without blocking the deploy.

As in the prior `.travis.yml`, there is matrix of jobs implied by the list of `jdk:` and `env:`. This matrix is enumerated as before, and will be run as part of the "test" stage. For clarity I've moved the eastwood and cljfmt jobs into a separate "check" stage. The "deploy" stage is last.

The net result of all this is, any commit you push to the master branch will result in a new artifact on clojars (provided the CI jobs succeed).  If you happen to be working on a snapshot version then a new snapshot is published, and if you happen to have run `make release` then you'll get a new release version AND the first iteration of the next snapshot.

