### PR TITLE
[#18] Add "make docs" target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-/target
-/classes
+/.lein-*
+/.nrepl-port
 /checkouts
+/classes
+/gh-pages
+/target
+autodoc.sh
 pom.xml
 pom.xml.asc
 *.jar
 *.class
-/.lein-*
-/.nrepl-port
-.hgignore
-.hg/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,15 @@ env:
   global:
     - secure: "BhXYh0WHTAzxFTEJHepjb3iBCRUiN+vvCKm8P0G89ZeuJIZ4wfI0lFxA46KPMFe42w4hFUYdrhoV5/BcUE16o1F/OThBIEmTuF4KaKjBaBBGkZuOOMdkgbXCAeiqrY97D/Stxwq0k/udYYm3VtzWb+RBXEgM+jxbTg8We4csl1R4uDoEZKbqF25PaJNMLfxcH9e94XpZDlSfJmqKkr/s9HrH+X5lnPLx5g2/MJLk1O96UDQwSSoX94wQerMDRDFBEXD2DOlNgYi4bkWGoCBkIgzyS5haCSohi/gxhnJkZXOExkjFiLYibK0nqA6tRdK9TdETTjTPpPVojO9R76WxaSQwsWEQevGGnDmDfX/WUYHpLBGRVUl47GlQ+KA05lQtkqH5Gs87qsw7ItHq43uE3AsdoWrZCHzKeumlBExz/stx59sWX888F/AOo0fRVh+HAMCMkkl2R6NQoT8IAOszpjl0V4SDeLx7i+SvMKuMC/gsk859O1PmJN6CS7x4x0Y7iTA+eRnKYxwkJIzZMiaWfV7IZmnHWN6C8lU7al0yRmUWKJhTnl6ysuN7r1ceY4NSnZDgibjUH94b4lu2YRjXdTyQgnlfSfsPsoSRb1dcZul4XWQKdRt+pcZgW2yToRUKA4lBA2NK3yLyHVf8lZ2OTMYMGgRXUrU8AJ7r8c3n5kM="
     - secure: "FjWsaYElco5BM3MeBxU7O00JBWjIccadpGLPzW2frx1ridDemJjOQ+J2z3UBfQkhI5q5Hc9p2lnozmbKl2Lz91krZH2akVtL/91t0XFJTmIQNjbHr8T4ErIMA78Ol1lfJAsMUenZUXORu2HUVeP5kbQdkgBfcP4cCOrsEYKurcrp9+aZhYkjIKheAc6yHGmIwd0M4C1YlGFEREwuTAGE0bMyQodp154o6LNyQmDii+vTPGGyz7YPGrXH3+UQ9+T5WQKse+ztghwIsqwy03fMvme0VLwKrgywcV2ewy+fOzAzHVx6LvDbY5W5rw9lsu+7NIlEpQ90cgXEdMQSHYjr1v97QomSfAVZUNYE6o7LQ7/wtv5Dxmhg6f+IeRnGUOFQI9smSSGbiyWaim2BJ9Xv4309n8jHhb7+klfX8cBM9PZVm3EvUh+e4xfSi/hjluA4wneXXtPsCUkztAtexo5rh3PDrqq+Aotuy4Mh7BL+dO6BKLT2sqc9daZqAnDHb0tYvJXclT95nbEtWS5dmrj17Nl12ajl1tH1zeG7cJbserPNVn5qvpsGjLMF6pZUqKp/pBanHUJOlYSbcJsTho08SedihU5NBLKcRg9vr7PcesA2WN7m2Yaqjt24QOLTHzPg8JKp0qzA1f5gjmXuzZBjFc28W5I/dZzJO45axZ+cqig="
+    - secure: "W+o4EJf1yNsuKWqHTQF1QcWHLUKXzN1ERngXdPK+QbRx6IVIjs9DvDm+PEnIepJxLSxZednR/GXayrjW6h2GPwDs3vHmhj0mvTpyMWELLO3/jYbll5n/RInUNDYA3Zc8P7+E1lrix/7VR8urSPrrT2ShzzvkHcgtOGO83wlYlNnavqMlvw6Bw7oZsGKgtpsqvF/WheQ01k+tJZHvnitflWMrwYGt6QJFyExs2aKhIug80ZgzqHKsz1ET7ZKfZSPO0zSrAJlJM72NJ+XZbwpWbDcbYB/ENNsqEM1AywD+dYf3Aw6JsOyuDdCIJ1mOKa26q1/5977COUvxIq6aHjxxTE+OAgNBQaHeYNxduUEE4pjtuWPZuiiiMGMd4UxI1gEKXL13nM5W5DNIuWbN8BNWwDedsXxTiF3ZNdk/e6iRZtf/FyA344/aQNYX7GiDDPIJ7NumP8wMeLK8Z/cKwnKSqqXJE+SrILGDC35g/TDnhKRgl1LTNORyik9vDj7Tur7sYfM4M1F9vLFDmF7vddoqyrcx1LwxyYgoAKwVegIJl9FInn51jRL4KFYAS4VGe7PwliUWYDzHs2SmCnRWhgCdeNS5PI9GWi36qiCLBK41gp+OAI/j+m9w2rpBxisfqz/YMw8nzjE2+mh79TKEkSCNj/QUX7aI1yKbUvbnDBf2s78="
+    - secure: "Kj9e6zoDmhmlwTLBnBReV8sxfDZN22JG5IcgjfTyOUhcL1vEIvtV52ltxK1U4RQn2ZdLNCLfKPoSXwJvmqcfe12sNkGj3ouQ2NiSyC64q5eXcSVmw/60ChBJhTlb8OnIgP5WSjxAoX/78iVmAkdZXThcNLdzw8UsmpYiMgyDMKNQ6eDUPoIRnA1QYYm80UcYF43EFqxMMb9X6iwLiuGBUes9+D6Uaja55KUEz/BrFKmbcMdCFFuOMP9ItL425o9Be76qItr1wj4jh3jg7hqxOyxW7I0i4Ygr38kb3AOTWNIIb3km+P9ibhaDyVjBL4dK/BCFLr9KTF0MQbmQ2wBgFdUCKv7Iz5+avnQqJHOJsCHfPlhSNGUv7eZTr4cvH1MsgpAC6rknjLJla6lQZSouoqmi8bmpNTEu1HvcLtniYR/BbZcUA2nJqbfZfdDLFGHfIHHtC3xjx82Fqxl+0JqqGfBYkCgLAcvbQIGMR8uhfwrxSGmIrZbRQ41PAQNmI2o/lCpyI/jPS5Q9SwhgLy0mjfNhjrF4iEoku46IR8vdwBrDFE5bJVtKJQ13OeHSCApgVG8DcW0dcWq+OTt65sji9TexHpcMJwxUAFiRmCRtG73KR5hCl7pJ1YOyR4X3Fgwsm6dhXLjLPXIhkC0UVhupBUFQAfxaFQOMqLSNVMBy9xQ="
 jdk:
   - openjdk7
   - oraclejdk8
   - oraclejdk9
 stages:
-  - name: test
   - name: check
+  - name: test
   # Deploy only from the home repo where the credentials can be
   # properly decrypted. Never deploy from a pull request job.
   # In addition, ensure we're on the master branch (snapshots)
@@ -54,7 +56,12 @@ jobs:
       env: VERSION=1.9 TARGET=cljfmt
       jdk: oraclejdk8
 
-    # Deployment
+    # Deploy documentation
+    - stage: deploy
+      env: TARGET=docs
+      jdk: oraclejdk8
+
+    # Deploy artifacts
     - stage: deploy
       env: TARGET=deploy
       jdk: oraclejdk8
@@ -63,8 +70,6 @@ jobs:
   allow_failures:
     - env: VERSION=master TARGET=test
     - env: VERSION=1.9 TARGET=cloverage
-    - env: VERSION=1.9 TARGET=eastwood
-    - env: VERSION=1.9 TARGET=cljfmt
 
 #notifications:
 #  webhooks:

--- a/project.clj
+++ b/project.clj
@@ -41,6 +41,16 @@
              :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
 
              ;; CI tools
+             :codox {:plugins [[lein-codox "0.10.3"]]
+                     :codox #=(eval
+                               (let [repo   (or (System/getenv "TRAVIS_REPO_SLUG") "clojure-emacs/orchard")
+                                     branch (or (System/getenv "AUTODOC_SUBDIR") "master")
+                                     urlfmt "https://github.com/%s/blob/%s/{filepath}#L{line}"]
+                                 {;; Distinct docs for tagged releases as well as "master"
+                                  :output-path (str "gh-pages/" branch)
+                                  ;; Generate URI links from docs back to this branch in github
+                                  :source-uri  (format urlfmt repo branch)}))}
+
              :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]


### PR DESCRIPTION
The "make codox" target, together with the configuration in `project.clj` causes a set of documentation to be produced under `gh-pages/{branch}` for whatever is the current branch.

This is a step toward auto-doc generation in CI. However before we can automate there needs to be some admin work on the GitHub project.
- [ ] a `gh-pages` branch needs to be created and pushed. Preferably an orphan branch with no parent.
- [x] we need a GitHub API token with permission to push, and encrypted for Travis (and eventually this will need to be done again for CircleCI)
- [ ] confirm GitHub Pages settings are publishing these docs from the `gh-pages` branch (I've seen GitHub figure this out automagically once the branch exists)


----

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings

Keep in mind that new orchard builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.
