### PR TITLE
Make sure project namespaces are found on Windows* OSes

### DIFF
--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -1,6 +1,12 @@
 (ns orchard.misc
   (:require [clojure.string :as str]))
 
+(def ^:const windows-prefix
+  "Windows")
+
+(defn os-windows? []
+  (.startsWith (System/getProperty "os.name") windows-prefix))
+
 (defn boot-fake-classpath
   "Retrieve Boot's fake classpath.
   When using Boot, fake.class.path contains the original directories with source

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -1,6 +1,8 @@
 (ns orchard.namespace-test
-  (:require [clojure.test :refer :all])
-  (:require [orchard.namespace :as n]))
+  (:require [clojure.test :refer :all]
+            [orchard.namespace :as n]
+            [orchard.misc :as misc]
+            [clojure.string :as str]))
 
 ;; Temporarily exclude this test under Java 9
 ;; See http://bit.ly/2DtfMMl for details
@@ -14,3 +16,14 @@
   ;; Shouldn't return any orchard namespaces
   (is (not-any? #(re-find #".*orchard" %)
                 (n/loaded-namespaces [".*orchard"]))))
+
+(deftest project-nses-ignore-case-on-windows-test
+  (let [orig-project-root n/project-root]
+    (testing "Project nses is case sensitive on non Windows oses"
+      (with-redefs [misc/os-windows? (constantly false)
+                    n/project-root   (str/replace orig-project-root "orchard" "Orchard")]
+        (is (not (seq (n/project-namespaces))))))
+    (testing "Project nses ignore cases on Windows oses"
+      (with-redefs [misc/os-windows? (constantly true)
+                    n/project-root   (str/replace orig-project-root "orchard" "Orchard")]
+        (is (seq (n/project-namespaces)))))))


### PR DESCRIPTION
When filtering the classpath with the project root lowercase both
sides of the comparison if the OS is Windows.

Enables running all tests on Windows, without this change no tests are
found because of a lower/upper case mismatch when filtering
the project neses on Windows.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings

Keep in mind that new orchard builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

Thanks!
