### PR TITLE
[clojure-emacs/cider-nrepl#489] Migrate tests from cider-nrepl

### DIFF
--- a/test/orchard/classloader_test.clj
+++ b/test/orchard/classloader_test.clj
@@ -1,0 +1,22 @@
+(ns orchard.classloader-test
+  (:require [orchard.classloader :as cl]
+            [orchard.java :as java]
+            [clojure.test :refer :all]))
+
+(deftest boot-resource-path-test
+  (let [tmp-dir-name (System/getProperty "java.io.tmpdir")]
+    (testing "when classpath is a jar"
+      (let [tmp-jar-path "jar:file:fake/clojure.jar"]
+        (try
+          (System/setProperty "fake.class.path" tmp-jar-path)
+          (is (some #{"file:fake/clojure.jar"}
+                    (->> (cl/class-loader) .getURLs (map str))))
+          (finally
+            (System/clearProperty "fake.class.path")))))
+    (testing "include sources when avaliable"
+      (when-let [src-url (java/jdk-resource-url "src.zip")]
+        (try
+          (System/setProperty "fake.class.path" tmp-dir-name)
+          (is (some #{src-url} (.getURLs (cl/class-loader))))
+          (finally
+            (System/clearProperty "fake.class.path")))))))


### PR DESCRIPTION

This is the companion to clojure-emacs/cider-nrepl#507 in which test namespaces were restructured to eliminate orchard dependencies. In a few cases, we needed to migrate tests into orchard.
