### PR TITLE
Ensure CI deploy jobs run at the proper times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,14 @@ jdk:
 stages:
   - name: test
   - name: check
+  # Deploy only from the home repo where the credentials can be
+  # properly decrypted. Never deploy from a pull request job.
+  # In addition, ensure we're on the master branch (snapshots)
+  # or a branch with semver naming (releases).
   - name: deploy
-    if: branch = master
+    if: repo = clojure-emacs/orchard
+        AND type != pull_request
+        AND ( branch = master OR branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ )
 jobs:
   include:
     # Test latest OpenJDK against latest Clojure stable

--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,10 @@ release:
 
 # Deploying requires the caller to set environment variables as
 # specified in project.clj to provide a login and password to the
-# artifact repository.  We're setting TRAVIS_PULL_REQUEST to a default
-# value to avoid accidentally deploying from the command line. Inside
-# Travis CI this variable will be set to the pull request number, or
-# to "false" if it's not a pull request.
-
-TRAVIS_PULL_REQUEST ?= "true"
+# artifact repository.
 
 deploy:
-	if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-	    echo "Pull request detected. Skipping deploy."; \
-	else \
-	    lein with-profile +$(VERSION) deploy clojars; \
-	fi
+	lein with-profile +$(VERSION) deploy clojars
 
 clean:
 	lein clean


### PR DESCRIPTION
Fixing two errors by updating the conditional test in the deploy
stage in `.travis.yml`

1. While `make release` creates a new version tag from which the
release should build and deploy, it turns out the resulting CI job
does not run the deploy task, because for those jobs the branch name
is not "master".  With this commit we allow deploys from branches
where the name matches "v#.#.#".

2. Anyone running Travis CI builds on their own fork of this project
ended up with failed deploy jobs because the Clojars credentials could
not be parsed. With this commit we exclude deploy jobs from even
running if we're on a fork.