### PR TITLE
Migrate `relevant-meta` and `relevant-meta-keys` back to cider-nrepl

### DIFF
--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -285,17 +285,3 @@
           ;; Clojure (even though it's inside meta).
           {original-key (list 'quote (strip-meta form))}))
       expanded)))
-
-(def relevant-meta-keys
-  "Metadata keys that are useful to us.
-  This is used so that we don't crowd the ns cache with useless or
-  redudant information, such as :name and :ns."
-  [:indent :deprecated :macro :arglists :test :doc :fn
-   :cider/instrumented :style/indent :clojure.tools.trace/traced])
-
-(defn relevant-meta
-  "Filter the entries in map m by `relevant-meta-keys` and non-nil values."
-  [m]
-  (->> (select-keys m relevant-meta-keys)
-       (filter second)
-       (u/update-vals pr-str)))

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -45,19 +45,6 @@
   ([a] nil)
   ([]))
 
-(deftest relevant-meta-test
-  (is (= (m/relevant-meta (meta #'test-fn))
-         {:arglists "([a b] [a] [])"
-          :doc "\"docstring\""}))
-  (is (= (:macro (m/relevant-meta (meta #'deftest)))
-         "true"))
-  (let [m (meta #'strip-meta-test)]
-    ;; #'strip-meta-test refers to the deftest, and not the defn
-    (alter-meta! #'strip-meta-test merge {:indent 1 :cider-instrumented 2 :something-else 3})
-    (is (= (m/relevant-meta (meta #'strip-meta-test))
-           {:indent "1", :test (pr-str (:test (meta #'strip-meta-test)))}))
-    (alter-meta! #'strip-meta-test (fn [x y] y) m)))
-
 (defmacro test-macro [& x]
   `(do ~@x))
 


### PR DESCRIPTION
Per [this comment](https://github.com/clojure-emacs/cider-nrepl/pull/507#discussion_r168180244) in clojure-emacs/cider-nrepl#507 this particular function is not likely useful outside cider-nrepl. In order to clean up some implementation details on the other side, then, this change moves the function back.

This PR needs to be merged at the same time as clojure-emacs/cider-nrepl#507 to avoid breaking the builds.
