### PR TITLE
Turn all class paths to absolute paths on java9+ clojure-emacs#2533

### DIFF
--- a/src/orchard/classpath.clj
+++ b/src/orchard/classpath.clj
@@ -9,6 +9,13 @@
    java.io.File
    java.util.jar.JarFile))
 
+(defn- ensure-absolute-paths
+  "Returns a `File` guaranteeing an absolute path for `file`."
+  [^File file]
+  (if (.isAbsolute file)
+    file
+    (File. (.getAbsolutePath file))))
+
 (defn classpath
   "Return a sequence of File objects of elements on the classpath.
 
@@ -24,7 +31,7 @@
                 ;; See https://dev.clojure.org/jira/browse/CLASSPATH-8
                 (or (seq (cp/classpath classloader))
                     ;; Java 9+
-                    (cp/system-classpath)))]
+                    (map ensure-absolute-paths (cp/system-classpath))))]
      path)))
 
 (defn classpath-directories


### PR DESCRIPTION
For the related issue see: https://github.com/clojure-emacs/cider/issues/2533.
I chose not to create an issue in orchard to keep the conversation in one place.

Let me know if there's any improvements that could be made concerning issues or the PR.

- [ X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ X] You've added tests to cover your change(s)
- [ X] All tests are passing
- [ X] The new code is not generating reflection warnings