### PR TITLE
get rid of npe in class-info*

### DIFF
--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -168,7 +168,7 @@
                        (source-info class)
                        {:name       (-> c .getSimpleName symbol)
                         :class      (-> c .getName symbol)
-                        :package    (-> c package symbol)
+                        :package    (some-> c package symbol)
                         :super      (-> c .getSuperclass typesym)
                         :interfaces (map typesym (.getInterfaces c))
                         :javadoc    (javadoc-url class)}))))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -66,6 +66,12 @@
         (is (every? map? (vals (:members c1))))
         (is (apply (every-pred :name :modifiers)
                    (mapcat vals (vals (:members c1))))))
+      (testing "doesn't throw on classes without dots in classname"
+        (let [reified (binding [*ns* (create-ns 'foo)]
+                        (clojure.core/eval
+                         '(clojure.core/reify Object)))
+              sym (symbol (.getName (class reified)))]
+          (is (class-info sym))))
       (testing "that doesn't exist"
         (is (nil? c3))))))
 


### PR DESCRIPTION
In recent version of cider-nrepl I've encountered an NPE when trying to load a file:
> #error { :cause nil
              :via  [{:type java.lang.NullPointerException
                         :message nil
                         :at [clojure.lang.Symbol intern Symbol.java 59]}]
                         :trace
 [[clojure.lang.Symbol intern Symbol.java 59]
  [clojure.core$symbol invokeStatic core.clj 581]
  [clojure.core$symbol invoke core.clj 576]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$class_info_STAR_ invokeStatic java.clj 169]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$class_info_STAR_ invoke java.clj 158]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$class_info invokeStatic java.clj 201]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$class_info invoke java.clj 195]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$resolve_class invokeStatic java.clj 272]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$resolve_class invoke java.clj 262]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$resolve_symbol invokeStatic java.clj 297]
  [cider.inlined_deps.orchard.v0v3v2.orchard.java$resolve_symbol invoke java.clj 284]
  [cider.nrepl.middleware.stacktrace$analyze_fn invokeStatic stacktrace.clj 88]
  [cider.nrepl.middleware.stacktrace$analyze_fn invoke stacktrace.clj 67]
  [clojure.core$comp$fn__4239 invoke core.clj 2563]
  [clojure.core$comp$fn__4239 invoke core.clj 2563]
  [clojure.core$comp$fn__4239 invoke core.clj 2563]
  [cider.nrepl.middleware.stacktrace$analyze_frame invokeStatic stacktrace.clj 185]
  [cider.nrepl.middleware.stacktrace$analyze_frame invoke stacktrace.clj 182]
  ...

I believe that it appeared after 124542e743f32b0304030272a4aac372e271d602 and is caused by getting package of objects that were instantiated using reify, as its classnames have no dots in it.

```
(ns sample)

(defprotocol P)
(def cls (class (reify P)))

cls             => sample$reify__6289
(package cls)   => nil
```
