### PR TITLE
Add environment query functions

### DIFF
--- a/eastwood.clj
+++ b/eastwood.clj
@@ -11,7 +11,39 @@
   :reason "The `break` macro commonly expands to contain an `if` with a condition that is a constant."})
 
 (disable-warning
+ {:linter :suspicious-expression
+  ;; specifically, those detected in function suspicious-macro-invocations
+  :for-macro 'clojure.core/let
+  :if-inside-macroexpansion-of #{'clojure.core/when-first}
+  :within-depth 6
+  :reason "when-first with an empty body is warned about, so warning about let with an empty body in its macroexpansion is redundant."})
+
+(disable-warning
+ {:linter :suspicious-expression
+  ;; specifically, those detected in function suspicious-macro-invocations
+  :for-macro 'clojure.core/let
+  :if-inside-macroexpansion-of #{'clojure.core/when-let}
+  :within-depth 6
+  :reason "when-let with an empty body is warned about, so warning about let with an empty body in its macroexpansion is redundant."})
+
+(disable-warning
+ {:linter :suspicious-expression
+  ;; specifically, those detected in function suspicious-macro-invocations
+  :for-macro 'clojure.core/let
+  :if-inside-macroexpansion-of #{'clojure.core/when-some}
+  :within-depth 3
+  :reason "when-some with an empty body is warned about, so warning about let with an empty body in its macroexpansion is redundant."})
+
+(disable-warning
+  {:linter :suspicious-expression
+   :for-macro 'clojure.core/and
+   :if-inside-macroexpansion-of #{'clojure.spec/every 'clojure.spec.alpha/every
+                                  'clojure.spec/and 'clojure.spec.alpha/and}
+   :within-depth 6
+   :reason "clojure.spec's macros `every` and `and` often contain `clojure.core/and` invocations with only one argument."})
+
+(disable-warning
  {:linter :constant-test
-  :if-inside-macroexpansion-of #{'clojure.core/cond->}
-  :within-depth 2
-  :reason "The `cond->` macro can legitimately contain always-true predicates."})
+  :if-inside-macroexpansion-of #{'clojure.core/cond-> 'clojure.core/cond->>}
+  :within-depth 2})
+:reason "Allow cond-> and cond->> to have constant tests without warning"

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -130,7 +130,7 @@
    :protocol :line :column :static :added :deprecated :resource])
 
 (defn var-meta
-  "Return a map of metadata for var or special form v.
+  "Return a map of metadata for var v.
   If whitelist is missing use var-meta-whitelist."
   ([v] (var-meta v var-meta-whitelist))
   ([v whitelist]
@@ -146,11 +146,16 @@
   (concat (keys (var-get #'clojure.repl/special-doc-map))
           '[& catch finally]))
 
+(defn meta+
+  "Return special form or var's meta."
+  [v]
+  (or (special-sym-meta v)
+      (meta v)))
+
 (defn var-name
   "Return special form or var's namespace-qualified name as string."
   [v]
-  (let [mta (or (special-sym-meta v)
-                (meta v))]
+  (let [mta (meta+ v)]
     (if-let [ns (:ns mta)]
       (str (ns-name ns) "/" (:name mta))
       (name (:name mta)))))
@@ -159,8 +164,7 @@
   "Return special form or var's docstring, optionally limiting the number of
   sentences returned to n."
   ([v]
-   (or (:doc (or (special-sym-meta v)
-                 (meta v)))
+   (or (:doc (meta+ v))
        "(not documented)"))
   ([n v]
    (->> (-> (var-doc v)

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -127,3 +127,8 @@
               (first paths)
               (recur (rest paths)))))))
     (catch Throwable _ nil)))
+
+(defn has-tests?
+  "Return a truthy value if the namespace has any vars with `:test` metadata."
+  [ns]
+  (seq (filter (comp :test meta val) (ns-interns ns))))

--- a/src/orchard/query.clj
+++ b/src/orchard/query.clj
@@ -1,0 +1,88 @@
+(ns orchard.query
+  "Query for namespaces and vars"
+  (:require [orchard.meta :as m]
+            [orchard.namespace :as ns]))
+
+(defn namespaces
+  "Takes a map containing these keys:
+
+  `:exactly` The namespaces returned should be exactly these.
+  `:project?` If true, the namespaces should all belong to the project.
+  `:load-project-ns?` If true, the project namespaces will be loaded if they are not already.
+  `:has-tests?` If true, only return namespaces containing tests.
+  `:include-regexps` A list of regexps which the namespaces must match.
+  `:exclude-regexps` A list of regexps which the namespaces must not match.
+
+  Returns a list of namespaces as `find-ns` would return them on the host."
+  [{:keys [project? load-project-ns?] :as ns-query}]
+  (cond->> (cond
+             (:exactly ns-query)
+             (:exactly ns-query)
+
+             project?
+             (if load-project-ns?
+               (map find-ns (ns/load-project-namespaces))
+               (map find-ns (ns/loaded-project-namespaces)))
+
+             :else
+             (all-ns))
+
+    true
+    (remove ns/inlined-dependency?)
+
+    (:has-tests? ns-query)
+    (filter ns/has-tests?)
+
+    (:include-regexps ns-query)
+    (filter #(ns/internal-namespace? % (:include-regexps ns-query)))
+
+    (:exclude-regexps ns-query)
+    (remove #(ns/internal-namespace? % (:exclude-regexps ns-query)))))
+
+(defn vars
+  "Takes a map containing these keys:
+  `:ns-query` A ns-query as `namespaces` takes, used to filter namespaces which contain vars.
+  `:private?` Include private vars in the results.
+  `:test?` Filter to vars which are also tests.
+  `:include-meta-key` A list of keywords searched for in the var's metadata, vars matching will be included.
+  `:exclude-meta-key` A list of keywords searched for in the var's metadata, vars matching will be excluded.
+  `:search` A regex to use for filtering vars, matches against `:search-property`.
+  `:search-property` Either :doc or :name, defaults to `:name`.
+  `:manipulate-vars` A callback run with the list of namespaces return by namespaces and the vars found within. Can be used to manipulate the list of vars before they are filtered.
+
+  Returns a list of vars, as the type that `var` would return on the host."
+  [{:keys [ns-query
+
+           private?
+           test?
+
+           include-meta-key
+           exclude-meta-key
+
+           search
+           search-property
+
+           manipulate-vars]
+    :as var-query}]
+  (let [ns-vars (if private? ns-interns ns-publics)
+        nss (namespaces ns-query)]
+    (cond->> (or (:exactly var-query)
+                 (mapcat (comp vals ns-vars) nss))
+
+      manipulate-vars
+      (manipulate-vars nss)
+
+      search
+      (filter (comp (partial re-find search)
+                    (case (or search-property :name)
+                      :doc m/var-doc
+                      :name m/var-name)))
+
+      test?
+      (filter #(:test (m/meta+ %)))
+
+      include-meta-key
+      (filter #((apply some-fn include-meta-key) (m/meta+ %)))
+
+      exclude-meta-key
+      (remove #((apply some-fn exclude-meta-key) (m/meta+ %))))))

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -27,3 +27,6 @@
       (with-redefs [misc/os-windows? (constantly true)
                     n/project-root   (str/replace orig-project-root "orchard" "Orchard")]
         (is (seq (n/project-namespaces)))))))
+
+(deftest has-tests-errors
+  (is (n/has-tests? (find-ns 'orchard.namespace-test))))

--- a/test/orchard/query_test.clj
+++ b/test/orchard/query_test.clj
@@ -1,0 +1,75 @@
+(ns orchard.query-test
+  (:require [clojure.set :as set]
+            [clojure.test :refer :all]
+            [orchard.query :refer :all]))
+
+(def ^:private a-private)
+(def ^:abc a-metad)
+(def ^:abc ^:def b-metad)
+
+(defn- docd-fn
+  "@@@regexpfriendly"
+  [])
+
+(deftest namespaces-test
+  (are [ns-query subset] (set/subset?
+                          (set (map the-ns subset))
+                          (set (namespaces ns-query)))
+    {:has-tests? true} #{'orchard.namespace-test}
+    {:project? true} #{'orchard.core 'orchard.meta 'orchard.namespace-test}
+    {:project? true
+     :has-tests? true} #{'orchard.namespace-test 'orchard.query-test}
+    {:include-regexps [#"query"]} #{'orchard.query 'orchard.query-test}
+    {:include-regexps [#"query"]
+     :exclude-regexps [#"test$"]} #{'orchard.query})
+  (are [ns-query subset] (empty? (set/intersection
+                                  (set (map the-ns subset))
+                                  (set (namespaces ns-query))))
+    {:has-tests? true} #{'orchard.namespace}
+    {:project? true} #{'clojure.core}
+    {:project? true
+     :has-tests? true} #{'orchard.namespace 'clojure.core}
+    {:include-regexps [#"orchard"]} #{'clojure.core}
+    {:include-regexps [#"orchard" #"query-env"]} #{'clojure.core 'clojure.set}
+    {:include-regexps [#"query"]
+     :exclude-regexps [#"test$"]} #{'orchard.query-test})
+  (is (= (namespaces {:exactly [(the-ns 'clojure.core) (the-ns 'clojure.set)]})
+         [(the-ns 'clojure.core) (the-ns 'clojure.set)])))
+
+(deftest vars-test
+  (are [var-query subset] (set/subset?
+                           (set (map find-var subset))
+                           (set (vars var-query)))
+    {:exactly [(find-var 'orchard.query-test/a-private)]}
+    #{'orchard.query-test/a-private}
+    {:private? true} #{'orchard.query-test/a-private
+                       'orchard.query/vars}
+    {:test? true} #{'orchard.query-test/vars-test}
+    {:include-meta-key [:abc]} #{'orchard.query-test/a-metad
+                                 'orchard.query-test/b-metad}
+    {:exclude-meta-key [:def]} #{'orchard.query-test/a-metad}
+    {:search #"metad"} #{'orchard.query-test/a-metad
+                         'orchard.query-test/b-metad}
+    {:search #"@@@.*"
+     :search-property :doc
+     :private? true} #{'orchard.query-test/docd-fn})
+
+  (is
+   (set/subset?
+    #{'x/my-test-var}
+    (set
+     (vars
+      {:manipulate-vars
+       (fn [nss vars]
+         (concat vars ['x/my-test-var]))}))))
+
+  (are [var-query subset] (empty? (set/intersection
+                                   (set (map find-var subset))
+                                   (set (vars var-query))))
+    {} #{'orchard.query-test/a-private}
+    {:test? true} #{'orchard.query/namespaces
+                    'orchard.query/vars}
+    {:search #"vars-test"} #{'clojure.core/defn 'orchard.query-test/namespaces-test}
+    {:include-meta-key [:abc]
+     :exclude-meta-key [:def]} #{'orchard.query-test/b-metad}
+    {:exclude-meta-key [:def]} #{'orchard.query-test/b-metad}))


### PR DESCRIPTION
This was added to allow the sharing of query logic between various
different facets of cider.  Apropos, tests, and the namespace explorer
all expose different methods for operating on sets of vars from the
environment.

In particular, I want to do an apropos of only project namespaces, and
this isn't possible with current filtering rules.

I'm suspect that my naming is not very good, so feedback on that is good.  It's
also notable that this changes apropos to use clojure types natively, and
expects cider-nrepl to do the correct coercion from bencode.