### PR TITLE
Remove reflection warning

### DIFF
--- a/src/orchard/eldoc.clj
+++ b/src/orchard/eldoc.clj
@@ -80,7 +80,7 @@
                  (or (:in query) "$")
                  ;; query as vector
                  (let [partitioned (partition-by keyword? query)
-                       index (.indexOf partitioned '(:in))]
+                       index (.indexOf ^clojure.lang.LazySeq partitioned '(:in))]
                    (if (= index -1)
                      "$"
                      (nth partitioned (+ 1 index)))))]


### PR DESCRIPTION
The Clojure compiler is unable to devine that `partitioned` is a `clojure.lang.LazySeq`, and emits a reflection warning when Cider is run in a project where `*warn-on-reflection*` is set to `true` globally.
This type-hint removes that warning

Before submitting a PR make sure the following things have been done:

- [ x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x ] All tests are passing
- [ x] The new code is not generating reflection warnings 

Keep in mind that new orchard builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

Thanks!
