### PR TITLE
Port cljs info and consolidate info api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test docs eastwood cljfmt cloverage release deploy clean
+.PHONY: test test-watch docs eastwood cljfmt cloverage release deploy clean
 
 VERSION ?= 1.10
 
@@ -9,14 +9,19 @@ JAVA_VERSION := $(shell lein with-profile +sysutils \
                         sysutils :java-version-simple | cut -d " " -f 2)
 TEST_SELECTOR := :java$(JAVA_VERSION)
 
+TEST_PROFILES := +test
+
 test:
-	lein with-profile +$(VERSION) test $(TEST_SELECTOR)
+	lein with-profile +$(VERSION),$(TEST_PROFILES) test $(TEST_SELECTOR)
+
+test-watch:
+	lein with-profile +$(VERSION),$(TEST_PROFILES) test-refresh $(TEST_SELECTOR)
 
 # Eastwood can't handle orchard.java.legacy-parser at the moment, because
 # tools.jar isn't in the classpath when Eastwood runs.
 
 eastwood:
-	lein with-profile +$(VERSION),+eastwood eastwood \
+	lein with-profile +$(VERSION),+eastwood,$(TEST_PROFILES) eastwood \
 	     "{:exclude-namespaces [orchard.java.legacy-parser]}"
 
 cljfmt:
@@ -28,7 +33,7 @@ cljfmt:
 # exact. See issue cider-nrepl/#457 for background.
 
 cloverage:
-	lein with-profile +$(VERSION),+cloverage cloverage --codecov \
+	lein with-profile +$(VERSION),+cloverage cloverage,$(TEST_PROFILES) --codecov \
 	     -e "orchard.java.legacy-parser"
 
 # When releasing, the BUMP variable controls which field in the

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/orchard"}
-  :dependencies [[org.tcrawley/dynapath "1.0.0"]]
+  :dependencies [[org.tcrawley/dynapath "1.0.0"]
+                 [org.clojure/clojurescript "1.10.520"]]
   :exclusions [org.clojure/clojure] ; see versions matrix below
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]}
@@ -37,6 +38,16 @@
                                      [org.clojure/clojure "1.11.0-master-SNAPSHOT" :classifier "sources"]]}
 
              :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
+
+             :test {:resource-paths ["test-resources"]}
+
+             ;; DEV tools
+             :dev {:dependencies [[pjstadig/humane-test-output "0.9.0"]]
+                   :resource-paths ["test-resources"]
+                   :plugins [[com.jakemccrary/lein-test-refresh "0.23.0"]]
+                   :injections [(require 'pjstadig.humane-test-output)
+                                (pjstadig.humane-test-output/activate!)]
+                   :test-refresh {:changes-only true}}
 
              ;; CI tools
              :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}

--- a/src/orchard/apropos.clj
+++ b/src/orchard/apropos.clj
@@ -3,7 +3,8 @@
   {:author "Jeff Valk"}
   (:require
    [orchard.meta :refer [var-name var-doc] :as m]
-   [orchard.query :as query])
+   [orchard.query :as query]
+   [orchard.misc :as u])
   (:import
    [clojure.lang MultiFn]))
 
@@ -47,7 +48,10 @@
                  :manipulate-vars
                  (fn [nss vars]
                    (if (first (filter #(= (find-ns 'clojure.core) %) nss))
-                     (concat m/special-forms vars)
+                     (concat (keys (or (u/require-and-resolve 'clojure.repl/special-doc-map)
+                                       (u/require-and-resolve 'cljs.repl/special-doc-map)))
+                             '[& catch finally]
+                             vars)
                      vars))))
          (apropos-sort ns)
          (map (fn [v]

--- a/src/orchard/cljs/analysis.cljc
+++ b/src/orchard/cljs/analysis.cljc
@@ -5,11 +5,9 @@
   (:require [orchard.misc :as u])
   (:refer-clojure :exclude [find-ns find-var all-ns ns-aliases]))
 
-(def NSES :cljs.analyzer/namespaces)
-
 (defn all-ns
   [env]
-  (->> (NSES env)
+  (->> (:cljs.analyzer/namespaces env)
        ;; recent CLJS versions include data about macro namespaces in the
        ;; compiler env, but we should not include them in completions or pass
        ;; them to format-ns unless they're actually required (which is handled
@@ -121,8 +119,8 @@
                  (filter macro?)
                  (into {})))
      :cljs (->> (merge
-                 (get-in env [NSES ns :macros])
-                 (get-in env [NSES ns :defs]))
+                 (get-in env [:cljs.analyzer/namespaces ns :macros])
+                 (get-in env [:cljs.analyzer/namespaces ns :defs]))
                 (remove (fn [[k v]] (:private v)))
                 (into {}))))
 
@@ -148,8 +146,8 @@
   [env ns]
   {:pre [(symbol? ns)]}
   (merge
-   (get-in env [NSES ns :macros])
-   (get-in env [NSES ns :defs])))
+   (get-in env [:cljs.analyzer/namespaces ns :macros])
+   (get-in env [:cljs.analyzer/namespaces ns :defs])))
 
 (defn sanitize-ns
   "Add :ns from :name if missing."

--- a/src/orchard/cljs/analysis.cljc
+++ b/src/orchard/cljs/analysis.cljc
@@ -1,0 +1,206 @@
+(ns ^{:doc "ClojureScript analysis functions."
+      :author "Gary Trakhman"
+      :added "0.6.0"}
+ orchard.cljs.analysis
+  (:require [orchard.misc :as u]
+            #?(:clj [cljs.repl]))
+  (:refer-clojure :exclude [find-ns find-var all-ns ns-aliases]))
+
+(def NSES :cljs.analyzer/namespaces)
+
+(defn all-ns
+  [env]
+  (->> (NSES env)
+       ;; recent CLJS versions include data about macro namespaces in the
+       ;; compiler env, but we should not include them in completions or pass
+       ;; them to format-ns unless they're actually required (which is handled
+       ;; by macro-ns-candidates below)
+       (into {} (filter (fn [[_ ns]]
+                          (not (and (contains? ns :macros)
+                                    (= 1 (count ns)))))))))
+
+(defn find-ns
+  [env ns]
+  (get (all-ns env) ns))
+
+;; Code adapted from clojure-complete (http://github.com/ninjudd/clojure-complete)
+
+(defn imports
+  "Returns a map of [import-name] to [ns-qualified-import-name] for all imports
+  in the given namespace."
+  [env ns]
+  (:imports (find-ns env ns)))
+
+(defn ns-aliases
+  "Returns a map of [ns-name-or-alias] to [ns-name] for the given namespace."
+  [env ns]
+  (let [imports (imports env ns)]
+    (->> (find-ns env ns)
+         :requires
+         (filter #(not (contains? imports (key %))))
+         (into {}))))
+
+(defn macro-ns-aliases
+  "Returns a map of [macro-ns-name-or-alias] to [macro-ns-name] for the given namespace."
+  [env ns]
+  (:require-macros (find-ns env ns)))
+
+(defn- expand-refer-map
+  [m]
+  (into {} (for [[k v] m] [k (symbol (str v "/" k))])))
+
+(defn referred-vars
+  "Returns a map of [var-name] to [ns-qualified-var-name] for all referred vars
+  in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :uses
+       expand-refer-map))
+
+(defn referred-macros
+  "Returns a map of [macro-name] to [ns-qualified-macro-name] for all referred
+  macros in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :use-macros
+       expand-refer-map))
+
+(defn ns-alias
+  "If sym is an alias to, or the name of, a namespace referred to in ns, returns
+  the name of the namespace; else returns nil."
+  [env sym ns]
+  (get (ns-aliases env ns) sym))
+
+(defn macro-ns-alias
+  "If sym is an alias to, or the name of, a macro namespace referred to in ns,
+  returns the name of the macro namespace; else returns nil."
+  [env sym ns]
+  (get (macro-ns-aliases env ns) sym))
+
+(defn- public?
+  [[_ var]]
+  (not (:private var)))
+
+(defn- named?
+  [[_ var]]
+  (not (:anonymous var)))
+
+(defn- foreign-protocol?
+  [[_ var]]
+  (and (:impls var)
+       (not (:protocol-symbol var))))
+
+(defn- macro?
+  [[_ var]]
+  (:macro (meta var)))
+
+(defn ns-vars
+  "Returns a list of the vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-vars
+  "Returns a list of the public vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? public? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-macros
+  "Given a namespace return all the public var analysis maps. Analagous to
+  clojure.core/ns-publics but returns var analysis maps not vars.
+
+  Inspired by the ns-publics in cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  #?(:clj (when (and ns (clojure.core/find-ns ns))
+            (->> (ns-publics ns)
+                 (filter macro?)
+                 (into {})))
+     :cljs (->> (merge
+                 (get-in env [NSES ns :macros])
+                 (get-in env [NSES ns :defs]))
+                (remove (fn [[k v]] (:private v)))
+                (into {}))))
+
+(defn core-vars
+  "Returns a list of cljs.core vars visible to the ns."
+  [env ns]
+  (let [vars (public-vars env 'cljs.core)
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc vars excludes)))
+
+(defn core-macros
+  "Returns a list of cljs.core macros visible to the ns."
+  [env ns]
+  (let [macros (public-macros env #?(:clj 'cljs.core :cljs 'cljs.core$macros))
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc macros excludes)))
+
+(defn ns-interns-from-env
+  "Given a namespace return all the var analysis maps. Analagous to
+  clojure.core/ns-interns but returns var analysis maps not vars.
+
+  Directly from cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  (merge
+   (get-in env [NSES ns :macros])
+   (get-in env [NSES ns :defs])))
+
+(defn sanitize-ns
+  "Add :ns from :name if missing."
+  [m]
+  (-> m
+      (assoc :ns (or (:ns m) (:name m)))
+      (update :ns u/namespace-sym)
+      (update :name u/name-sym)))
+
+(defn var-meta
+  "Return meta for the var, we wrap it in order to support both JVM and
+  self-host."
+  [var]
+  (cond-> {}
+    (map? var) (merge var)
+    (var? var) (-> (merge (meta var))
+                   (update :ns #(cond-> % (u/ns-obj? %) ns-name)))
+    true sanitize-ns
+    #?@(:cljs [true (-> (update :ns u/remove-macros)
+                        (update :name u/remove-macros))])))
+
+(defn ns-meta
+  "Return meta for the var, we wrap it in order to support both JVM and
+  self-host."
+  [var]
+  (cond-> {}
+    (map? var) (merge var)
+    (u/ns-obj? var) (merge {:ns (ns-name var)
+                            :name (ns-name var)})
+    true sanitize-ns
+    #?@(:cljs [true (-> (update :ns u/remove-macros)
+                        (update :name u/remove-macros))])))
+
+(defn find-symbol-meta
+  "Given a namespace-qualified var name, gets the analyzer metadata for that
+  var."
+  [env sym]
+  (let [ns (find-ns env (u/namespace-sym sym))]
+    (some-> (:defs ns)
+            (get (u/name-sym sym))
+            var-meta)))
+
+(defn special-meta
+  "Given a special symbol, gets the analyzer metadata."
+  [_ sym]
+  (when-let [meta #?(:clj (or (get (u/require-and-resolve 'cljs.repl/special-doc-map) sym)
+                              (get (u/require-and-resolve 'cljs.repl/repl-special-doc-map) sym))
+                     :cljs (or (get special/special-doc-map sym)
+                               (get special/repl-special-doc-map sym)))]
+    (merge {:name sym
+            :ns 'cljs.core
+            :special-form true}
+           meta)))

--- a/src/orchard/cljs/analysis.cljc
+++ b/src/orchard/cljs/analysis.cljc
@@ -2,8 +2,7 @@
       :author "Gary Trakhman"
       :added "0.6.0"}
  orchard.cljs.analysis
-  (:require [orchard.misc :as u]
-            #?(:clj [cljs.repl]))
+  (:require [orchard.misc :as u])
   (:refer-clojure :exclude [find-ns find-var all-ns ns-aliases]))
 
 (def NSES :cljs.analyzer/namespaces)

--- a/src/orchard/cljs/meta.cljc
+++ b/src/orchard/cljs/meta.cljc
@@ -1,0 +1,109 @@
+(ns ^{:doc "ClojureScript metadata functions."
+      :author "Gary Trakhman"
+      :added "0.6.0"}
+ orchard.cljs.meta
+  (:require [orchard.cljs.analysis :as a #?@(:cljs [:include-macros true])]
+            [orchard.misc :as u #?@(:cljs [:include-macros true])]))
+
+(defn normalize-ns-meta
+  "Normalize cljs namespace metadata to look like a clj."
+  [meta]
+  (merge (select-keys meta [:doc :author])
+         (when-let [n (:name meta)]
+           {:ns n})
+         {:file (-> meta :defs first second :file)
+          :line 1}))
+
+(defn normalize-macro-ns
+  "Normalize cljs namespace macro metadata to look like clj."
+  [env var]
+  (let [meta (a/ns-meta var)
+        ns (:ns meta)]
+    (merge (select-keys meta [:doc :ns :name :author])
+           {:file #?(:clj (some-> var
+                                  ns-interns
+                                  first
+                                  val
+                                  a/var-meta
+                                  :file)
+                     :cljs (some-> env
+                                   (a/ns-interns-from-env (u/add-ns-macros ns))
+                                   first
+                                   val
+                                   :file))
+            :line 1})))
+
+(defn unquote-1
+  "Handles some weird double-quoting in the analyzer"
+  [[fst & more :as form]]
+  (if (= fst 'quote)
+    (first more)
+    form))
+
+(defn normalize-var-meta
+  "Normalize cljs metadata to look like a clj var."
+  [meta]
+  (update meta :arglists unquote-1))
+
+(defn normalize-macro-meta
+  "Normalize cljs macro metadata to look like a clj var."
+  [meta]
+  (-> meta
+      (merge (:meta meta))
+      (merge (select-keys meta [:file :ns :name])) ;; :file is more accurate than in :meta
+      (update :arglists unquote-1)))
+
+(defn scoped-var-meta
+  [env sym & [context-ns]]
+  (or (a/find-symbol-meta env sym)
+      (let [scope (u/namespace-sym sym)
+            aliased-ns (a/ns-alias env scope context-ns)
+            sym (symbol (str (or aliased-ns context-ns) "/" (u/name-sym sym)))]
+        (a/find-symbol-meta env sym))))
+
+(defn macro-namespace
+  "Compute the namespace of a macro symbol."
+  [env sym & [context-ns]]
+  {:pre [(symbol? sym)]}
+  (let [ns-from-sym (u/as-sym (namespace sym))]
+    (or (a/macro-ns-alias env ns-from-sym context-ns)
+        ns-from-sym
+        context-ns)))
+
+(defn scoped-macro-meta
+  [env sym & [context-ns]]
+  (let [ns (or context-ns (macro-namespace env sym context-ns))
+        sym (symbol (name sym))]
+    (when (and ns (find-ns ns))
+      (some-> env
+              (a/public-macros #?(:clj ns
+                                  :cljs (u/add-ns-macros ns)))
+              (get sym)
+              a/var-meta))))
+
+(defn referred-macro-meta
+  [env sym & [context-ns]]
+  (let [ns (macro-namespace env sym context-ns)
+        sym (symbol (name sym))]
+    (when-let [referred (get (a/referred-macros env ns) sym)]
+      #?(:clj (-> referred
+                  find-var
+                  a/var-meta)
+         :cljs (let [referred-ns (symbol (namespace referred))
+                     referred-sym (symbol (name referred))]
+                 (-> env
+                     (a/ns-interns-from-env (u/add-ns-macros referred-ns))
+                     (get referred-sym)
+                     a/var-meta))))))
+
+(defn aliased-macro-var
+  [env sym & [context-ns]]
+  (let [ns (macro-namespace env sym context-ns)]
+    (some-> env
+            (a/macro-ns-alias sym ns)
+            #?(:cljs u/add-ns-macros)
+            find-ns)))
+
+(defn special-sym-meta
+  [env sym]
+  (some-> (a/special-meta env sym) normalize-var-meta))

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -1,12 +1,154 @@
 (ns orchard.info
+  "Retrieve the info map from var and symbols."
+  (:refer-clojure :exclude [qualified-symbol?])
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.javadoc :as javadoc]
    [orchard.classpath :as cp]
    [orchard.java :as java]
+   [orchard.cljs.analysis :as cljs-ana]
+   [orchard.cljs.meta :as cljs-meta]
    [orchard.meta :as m]
    [orchard.misc :as u]))
+
+(defn normalize-ns-meta
+  "Normalize cljs namespace metadata to look like a clj."
+  [meta]
+  (merge (select-keys meta [:doc :author])
+         {:file (-> meta :defs first second :file)
+          :line 1
+          :name (:name meta)
+          :ns (:name meta)}))
+
+(defn qualify-sym
+  "Qualify a symbol, if any in :sym, with :ns.
+
+  Return nil if :sym is nil, attempting to generate a valid symbol even
+  in case some :ns is missing."
+  {:added "0.6.0"}
+  [ns sym]
+  (when sym (symbol (some-> ns str) (str sym))))
+
+(defn qualified-symbol?
+  "Return true if x is a symbol with a namespace
+
+  This is only available from Clojure 1.9 so we backport it until we
+  drop support for Clojure 1.8."
+  {:added "0.6.0"}
+  [x]
+  (boolean (and (symbol? x) (namespace x) true)))
+
+(defn normalize-params
+  "Normalize the info params.
+
+  If :sym is unqualified we assoc a :qualified-sym key with it. The
+  namespace used is :ns first and then :context-ns.
+
+  If :sym is already qualified with assoc a :computed-ns key
+  and :unqualified-sym key.
+
+  If :dialect is nil, we assoc :clj, our default."
+  {:added "0.6.0"}
+  [params]
+  (let [{:keys [sym ns context-ns]} params]
+    (cond-> (update params :dialect #(or % :clj))
+      ;; If :sym is qualified, we have to use (name), cause:
+      ;;   (namespace 'mount.core) ;;=> nil
+      ;;   (name 'mount.core) ;;=> "mount.core
+      (qualified-symbol? sym)
+      (assoc :qualified-sym sym
+             :unqualified-sym (u/name-sym sym)
+             :computed-ns (u/namespace-sym sym))
+
+      (and sym (not (qualified-symbol? sym)))
+      (assoc :unqualified-sym (-> sym name symbol))
+
+      ;; if :sym is missing we still assoc :unqualified-sym from :ns
+      (and (not sym) ns)
+      (assoc :unqualified-sym ns)
+
+      (and sym (not (qualified-symbol? sym)) (or ns context-ns))
+      (assoc :qualified-sym (qualify-sym (or ns context-ns) sym)))))
+
+(defn clj-meta
+  {:added "0.6.0"}
+  [{:keys [dialect ns sym computed-ns unqualified-sym]}]
+  {:pre [(= dialect :clj)]}
+  (let [ns (or ns computed-ns)]
+    (or
+     ;; it's a special (special-symbol?)
+     (m/special-sym-meta sym)
+     ;; it's an unqualified sym for an aliased var
+     (some-> ns (m/resolve-var unqualified-sym) (m/var-meta))
+     ;; it's a var
+     (some-> ns (m/resolve-var sym) (m/var-meta))
+     ;; sym is an alias for another ns
+     (some-> ns (m/resolve-aliases) (get sym) (m/ns-meta))
+     ;; We use :unqualified-sym *exclusively* here because because our :ns is
+     ;; too ambiguous.
+     ;;
+     ;; Observe the incorrect behavior (should return nil, there is a test):
+     ;;
+     ;;   (info '{:ns clojure.core :sym non-existing}) ;;=> {:author "Rich Hickey" :ns clojure.core ...}
+     ;;
+     (some-> (find-ns unqualified-sym) (m/ns-meta))
+     ;; it's a Java class/member symbol...or nil
+     (some-> ns (java/resolve-symbol sym)))))
+
+(defn cljs-meta
+  {:added "0.6.0"}
+  [{:keys [dialect ns sym env context-ns unqualified-sym]}]
+  {:pre [(= dialect :cljs)]}
+  (let [context-ns (or context-ns ns)]
+    (or
+     ;; a special symbol - always use :unqualified-sym
+     (some-> (cljs-ana/special-meta env unqualified-sym)
+             (cljs-meta/normalize-var-meta))
+     ;; an NS
+     (some->> (cljs-ana/find-ns env sym)
+              (normalize-ns-meta))
+     ;; ns alias
+     (some->> (cljs-ana/ns-alias env sym context-ns)
+              (cljs-ana/find-ns env)
+              (normalize-ns-meta))
+     ;; macro ns
+     (some->> (find-ns unqualified-sym)
+              (cljs-meta/normalize-macro-ns env))
+
+     ;; macro ns alias
+     (some->> (cljs-meta/aliased-macro-var env sym context-ns)
+              (cljs-meta/normalize-macro-ns env))
+     ;; referred var
+     (some->> (get (cljs-ana/referred-vars env context-ns) sym)
+              (cljs-ana/find-symbol-meta env)
+              (cljs-meta/normalize-var-meta))
+     ;; referred macro
+     (some->> (cljs-meta/referred-macro-meta env sym context-ns)
+              (cljs-meta/normalize-macro-meta))
+     ;; scoped var
+     (some->> (cljs-meta/scoped-var-meta env sym context-ns)
+              (cljs-meta/normalize-var-meta))
+     ;; scoped macro
+     (some->> (cljs-meta/scoped-macro-meta env sym context-ns)
+              (cljs-meta/normalize-macro-meta))
+     ;; var in cljs.core
+     (some->> (get (cljs-ana/core-vars env context-ns) sym)
+              (cljs-ana/var-meta)
+              (cljs-meta/normalize-var-meta))
+     ;; macro in cljs.core
+     (some->> (cljs-meta/scoped-macro-meta env sym 'cljs.core)
+              (cljs-meta/normalize-macro-meta)))))
+
+(defn info
+  [params]
+  {:pre [(contains? #{:cljs :clj nil} (:dialect params))]}
+  (let [params (normalize-params params)
+        dialect (:dialect params)]
+    (cond-> params
+      ;; TODO split up responsability of finding meta and normalizing the meta map
+      (= dialect :clj) clj-meta
+      (= dialect :cljs) cljs-meta)))
 
 (def see-also-data
   (edn/read-string (slurp (io/resource "see-also.edn"))))
@@ -16,20 +158,6 @@
   (let [var-key (str ns "/" sym)]
     (->> (get see-also-data var-key)
          (filter (comp resolve u/as-sym)))))
-
-(defn info
-  [ns sym]
-  (or
-   ;; it's a special (special-symbol?)
-   (m/special-sym-meta sym)
-   ;; it's a var
-   (m/var-meta (m/resolve-var ns sym))
-   ;; sym is an alias for another ns
-   (m/ns-meta (get (m/resolve-aliases ns) sym))
-   ;; it's simply a full ns
-   (m/ns-meta (find-ns sym))
-   ;; it's a Java class/member symbol...or nil
-   (java/resolve-symbol ns sym)))
 
 (defn info-java
   [class member]

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -172,7 +172,12 @@ resolved (real) namespace and name here"}
 
      ;; do not merge see-also if the info was not found
      (merge (when-let [m (see-also params)]
-              {:see-also m})))))
+              {:see-also m}))
+
+     (update :file (fn [file-path]
+                     (if (u/boot-project?)
+                       (cp/classpath-file-relative-path file-path)
+                       file-path))))))
 
 (defn info-java
   [class member]

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -158,11 +158,16 @@
 resolved (real) namespace and name here"}
   see-also (memoize see-also*))
 
-(defn info
+(defn info*
+  "Provide the info map for the input ns and sym.
+
+  The default dialect is :clj but it can be specified as part of params.
+
+  Note that the :cljs dialect requires the compiler state to be passed
+  in as :env key in params."
   [params]
-  {:pre [(contains? #{:cljs :clj nil} (:dialect params))]}
-  (let [params   (normalize-params params)
-        dialect  (:dialect params)]
+  (let [params  (normalize-params params)
+        dialect (:dialect params)]
 
     ;; TODO split up responsability of finding meta and normalizing the meta map
     (some->
@@ -178,6 +183,18 @@ resolved (real) namespace and name here"}
                      (if (u/boot-project?)
                        (cp/classpath-file-relative-path file-path)
                        file-path))))))
+
+(defn info
+  "Provide the info map for the input ns and sym.
+
+  The default dialect is :clj but it can be specified as part of params.
+
+  Note that the :cljs dialect requires the compiler state to be passed
+  in as :env key in params."
+  ([ns sym]
+   (info* {:ns ns :sym sym}))
+  ([ns sym params]
+   (info* (assoc params :ns ns :sym sym))))
 
 (defn info-java
   [class member]

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -104,12 +104,17 @@
 ;; They just map to a special symbol.
 (def special-sub-symbs '{& fn*, catch try, finally try})
 
-(defn repl-special-meta
+(defn repl-special-meta*
+  "Return the REPL specials info."
   [sym]
   (or (when-let [f (u/require-and-resolve 'clojure.repl/special-doc)]
         (f sym))
       (when-let [f (u/require-and-resolve 'cljs.repl/special-doc)]
         (f sym))))
+
+(def repl-special-meta
+  "Return the REPL specials info. Memoized."
+  (memoize repl-special-meta*))
 
 ;; What I find very confusing in Clojure documentation is the use of "special form" which is not a concept,
 ;; just an annotation on vars (always macros) that are special forms in other lisps.

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -161,12 +161,6 @@
                         (update :ns ns-name))]
        (maybe-add-spec v meta-map)))))
 
-(def special-forms
-  "Special forms that can be apropo'ed."
-  (concat (keys (or (u/require-and-resolve 'clojure.repl/special-doc-map)
-                    (u/require-and-resolve 'cljs.repl/special-doc-map)))
-          '[& catch finally]))
-
 (defn meta+
   "Return special form or var's meta."
   [v]

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -3,11 +3,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]))
 
-(def ^:const windows-prefix
-  "Windows")
-
 (defn os-windows? []
-  (.startsWith (System/getProperty "os.name") windows-prefix))
+  (.startsWith (System/getProperty "os.name") "Windows"))
 
 (defn directory?
   "Whether the argument is a directory"
@@ -35,6 +32,24 @@
     (string? x) (if-let [[_ ns sym] (re-matches #"(.+)/(.+)" x)]
                   (symbol ns sym)
                   (symbol x))))
+
+(defn namespace-sym
+  "Return the namespace of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [ns (and sym (namespace sym))]
+    (as-sym ns)
+    sym))
+
+(defn name-sym
+  "Return the name of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [n (and sym (name sym))]
+    (as-sym n)
+    sym))
 
 (defn update-vals
   "Update the values of map `m` via the function `f`."
@@ -105,3 +120,25 @@
 
 ;; handles vectors
 (prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)
+
+;; TODO move back to analysis.cljs
+(defn add-ns-macros
+  "Append $macros to the input symbol"
+  [sym]
+  (some-> sym
+          (str "$macros")
+          symbol))
+
+;; TODO move back to analysis.cljs
+(defn remove-macros
+  "Remove $macros from the input symbol"
+  [sym]
+  (some-> sym
+          str
+          (str/replace #"\$macros" "")
+          symbol))
+
+(defn ns-obj?
+  "Return true if n is a namespace object"
+  [ns]
+  (instance? clojure.lang.Namespace ns))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -6,6 +6,20 @@
 (defn os-windows? []
   (.startsWith (System/getProperty "os.name") "Windows"))
 
+(defn boot-fake-classpath
+  "Retrieve Boot's fake classpath.
+  When using Boot, fake.class.path contains the original directories with source
+  files, which makes it way more useful than the real classpath.
+  See https://github.com/boot-clj/boot/issues/249 for details."
+  []
+  (System/getProperty "fake.class.path"))
+
+(defn boot-project?
+  "Check whether we're dealing with a Boot project.
+  We figure this by checking for the presence of Boot's fake classpath."
+  []
+  (not (nil? (boot-fake-classpath))))
+
 (defn directory?
   "Whether the argument is a directory"
   [f]

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -156,3 +156,17 @@
   "Return true if n is a namespace object"
   [ns]
   (instance? clojure.lang.Namespace ns))
+
+;; Drop this in favor of clojure.core/requiring-resolve at some point?
+
+(defn require-and-resolve
+  "Try to require the namespace and get a var for the symbol, return the
+  var if successful, nil if not."
+  {:added "0.6.0"}
+  [sym]
+  (when-let [ns (some-> sym namespace symbol)]
+    (when-not (find-ns ns)
+      (try
+        (require ns)
+        (catch Exception _ nil)))
+    (some-> sym find-var var-get)))

--- a/test-resources/orchard/cljs/test_env.cljc
+++ b/test-resources/orchard/cljs/test_env.cljc
@@ -1,0 +1,36 @@
+(ns orchard.cljs.test-env
+  (:require
+   [clojure.test :as test #?(:clj :refer :cljs :refer-macros) [deftest is testing]]
+   [clojure.set :as set]
+   [cljs.env :as env]
+   #?@(:clj [[cljs.analyzer.api :as ana]
+             [cljs.build.api :as build]
+             [cljs.compiler.api :as comp]
+             [clojure.java.io :as io]
+             [cljs.repl]]
+       :cljs [[lumo.repl :as repl]])))
+
+(def +test-namespace+ "orchard/test_ns.cljc")
+(def +test-output-dir+ "target/cljs-out")
+
+(defn create-test-env []
+  #?(:clj
+     (let [opts (build/add-implicit-options {:cache-analysis true, :output-dir +test-output-dir+})
+           env (env/default-compiler-env opts)]
+       (comp/with-core-cljs env opts
+         (fn []
+           (if-let [test-resource (io/resource +test-namespace+)]
+             (ana/analyze-file env test-resource opts)
+             (throw (ex-info (str "Cannot find test file " +test-namespace+) {:test-namespace +test-namespace+})))))
+       @env)
+
+     :cljs
+     (do (repl/eval '(require (quote orchard.cljs.test-ns)) 'orchard.cljs.test-env)
+         @env/*compiler*)))
+
+(def ^:dynamic *env*)
+
+(defn wrap-test-env
+  [f]
+  (binding [*env* (create-test-env)]
+    (f)))

--- a/test-resources/orchard/cljs/test_runner.cljs
+++ b/test-resources/orchard/cljs/test_runner.cljs
@@ -1,0 +1,54 @@
+(ns orchard.cljs.test-runner
+  (:require [cljs.test :as test :include-macros true]
+            orchard.cljs.info-test
+            orchard.cljs.env-test
+            orchard.meta-test
+            orchard.misc-test))
+
+;; setting *assert* dynamically like this only works in self-host
+(set! cljs.core/*assert* true)
+
+(defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
+  (when-not (cljs.test/successful? m)
+    (.exit js/process 1)))
+
+(defmethod cljs.test/report [:cljs.test/default :error] [m]
+  (cljs.test/inc-report-counter! :error)
+  (println "\nERROR in" (cljs.test/testing-vars-str m))
+  (when (seq (:testing-contexts (cljs.test/get-current-env)))
+    (println (cljs.test/testing-contexts-str)))
+  (when-let [message (:message m)] (println message))
+  (let [actual (:actual m)
+        ex-data (ex-data actual)]
+    (if (:cljs.spec.alpha/failure ex-data)
+      (do (println "expected:" (pr-str (:expected m)))
+          (print "  actual:\n")
+          (println (.-message actual)))
+      (cljs.test/print-comparison m))
+    (when (.-stack actual)
+      (println (.-stack actual)))))
+
+(defmethod cljs.test/report [:cljs.test/default :fail] [m]
+  (cljs.test/inc-report-counter! :error)
+  (println "\nERROR in" (cljs.test/testing-vars-str m))
+  (when (seq (:testing-contexts (cljs.test/get-current-env)))
+    (println (cljs.test/testing-contexts-str)))
+  (when-let [message (:message m)] (println message))
+  (let [actual (:actual m)
+        ex-data (ex-data actual)]
+    (if (:cljs.spec.alpha/failure ex-data)
+      (do (println "expected:" (pr-str (:expected m)))
+          (print "  actual:\n")
+          (println (.-message actual)))
+      (cljs.test/print-comparison m))
+    (when (.-stack actual)
+      (println (.-stack actual)))))
+
+(defn -main [& args]
+  (test/run-tests #_'orchard.cljs.info-test
+                  #_'orchard.cljs.env-test
+                  #_'orchard.meta-test
+                  'orchard.namespace-test
+                  'orchard.misc-test))
+
+(set! *main-cli-fn* -main)

--- a/test-resources/orchard/test_macros.clj
+++ b/test-resources/orchard/test_macros.clj
@@ -1,0 +1,12 @@
+(ns ^{:doc "A test macro namespace"}
+    orchard.test-macros)
+
+(defmacro my-add
+  "This is an addition macro"
+  [a b]
+  `(+ ~a ~b))
+
+(defmacro my-sub
+  "This is a subtraction macro"
+  [a b]
+  `(- ~a ~b))

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,0 +1,24 @@
+(ns ^{:doc "A test namespace"} orchard.test-ns
+  (:refer-clojure :exclude [unchecked-byte while])
+  (:require [clojure.string]
+            [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]])
+  #?(:cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]])
+     :clj  (:require [orchard.test-macros :as test-macros :refer [my-add]]))
+  #?(:cljs (:import [goog.ui IdGenerator])))
+
+(defrecord TestRecord [a b c])
+(deftype TestType [])
+
+(def x ::some-namespaced-keyword)
+
+(defn issue-28
+  []
+  (str "https://github.com/clojure-emacs/cljs-tooling/issues/28"))
+
+(defn test-public-fn
+  []
+  42)
+
+(defn- test-private-fn
+  []
+  (inc (test-public-fn)))

--- a/test-resources/orchard/test_ns_dep.cljc
+++ b/test-resources/orchard/test_ns_dep.cljc
@@ -1,0 +1,5 @@
+(ns ^{:doc "Dependency of test-ns namespace"} orchard.test-ns-dep)
+
+(defn foo-in-dep [foo] :bar)
+
+(def x ::dep-namespaced-keyword)

--- a/test/orchard/cljs/env_test.cljc
+++ b/test/orchard/cljs/env_test.cljc
@@ -1,0 +1,17 @@
+(ns orchard.cljs.env-test
+  (:require [clojure.set :as set]
+            [clojure.test :as test #?(:clj :refer :cljs :refer-macros) [deftest is testing use-fixtures]]
+            [orchard.cljs.analysis :as a]
+            [orchard.cljs.test-env :as test-env]))
+
+(deftest test-env
+  (let [env (test-env/create-test-env)]
+    (testing "Test environment"
+      (is (empty? (set/difference (set (keys (a/all-ns env)))
+                                  '#{orchard.test-ns
+                                     orchard.test-ns-dep
+                                     orchard.test-macros
+                                     cljs.core
+                                     cljs.user
+                                     clojure.set
+                                     clojure.string}))))))

--- a/test/orchard/cljs/meta_test.cljc
+++ b/test/orchard/cljs/meta_test.cljc
@@ -1,0 +1,8 @@
+(ns orchard.cljs.meta-test
+  (:require [clojure.test :as test #?(:clj :refer :cljs :refer-macros) [deftest is testing]]
+            [orchard.cljs.meta :as cljs-meta]))
+
+(deftest unquote-test
+  (is (= [1 2 3] (cljs-meta/unquote-1 '(quote [1 2 3]))))
+  (is (= [1 2 3] (cljs-meta/unquote-1 [1 2 3])))
+  (is (= nil (cljs-meta/unquote-1 nil))))

--- a/test/orchard/eldoc_test.clj
+++ b/test/orchard/eldoc_test.clj
@@ -30,13 +30,13 @@
              ["Classname/staticField"])))
 
     ;; sanity checks and special cases
-    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core 'map))))
-    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core '.toString))))
-    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core '.))))
-    (is (not (:eldoc (eldoc/eldoc (info/info 'clojure.core (gensym "non-existing")))))))
+    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym map}))))
+    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym .toString}))))
+    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym .}))))
+    (is (not (:eldoc (eldoc/eldoc (info/info {:ns 'clojure.core :sym (gensym "non-existing")}))))))
 
   (testing "Clojure result structure"
-    (let [result (eldoc/eldoc (info/info 'clojure.core 'map))]
+    (let [result (eldoc/eldoc (info/info '{:ns clojure.core :sym map}))]
       (is (:ns result))
       (is (:name result))
       (is (:type result))

--- a/test/orchard/eldoc_test.clj
+++ b/test/orchard/eldoc_test.clj
@@ -30,13 +30,13 @@
              ["Classname/staticField"])))
 
     ;; sanity checks and special cases
-    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym map}))))
-    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym .toString}))))
-    (is (:eldoc (eldoc/eldoc (info/info '{:ns clojure.core :sym .}))))
-    (is (not (:eldoc (eldoc/eldoc (info/info {:ns 'clojure.core :sym (gensym "non-existing")}))))))
+    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core 'map))))
+    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core '.toString))))
+    (is (:eldoc (eldoc/eldoc (info/info 'clojure.core '.))))
+    (is (not (:eldoc (eldoc/eldoc (info/info 'clojure.core (gensym "non-existing")))))))
 
   (testing "Clojure result structure"
-    (let [result (eldoc/eldoc (info/info '{:ns clojure.core :sym map}))]
+    (let [result (eldoc/eldoc (info/info 'clojure.core 'map))]
       (is (:ns result))
       (is (:name result))
       (is (:type result))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -30,7 +30,7 @@
     (let [target-ns 'orchard.info
           ns-syms (keys (ns-map target-ns))
           info-specials (fn [info-params]
-                          (as-> (map info/info info-params) it
+                          (as-> (map info/info* info-params) it
                             (group-by :special-form it)
                             (get it true)
                             (map :name it)
@@ -56,11 +56,11 @@
                      :name foo-in-dep
                      :arglists ([foo])}]
       (testing "- :cljs"
-        (let [i (info/info (merge *cljs-params* params))]
+        (let [i (info/info* (merge *cljs-params* params))]
           (is (= expected (select-keys i [:ns :name :arglists])))
           (is (str/includes? (:file i) "test_ns_dep"))))
       (testing "- :clj"
-        (let [i (info/info params)]
+        (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :arglists])))
           (is (str/includes? (:file i) "test_ns_dep")))))))
 
@@ -73,37 +73,37 @@
                      :arglists ([s])
                      :doc "Removes whitespace from both ends of string."}]
       (testing "- :cljs"
-        (is (= expected (-> (info/info (merge *cljs-params* params))
+        (is (= expected (-> (info/info* (merge *cljs-params* params))
                             (select-keys [:ns :name :arglists :doc])))))
       (testing "- :clj"
-        (is (= expected (-> (info/info params)
+        (is (= expected (-> (info/info* params)
                             (select-keys [:ns :name :arglists :doc])
                             (update :ns ns-name))))))))
 
 (deftest info-unqualified-sym-and-namespace-test
   (testing "Resolution from current namespace"
     (testing "- :cljs"
-      (let [i (info/info (merge *cljs-params* '{:ns cljs.core :sym +}))]
+      (let [i (info/info* (merge *cljs-params* '{:ns cljs.core :sym +}))]
         (is (= '+ (:name i)))
         (is (= 'cljs.core (:ns i)))))
     (testing "- :clj"
-      (let [i (info/info '{:ns clojure.core :sym +})]
+      (let [i (info/info* '{:ns clojure.core :sym +})]
         (is (= '+ (:name i)))
         (is (= 'clojure.core (:ns i))))))
 
   (testing "Resolution from other namespaces"
     (testing "- :cljs"
-      (let [i (info/info (merge *cljs-params* '{:ns cljs.user :sym +}))]
+      (let [i (info/info* (merge *cljs-params* '{:ns cljs.user :sym +}))]
         (is (= (-> #'+ meta :name) (:name i)))
         (is (= 'cljs.core (:ns i)))))
     (testing "- :clj"
-      (let [i (info/info '{:ns user :sym +})]
+      (let [i (info/info* '{:ns user :sym +})]
         (is (= '+ (:name i)))
         (is (= 'clojure.core (:ns i)))))))
 
 (deftest info-cljs-tooling-issue-28-test
   (testing "Resolution from current namespace - issue #28 from cljs-tooling"
-    (let [i (info/info (merge *cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
+    (let [i (info/info* (merge *cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
       (is (= '{:arglists ([])
                :line 14
                :column 1
@@ -120,11 +120,11 @@
                      :doc "A test namespace"
                      :line 1}]
       (testing "- :cljs"
-        (let [i (info/info (merge *cljs-params* params))]
+        (let [i (info/info* (merge *cljs-params* params))]
           (is (= expected (select-keys i [:line :doc :name :ns])))
           (is (str/includes? (:file i) "orchard/test_ns"))))
       (testing "- :clj"
-        (let [i (info/info params)]
+        (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
           (is (str/includes? (:file i) "orchard/test_ns"))))
 
@@ -132,7 +132,7 @@
       (testing "- :cljs with context"
         (let [params '{:context-ns orchard.test-ns
                        :sym orchard.test-ns}
-              i (info/info (merge *cljs-params* params))]
+              i (info/info* (merge *cljs-params* params))]
           (is (= '{:ns orchard.test-ns
                    :name orchard.test-ns
                    :line 1}
@@ -147,11 +147,11 @@
                      :doc "Dependency of test-ns namespace"
                      :line 1}]
       (testing "- :cljs"
-        (let [i (info/info (merge *cljs-params* params))]
+        (let [i (info/info* (merge *cljs-params* params))]
           (is (= expected (select-keys i [:line :doc :name :ns])))
           (is (str/includes? (:file i) "orchard/test_ns_dep"))))
       (testing "- :clj"
-        (let [i (info/info params)]
+        (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
           (is (str/includes? (:file i) "orchard/test_ns_dep"))))
 
@@ -159,7 +159,7 @@
       (testing "- :cljs with context"
         (let [params '{:sym orchard.test-ns-dep
                        :context-ns orchard.test-ns}
-              i (info/info (merge *cljs-params* params))]
+              i (info/info* (merge *cljs-params* params))]
           (is (= '{:ns orchard.test-ns-dep
                    :name orchard.test-ns-dep
                    :doc "Dependency of test-ns namespace"
@@ -170,9 +170,9 @@
 (deftest info-cljs-core-namespace-test
   (testing "Namespace itself but cljs.core"
     (testing "- :cljs"
-      (is (= 'cljs.core (:ns (info/info (merge *cljs-params* '{:sym cljs.core}))))))
+      (is (= 'cljs.core (:ns (info/info* (merge *cljs-params* '{:sym cljs.core}))))))
     (testing "- :clj"
-      (is (= 'clojure.core (:ns (info/info '{:sym clojure.core})))))))
+      (is (= 'clojure.core (:ns (info/info* '{:sym clojure.core})))))))
 
 (deftest info-namespace-alias-test
   (testing "Namespace alias"
@@ -183,12 +183,12 @@
                      :doc "Dependency of test-ns namespace"
                      :line 1}]
       (testing "- :cljs"
-        (let [i (info/info (merge *cljs-params* params))]
+        (let [i (info/info* (merge *cljs-params* params))]
           (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
           (is (str/includes? (:file i) "orchard/test_ns_dep"))))
 
       (testing "- :clj"
-        (let [i (info/info params)]
+        (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
           (is (str/includes? (:file i) "orchard/test_ns_dep")))))))
 
@@ -207,7 +207,7 @@
                        :name orchard.test-macros
                        :line 1}]
         (is (= (take 4 (repeat expected))
-               (map #(info/info (merge *cljs-params* %)) params)))))))
+               (map #(info/info* (merge *cljs-params* %)) params)))))))
 
 (deftest info-namespace-cljs-core-macro-test
   (testing "cljs.core macro"
@@ -224,7 +224,7 @@
                        :arglists ([bindings & body])}]
         (is (= (take 6 (repeat expected))
                (->> params
-                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(info/info* (merge *cljs-params* %)))
                     (map #(select-keys % [:ns :name :doc :arglists])))))))))
 
 (deftest info-namespace-macro-alias-test
@@ -237,7 +237,7 @@
                        :file "orchard/test_macros.clj"
                        :line 1}]
         (is (= (take 2 (repeat expected))
-               (map #(info/info (merge *cljs-params* %)) params)))))))
+               (map #(info/info* (merge *cljs-params* %)) params)))))))
 
 (deftest info-macros-var-test
   (testing "Macro"
@@ -252,7 +252,7 @@
                        :file "orchard/test_macros.clj"}]
         (is (= (take 2 (repeat expected))
                (->> params
-                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(info/info* (merge *cljs-params* %)))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))
 
     (testing "- :clj"
@@ -266,7 +266,7 @@
                        :file "orchard/test_macros.clj"}]
         (is (= (take 2 (repeat expected))
                (->> params
-                    (map #(info/info %))
+                    (map #(info/info* %))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
 
 (deftest info-macros-referred-var-test
@@ -283,13 +283,13 @@
       (testing "- :cljs"
         (is (= (take 2 (repeat expected))
                (->> params
-                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(info/info* (merge *cljs-params* %)))
                     (map #(select-keys % [:ns :name :arglists :macro :file]))))))
 
       (testing "- :clj"
         (is (= (take 2 (repeat expected))
                (->> params
-                    (map #(info/info %))
+                    (map #(info/info* %))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
 
 ;;;;;;;;;;;;;;;;;;
@@ -312,18 +312,18 @@
                           info/normalize-params
                           info/see-also))))
 
-    (testing "info/see-also through info/info in a required namespace"
+    (testing "info/see-also through info/info* in a required namespace"
       (is (= expected (-> '{:ns orchard.test-ns :sym map}
-                          info/info
+                          info/info*
                           :see-also)))))
 
   (testing "info/see-also does not support ClojureScript"
-    (is (nil? (:see-also (info/info '{:ns cljs.core :sym map :dialect :cljs :env {}}))))))
+    (is (nil? (:see-also (info/info* '{:ns cljs.core :sym map :dialect :cljs :env {}}))))))
 
 (deftest info-jvm-test
-  (is (info/info {:ns 'orchard.info :sym 'java.lang.Class}))
-  (is (info/info {:ns 'orchard.info :sym 'Class/forName}))
-  (is (info/info {:ns 'orchard.info :sym '.toString})))
+  (is (info/info* {:ns 'orchard.info :sym 'java.lang.Class}))
+  (is (info/info* {:ns 'orchard.info :sym 'Class/forName}))
+  (is (info/info* {:ns 'orchard.info :sym '.toString})))
 
 (deftest info-java-test
   (is (info/info-java 'clojure.lang.Atom 'swap)))
@@ -456,7 +456,7 @@
                (select-keys [:ns :unqualified-sym]))))))
 
 (deftest boot-file-resolution-test
-  ;; this checks the files on the classpath, soo you need the test-resources
+  ;; this checks the files on the classpath soo you need the test-resources
   ;; and specifically test-resources/orchard/test_ns.cljc
   ;;
   ;; Note that :file in :meta is left untouched
@@ -465,5 +465,5 @@
              :name x
              :file "orchard/test_ns.cljc"}
            (-> (merge *cljs-params* '{:ns orchard.test-ns :sym x})
-               (info/info)
+               (info/info*)
                (select-keys [:ns :name :file]))))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -295,7 +295,28 @@
 ;;;;;;;;;;;;;;;;;;
 
 (deftest see-also-test
-  (is (not-empty (info/see-also 'clojure.core 'map))))
+  (let [expected '(clojure.core/map-indexed
+                   clojure.core/pmap
+                   clojure.core/amap
+                   clojure.core/mapcat
+                   clojure.core/keep
+                   clojure.core/juxt
+                   clojure.core/mapv
+                   clojure.core/reduce
+                   clojure.core/run!)]
+
+    (testing "unit test of info/see-also"
+      (is (= expected (-> '{:ns orchard.test-ns :sym map}
+                          info/normalize-params
+                          info/see-also))))
+
+    (testing "info/see-also through info/info in a required namespace"
+      (is (= expected (-> '{:ns orchard.test-ns :sym map}
+                          info/info
+                          :see-also)))))
+
+  (testing "info/see-also does not support ClojureScript"
+    (is (nil? (:see-also (info/info '{:ns cljs.core :sym map :dialect :cljs :env {}}))))))
 
 (deftest info-jvm-test
   (is (info/info {:ns 'orchard.info :sym 'java.lang.Class}))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -5,7 +5,7 @@
    [orchard.info :as info]
    [orchard.misc :as misc]
    [orchard.cljs.test-env :as test-env]
-   [clojure.repl :as repl]
+   [orchard.meta :as meta]
    [orchard.test-ns]))
 
 (def ^:dynamic *cljs-params*)
@@ -36,12 +36,14 @@
                             (map :name it)
                             (set it)))]
       (testing "- :cljs"
-        (let [special-syms (into '#{in-ns load load-file} (keys @#'cljs.repl/special-doc-map))]
+        (let [special-doc-map (misc/require-and-resolve 'cljs.repl/special-doc-map)
+              special-syms (into '#{in-ns load load-file} (keys special-doc-map))]
           (is (= special-syms (->> (into special-syms ns-syms)
                                    (map #(merge *cljs-params* {:ns target-ns :sym %}))
                                    (info-specials))))))
       (testing "- :clj"
-        (let [special-syms (into '#{letfn let loop fn} (keys @#'clojure.repl/special-doc-map))]
+        (let [special-doc-map (misc/require-and-resolve 'clojure.repl/special-doc-map)
+              special-syms (into '#{letfn let loop fn} (keys special-doc-map))]
           (is (= special-syms (->> (into special-syms ns-syms)
                                    (map #(hash-map :ns target-ns :sym %))
                                    (info-specials)))))))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -452,3 +452,16 @@
            (-> '{:ns orchard.info}
                (info/normalize-params)
                (select-keys [:ns :unqualified-sym]))))))
+
+(deftest boot-file-resolution-test
+  ;; this checks the files on the classpath, soo you need the test-resources
+  ;; and specifically test-resources/orchard/test_ns.cljc
+  ;;
+  ;; Note that :file in :meta is left untouched
+  (with-redefs [orchard.misc/boot-project? (constantly true)]
+    (is (= '{:ns orchard.test-ns
+             :name x
+             :file "orchard/test_ns.cljc"}
+           (-> (merge *cljs-params* '{:ns orchard.test-ns :sym x})
+               (info/info)
+               (select-keys [:ns :name :file]))))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -1,40 +1,306 @@
 (ns orchard.info-test
   (:require
-   [clojure.test :refer :all]
-   [clojure.repl :as repl]
+   [clojure.test :as test :refer [deftest is testing use-fixtures]]
+   [clojure.string :as str]
    [orchard.info :as info]
-   [orchard.misc :as misc]))
+   [orchard.misc :as misc]
+   [orchard.cljs.test-env :as test-env]
+   [clojure.repl :as repl]
+   [orchard.test-ns]))
+
+(def ^:dynamic *cljs-params*)
+
+(defn wrap-info-params
+  [f]
+  (binding [*cljs-params* {:dialect :cljs
+                           :env (test-env/create-test-env)}]
+    (f)))
+
+(use-fixtures :once wrap-info-params)
+
+;; TODO use test-ns instead
+;; (is (info/info 'orchard.info-test 'TestType))
+;; (is (info/info 'orchard.info-test 'TestRecord))
+
+(deftest info-non-existing-test
+  (is (nil? (info/info {:ns 'clojure.core :sym (gensym "non-existing")}))))
+
+(deftest info-special-form-test
+  (testing "special forms are marked as such and nothing else is (for all syms in ns)"
+    (let [target-ns 'orchard.info
+          ns-syms (keys (ns-map target-ns))
+          info-specials (fn [info-params]
+                          (as-> (map info/info info-params) it
+                            (group-by :special-form it)
+                            (get it true)
+                            (map :name it)
+                            (set it)))]
+      (testing "- :cljs"
+        (let [special-syms (into '#{in-ns load load-file} (keys @#'cljs.repl/special-doc-map))]
+          (is (= special-syms (->> (into special-syms ns-syms)
+                                   (map #(merge *cljs-params* {:ns target-ns :sym %}))
+                                   (info-specials))))))
+      (testing "- :clj"
+        (let [special-syms (into '#{letfn let loop fn} (keys @#'clojure.repl/special-doc-map))]
+          (is (= special-syms (->> (into special-syms ns-syms)
+                                   (map #(hash-map :ns target-ns :sym %))
+                                   (info-specials)))))))))
+
+(deftest info-var-alias-test
+  (testing "Aliased var"
+    (let [params '{:ns orchard.test-ns
+                   :sym test-dep/foo-in-dep}
+          expected '{:ns orchard.test-ns-dep
+                     :name foo-in-dep
+                     :arglists ([foo])}]
+      (testing "- :cljs"
+        (let [i (info/info (merge *cljs-params* params))]
+          (is (= expected (select-keys i [:ns :name :arglists])))
+          (is (str/includes? (:file i) "test_ns_dep"))))
+      (testing "- :clj"
+        (let [i (info/info params)]
+          (is (= expected (select-keys i [:ns :name :arglists])))
+          (is (str/includes? (:file i) "test_ns_dep")))))))
+
+(deftest info-fully-qualified-var-test
+  (testing "Fully-qualified var"
+    (let [params '{:ns orchard.test-ns
+                   :sym clojure.string/trim}
+          expected '{:ns clojure.string
+                     :name trim
+                     :arglists ([s])
+                     :doc "Removes whitespace from both ends of string."}]
+      (testing "- :cljs"
+        (is (= expected (-> (info/info (merge *cljs-params* params))
+                            (select-keys [:ns :name :arglists :doc])))))
+      (testing "- :clj"
+        (is (= expected (-> (info/info params)
+                            (select-keys [:ns :name :arglists :doc])
+                            (update :ns ns-name))))))))
+
+(deftest info-unqualified-sym-and-namespace-test
+  (testing "Resolution from current namespace"
+    (testing "- :cljs"
+      (let [i (info/info (merge *cljs-params* '{:ns cljs.core :sym +}))]
+        (is (= '+ (:name i)))
+        (is (= 'cljs.core (:ns i)))))
+    (testing "- :clj"
+      (let [i (info/info '{:ns clojure.core :sym +})]
+        (is (= '+ (:name i)))
+        (is (= 'clojure.core (:ns i))))))
+
+  (testing "Resolution from other namespaces"
+    (testing "- :cljs"
+      (let [i (info/info (merge *cljs-params* '{:ns cljs.user :sym +}))]
+        (is (= (-> #'+ meta :name) (:name i)))
+        (is (= 'cljs.core (:ns i)))))
+    (testing "- :clj"
+      (let [i (info/info '{:ns user :sym +})]
+        (is (= '+ (:name i)))
+        (is (= 'clojure.core (:ns i)))))))
+
+(deftest info-cljs-tooling-issue-28-test
+  (testing "Resolution from current namespace - issue #28 from cljs-tooling"
+    (let [i (info/info (merge *cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
+      (is (= '{:arglists ([])
+               :line 14
+               :column 1
+               :ns orchard.test-ns
+               :name issue-28}
+             (select-keys i [:arglists :line :column :ns :name])))
+      (is (str/includes? (:file i) "orchard/test_ns")))))
+
+(deftest info-ns-as-sym-test
+  (testing "Only namespace as qualified symbol"
+    (let [params   '{:sym orchard.test-ns}
+          expected '{:ns orchard.test-ns
+                     :name orchard.test-ns
+                     :doc "A test namespace"
+                     :line 1}]
+      (testing "- :cljs"
+        (let [i (info/info (merge *cljs-params* params))]
+          (is (= expected (select-keys i [:line :doc :name :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns"))))
+      (testing "- :clj"
+        (let [i (info/info params)]
+          (is (= expected (select-keys i [:line :doc :name :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns"))))
+
+      ;; is how the info middleware sends it
+      (testing "- :cljs with context"
+        (let [params '{:context-ns orchard.test-ns
+                       :sym orchard.test-ns}
+              i (info/info (merge *cljs-params* params))]
+          (is (= '{:ns orchard.test-ns
+                   :name orchard.test-ns
+                   :line 1}
+                 (select-keys i [:line :name :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns")))))))
+
+(deftest info-ns-dependency-as-sym-test
+  (testing "Namespace dependency"
+    (let [params '{:sym orchard.test-ns-dep}
+          expected '{:ns orchard.test-ns-dep
+                     :name orchard.test-ns-dep
+                     :doc "Dependency of test-ns namespace"
+                     :line 1}]
+      (testing "- :cljs"
+        (let [i (info/info (merge *cljs-params* params))]
+          (is (= expected (select-keys i [:line :doc :name :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns_dep"))))
+      (testing "- :clj"
+        (let [i (info/info params)]
+          (is (= expected (select-keys i [:line :doc :name :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns_dep"))))
+
+      ;; is how the info middleware sends it
+      (testing "- :cljs with context"
+        (let [params '{:sym orchard.test-ns-dep
+                       :context-ns orchard.test-ns}
+              i (info/info (merge *cljs-params* params))]
+          (is (= '{:ns orchard.test-ns-dep
+                   :name orchard.test-ns-dep
+                   :doc "Dependency of test-ns namespace"
+                   :line 1}
+                 (select-keys i [:line :name :doc :ns])))
+          (is (str/includes? (:file i) "orchard/test_ns_dep")))))))
+
+(deftest info-cljs-core-namespace-test
+  (testing "Namespace itself but cljs.core"
+    (testing "- :cljs"
+      (is (= 'cljs.core (:ns (info/info (merge *cljs-params* '{:sym cljs.core}))))))
+    (testing "- :clj"
+      (is (= 'clojure.core (:ns (info/info '{:sym clojure.core})))))))
+
+(deftest info-namespace-alias-test
+  (testing "Namespace alias"
+    (let [params '{:ns orchard.test-ns
+                   :sym test-dep}
+          expected '{:ns orchard.test-ns-dep
+                     :name orchard.test-ns-dep
+                     :doc "Dependency of test-ns namespace"
+                     :line 1}]
+      (testing "- :cljs"
+        (let [i (info/info (merge *cljs-params* params))]
+          (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
+          (is (str/includes? (:file i) "orchard/test_ns_dep"))))
+
+      (testing "- :clj"
+        (let [i (info/info params)]
+          (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
+          (is (str/includes? (:file i) "orchard/test_ns_dep")))))))
+
+(deftest info-namespace-macro-test
+  (testing "Macro namespace"
+    (testing "- :cljs"
+      (let [params '[{:sym orchard.test-macros}
+                     {:sym orchard.test-macros
+                      :ns orchard.test-ns}
+                     {:sym orchard.test-macros
+                      :context-ns orchard.test-ns}
+                     {:sym orchard.test-macros
+                      :context-ns orchard.test-ns}]
+            expected '{:ns orchard.test-macros
+                       :file "orchard/test_macros.clj"
+                       :name orchard.test-macros
+                       :line 1}]
+        (is (= (take 4 (repeat expected))
+               (map #(info/info (merge *cljs-params* %)) params)))))))
+
+(deftest info-namespace-cljs-core-macro-test
+  (testing "cljs.core macro"
+    (testing "- :cljs"
+      (let [params '[{:sym loop}
+                     {:sym loop :ns cljs.core}
+                     {:sym loop :context-ns cljs.core}
+                     {:sym cljs.core/loop}
+                     {:sym cljs.core/loop :context-ns cljs.user}
+                     {:sym cljs.core/loop :ns cljs.user}]
+            expected '{:ns cljs.core
+                       :doc "Evaluates the exprs in a lexical context in which the symbols in\n  the binding-forms are bound to their respective init-exprs or parts\n  therein. Acts as a recur target."
+                       :name loop
+                       :arglists ([bindings & body])}]
+        (is (= (take 6 (repeat expected))
+               (->> params
+                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(select-keys % [:ns :name :doc :arglists])))))))))
+
+(deftest info-namespace-macro-alias-test
+  (testing "Macro namespace alias"
+    (testing "- :cljs"
+      (let [params '[{:sym test-macros :context-ns orchard.test-ns}
+                     {:sym test-macros :ns orchard.test-ns}]
+            expected '{:ns orchard.test-macros
+                       :name orchard.test-macros
+                       :file "orchard/test_macros.clj"
+                       :line 1}]
+        (is (= (take 2 (repeat expected))
+               (map #(info/info (merge *cljs-params* %)) params)))))))
+
+(deftest info-macros-var-test
+  (testing "Macro"
+    (testing "- :cljs"
+      (let [params '[{:sym orchard.test-macros/my-add}
+                     {:ns orchard.test-macros
+                      :sym my-add}]
+            expected '{:ns orchard.test-macros
+                       :name my-add
+                       :arglists ([a b])
+                       :macro true
+                       :file "orchard/test_macros.clj"}]
+        (is (= (take 2 (repeat expected))
+               (->> params
+                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(select-keys % [:ns :name :arglists :macro :file])))))))
+
+    (testing "- :clj"
+      (let [params '[{:sym orchard.test-macros/my-add}
+                     {:ns orchard.test-macros
+                      :sym my-add}]
+            expected '{:ns orchard.test-macros
+                       :name my-add
+                       :arglists ([a b])
+                       :macro true
+                       :file "orchard/test_macros.clj"}]
+        (is (= (take 2 (repeat expected))
+               (->> params
+                    (map #(info/info %))
+                    (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
+
+(deftest info-macros-referred-var-test
+  (testing "Macro - referred"
+    (let [params '[{:sym orchard.test-ns/my-add}
+                   {:ns orchard.test-ns
+                    :sym my-add}]
+          expected '{:name my-add
+                     :ns orchard.test-macros
+                     :arglists ([a b])
+                     :file "orchard/test_macros.clj"
+                     :macro true}]
+
+      (testing "- :cljs"
+        (is (= (take 2 (repeat expected))
+               (->> params
+                    (map #(info/info (merge *cljs-params* %)))
+                    (map #(select-keys % [:ns :name :arglists :macro :file]))))))
+
+      (testing "- :clj"
+        (is (= (take 2 (repeat expected))
+               (->> params
+                    (map #(info/info %))
+                    (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
+
+;;;;;;;;;;;;;;;;;;
+;; Clojure Only ;;
+;;;;;;;;;;;;;;;;;;
 
 (deftest see-also-test
   (is (not-empty (info/see-also 'clojure.core 'map))))
 
-(deftype T [])
-(defrecord R [])
-
-(deftest info-test
-  (is (info/info 'orchard.info 'io))
-
-  (is (info/info 'orchard.info 'info))
-
-  (is (info/info 'orchard.info 'java.lang.Class))
-  (is (info/info 'orchard.info 'Class/forName))
-  (is (info/info 'orchard.info '.toString))
-
-  (is (not (info/info 'clojure.core (gensym "non-existing"))))
-  (is (info/info 'orchard.info-test 'T))
-  (is (info/info 'orchard.info-test 'R))
-
-  (is (= (the-ns 'clojure.core) (:ns (info/info 'orchard.info 'str))))
-
-  ;; special forms are marked as such and nothing else is (for all syms in ns)
-  (let [ns 'orchard.info
-        spec-forms (into '#{letfn fn let loop} (keys @#'repl/special-doc-map))
-        infos (->> (into spec-forms (keys (ns-map ns)))
-                   (map (partial info/info ns)))]
-    (is (= spec-forms (->> (-> (group-by :special-form infos)
-                               (get true))
-                           (map :name)
-                           (set))))))
+(deftest info-jvm-test
+  (is (info/info {:ns 'orchard.info :sym 'java.lang.Class}))
+  (is (info/info {:ns 'orchard.info :sym 'Class/forName}))
+  (is (info/info {:ns 'orchard.info :sym '.toString})))
 
 (deftest info-java-test
   (is (info/info-java 'clojure.lang.Atom 'swap)))
@@ -45,13 +311,13 @@
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity()")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity()"]
-        (is (.endsWith url exp-suffix))))
+        (is (str/includes? url exp-suffix))))
 
     (testing "Javadoc 1.8 format"
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity--")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity--"]
-        (is (.endsWith url exp-suffix)))))
+        (is (str/includes? url exp-suffix)))))
 
   (testing "Get general URL for a clojure javadoc"
     (let [reply    (info/javadoc-info "clojure/java/io.clj")
@@ -106,8 +372,62 @@
          java.net.URL))
   (is (= (class (file "clojure-1.7.0.jar:clojure/core.clj"))
          java.net.URL))
-  (is (= (class (file "test/orchard/info_test.clj"))
+  (is (= (class (file "orchard/test_ns.cljc"))
          java.net.URL))
   (is (relative "clojure/core.clj"))
   (is (nil? (relative "notclojure/core.clj")))
   (is (nil? (info/resource-path "jar:file:fake.jar!/fake/file.clj"))))
+
+(deftest qualify-sym-test
+  (is (= '+ (info/qualify-sym nil '+)))
+  (is (nil? (info/qualify-sym 'cljs.core nil)))
+  (is (nil? (info/qualify-sym  nil nil)))
+  (is (= 'cljs.core/+ (info/qualify-sym 'cljs.core '+))))
+
+(deftest normalize-params-test
+  (testing ":qualified-sym namespace coming from :ns"
+    (is (= 'cljs.core/+ (-> '{:ns cljs.core
+                              :sym +
+                              :context-ns orchard.info}
+                            info/normalize-params
+                            :qualified-sym))))
+
+  (testing ":qualified-sym namespace coming from :context-ns if :ns is missing"
+    (is (= 'orchard.info/+ (-> '{:sym + :context-ns orchard.info}
+                               info/normalize-params
+                               :qualified-sym))))
+
+  (testing "adding :qualified-sym if :sym is qualified"
+    (is (= '{:sym orchard.info/+
+             :qualified-sym orchard.info/+}
+           (-> '{:sym orchard.info/+}
+               (info/normalize-params)
+               (select-keys [:sym :qualified-sym])))))
+
+  (testing "adding :computed-ns if :sym is qualified"
+    (is (= '{:sym orchard.info/+
+             :computed-ns orchard.info}
+           (-> '{:sym orchard.info/+}
+               (info/normalize-params)
+               (select-keys [:sym :computed-ns])))))
+
+  (testing "adding :unqualified-sym if :sym is qualified"
+    (is (= '{:sym orchard.info/+
+             :unqualified-sym +}
+           (-> '{:sym orchard.info/+}
+               (info/normalize-params)
+               (select-keys [:sym :unqualified-sym])))))
+
+  (testing "adding :unqualified-sym if :sym is unqualified"
+    (is (= '{:sym +
+             :unqualified-sym +}
+           (-> '{:sym +}
+               (info/normalize-params)
+               (select-keys [:sym :unqualified-sym])))))
+
+  (testing "in case of :ns only it should always assoc :unqualified-sym"
+    (is (= '{:ns orchard.info
+             :unqualified-sym orchard.info}
+           (-> '{:ns orchard.info}
+               (info/normalize-params)
+               (select-keys [:ns :unqualified-sym]))))))

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.misc-test
   (:require
    [clojure.string :as str]
-   [clojure.test :refer :all]
+   [clojure.test :as test :refer [deftest is testing]]
    [orchard.misc :as misc]))
 
 (deftest as-sym-test
@@ -31,3 +31,24 @@
          '{(0) 2, (0 1 2) 4, (0 1 2 3 4) 6}))
   (is (= (misc/update-keys str {:a :b :c :d :e :f})
          {":a" :b, ":c" :d, ":e" :f})))
+
+(deftest macros-suffix-add-remove
+  (testing "add-ns-macros"
+    (is (nil? (misc/add-ns-macros nil)))
+    (is (= 'mount.tools.macro$macros (misc/add-ns-macros 'mount.tools.macro))))
+
+  (testing "remove-macros"
+    (is (nil? (misc/remove-macros nil)) "it should return nil if input is nil")
+    (is (= 'mount.tools.macro (misc/remove-macros 'mount.tools.macro)) "it should not change the input if no $macros")
+    (is (= 'cljs.core.async/go (misc/remove-macros 'cljs.core.async$macros/go)) "it should remove $macros from a namespaced var")
+    (is (= 'mount.tools.macro (misc/remove-macros 'mount.tools.macro$macros)) "it should remove $macros from a namespace")))
+
+(deftest name-sym
+  (is (nil? (misc/name-sym nil)))
+  (is (= 'unqualified (misc/name-sym 'unqualified)))
+  (is (= 'sym (misc/name-sym 'qualified/sym))))
+
+(deftest namespace-sym
+  (is (nil? (misc/namespace-sym nil)))
+  (is (= 'unqualified (misc/namespace-sym 'unqualified)))
+  (is (= 'qualified (misc/namespace-sym 'qualified/sym))))


### PR DESCRIPTION
In order to start consolidating Clojure and ClojureScript tooling under our apple orchard, this patch starts porting the info op from cljs-tooling. Consequently, it paves the way to port some of the orchard Clojure-only code to ClojureScript.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [x] All tests are passing
- [X] The new code is not generating reflection warnings
