### PR TITLE
Various inspector improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* [#35](https://github.com/clojure-emacs/orchard/pull/35): [Inspector] Render Java's lists, maps, and arrays as collections.
+* [#35](https://github.com/clojure-emacs/orchard/pull/35): [Inspector] Truncate long inline values
+
 ## 0.3.3 (2018-10-20)
 
 ### Bugs fixed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cider/orchard "0.3.3"
+(defproject cider/orchard "0.3.4-SNAPSHOT"
   :description "A fertile ground for Clojure tooling"
   :url "https://github.com/clojure-emacs/orchard"
   :license {:name "Eclipse Public License"

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -150,6 +150,15 @@
 (defn- short? [coll]
   (<= (count coll) 5))
 
+(def ^:private truncate-max-length 150)
+
+(defn- truncate-string [s]
+  (when s
+    (let [len (count s)]
+      (if (> len truncate-max-length)
+        (str (subs s 0 (- truncate-max-length 2)) "...")
+        s))))
+
 (defn value-types [value]
   (cond
     (nil? value)                                   nil
@@ -176,7 +185,7 @@
 (defmulti inspect-value #'value-types)
 
 (defmethod inspect-value :atom [value]
-  (pr-str value))
+  (truncate-string (pr-str value)))
 
 (defmethod inspect-value :seq-empty [value]
   (pr-str value))
@@ -227,7 +236,7 @@
   (pr-str value))
 
 (defmethod inspect-value :default [value]
-  (str value))
+  (truncate-string (str value)))
 
 (defn render-onto [inspector coll]
   (update-in inspector [:rendered] concat coll))

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -140,8 +140,7 @@
 
 (defn safe-pr-seq [value fmt]
   (->> (map inspect-value value)
-       (interpose " ")
-       s/join
+       (s/join " ")
        (format fmt)))
 
 (defn value-types [value]
@@ -172,8 +171,7 @@
   (->> value
        (map (fn [[k v]]
               (str (inspect-value k) " " (inspect-value v))))
-       (interpose ", ")
-       s/join
+       (s/join ", ")
        (format "{ %s }")))
 
 (defmethod inspect-value :map-long [value]

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -479,5 +479,7 @@
   (print x))
 
 (defn inspect-print [x]
-  (doseq [component (:rendered (inspect-render (fresh) x))]
-    (inspect-print-component component)))
+  (print
+   (with-out-str
+     (doseq [component (:rendered (inspect-render (assoc (fresh) :display-fields true) x))]
+       (inspect-print-component component)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -23,6 +23,7 @@
 (def long-vector (vec (range 70)))
 (def long-map (zipmap (range 70) (range 70)))
 (def long-nested-coll (vec (map #(range (* % 10) (+ (* % 10) 80)) (range 200))))
+(def truncated-string (str "\"" (apply str (repeat 147 "a")) "..."))
 
 (defn inspect
   [value]
@@ -224,6 +225,7 @@
     (are [result form] (= result (inspect/inspect-value form))
       "1" 1
       "\"2\"" "2"
+      truncated-string (apply str (repeat 300 \a))
       ":foo" :foo
       ":abc/def" :abc/def
       "( :a :b :c )" '(:a :b :c)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -17,6 +17,8 @@
 
 (def inspect-result-with-nil ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"1\" 1) (:newline) \"  \" \"1\" \". \" (:value \"2\" 2) (:newline) \"  \" \"2\" \". \" (:value \"\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline))"])
 
+(def java-hashmap-inspect-result ["(\"Class\" \": \" (:value \"java.util.HashMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"2\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"3\" 4) (:newline) \"  \" (:value \":a\" 5) \" = \" (:value \"1\" 6) (:newline))"])
+
 (def long-sequence (range 70))
 (def long-vector (vec (range 70)))
 (def long-map (zipmap (range 70) (range 70)))
@@ -230,14 +232,23 @@
       "#{ :a }" #{:a}
       "( 1 1 1 1 1 ... )" (repeat 1)
       "[ ( 1 1 1 1 1 ... ) ]" [(repeat 1)]
-      "{ :a { ( 0 1 2 3 4 ... ) 1, ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9}}
+      "{ :a { ( 0 1 2 3 4 ... ) 1, ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
       "( 1 2 3 )" (lazy-seq '(1 2 3))
+      "( 1 1 1 1 1 ... )" (java.util.ArrayList. (repeat 100 1))
+      "( 1 2 3 )" (java.util.ArrayList. [1 2 3])
+      "{ :a 1, :b 2 }" (java.util.HashMap. {:a 1 :b 2})
       "#<MyTestType test1>" (MyTestType. "test1"))))
 
 (deftest inspect-coll-test
   (testing "inspect :coll prints contents of the coll"
     (is (= inspect-result-with-nil
            (render (inspect/start (inspect/fresh) [1 2 nil 3]))))))
+
+(deftest inspect-java-hashmap-test
+  (testing "inspecting java.util.Map descendendants prints a key-value coll"
+    (is (= java-hashmap-inspect-result
+           (render (inspect/start (inspect/fresh)
+                                  (java.util.HashMap. {:a 1, :b 2, :c 3})))))))
 
 (deftest inspect-path
   (testing "inspector keeps track of the path in the inspected structure"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -237,6 +237,8 @@
       "( 1 1 1 1 1 ... )" (java.util.ArrayList. (repeat 100 1))
       "( 1 2 3 )" (java.util.ArrayList. [1 2 3])
       "{ :a 1, :b 2 }" (java.util.HashMap. {:a 1 :b 2})
+      "long[] { 1, 2, 3, 4 }" (long-array [1 2 3 4])
+      "java.lang.Long[] { 0, 1, 2, 3, 4 ... }" (into-array Long (range 10))
       "#<MyTestType test1>" (MyTestType. "test1"))))
 
 (deftest inspect-coll-test


### PR DESCRIPTION
A few useful goodies. Nothing too ground-breaking, so this might still have a chance to land into the upcoming cider-nrepl release.

- Render everything that implements j.u.List and j.u.Map as collections –– useful when interacting with Java libraries.
- Render inline arrays as collections – same.
- Truncate inline long strings and other objects – this helps when the inspected object has long strings as fields/contained values, or also unknown objects with toString implementations that produce long strings. The truncation limit is quite arbitrary, but I don't think this would be too useful to customize. Also, jumping into the string still renders it fully.