### PR TITLE
Add eval and def features to inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* [#38](https://github.com/clojure-emacs/orchard/pull/38): [Inspector] Add eval
+  and def features to inspector.
+
 ## 0.3.4 (2018-12-29)
 
 ### Changes

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -142,6 +142,13 @@
         (update :path conj '<unknown>)
         (inspect-render result))))
 
+(defn def-current-value
+  "Define the currently inspected value as a var with the given name in the
+  provided namespace."
+  [inspector namespace var-name]
+  (intern namespace (symbol var-name) (:value inspector))
+  (inspect-render inspector))
+
 (declare inspector-value-string)
 
 ;;

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -129,6 +129,19 @@
                          :page-size new-page-size
                          :current-page 0)))
 
+(defn eval-and-inspect
+  "Evaluate the given expression where `v` is bound to the currently inspected
+  value. Open the evaluation result in the inspector."
+  [inspector expr]
+  (let [{:keys [index path current-page page-size value]} inspector
+        eval-fn `(fn [~'v] ~(read-string expr))
+        result ((eval eval-fn) value)]
+    (-> (update inspector :stack conj value)
+        (update :pages-stack conj current-page)
+        (assoc :current-page 0)
+        (update :path conj '<unknown>)
+        (inspect-render result))))
+
 (declare inspector-value-string)
 
 ;;

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -17,6 +17,8 @@
 
 (def inspect-result-with-nil ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"1\" 1) (:newline) \"  \" \"1\" \". \" (:value \"2\" 2) (:newline) \"  \" \"2\" \". \" (:value \"\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline))"])
 
+(def eval-and-inspect-result ["(\"Class\" \": \" (:value \"java.lang.String\" 0) (:newline) \"Value: \" \"\\\"1001\\\"\")"])
+
 (def java-hashmap-inspect-result ["(\"Class\" \": \" (:value \"java.util.HashMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"2\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"3\" 4) (:newline) \"  \" (:value \":a\" 5) \" = \" (:value \"1\" 6) (:newline))"])
 
 (def long-sequence (range 70))
@@ -177,6 +179,16 @@
                     inspect/next-page)]
         (is (= 2 (:current-page ins)))
         (is (= 4 (:current-page (inspect/up ins))))))))
+
+(deftest eval-and-inspect-test
+  (testing "evaluate expr in the context of currently inspected value"
+    (is (= eval-and-inspect-result
+           (-> eval-result
+               inspect
+               (inspect/down 2)
+               (inspect/down 2)
+               (inspect/eval-and-inspect "(str (+ v 1000))")
+               render)))))
 
 (deftest path-test
   (testing "inspector tracks the path in the data structure"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -190,6 +190,15 @@
                (inspect/eval-and-inspect "(str (+ v 1000))")
                render)))))
 
+(deftest def-value-test
+  (testing "define var with the currently inspected value"
+    (-> eval-result
+        inspect
+        (inspect/down 2)
+        (inspect/down 2)
+        (inspect/def-current-value *ns* "--test-val--"))
+    (is (= 1 @(resolve '--test-val--)))))
+
 (deftest path-test
   (testing "inspector tracks the path in the data structure"
     (is (.endsWith (first (-> long-map

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -206,7 +206,7 @@
         (is (= 'java.lang.String (:class (resolve-symbol ns 'String)))))
       (testing "of unambiguous instance members"
         (is (= 'java.lang.SecurityManager
-               (:class (resolve-symbol ns 'checkSystemClipboardAccess)))))
+               (:class (resolve-symbol ns 'checkPackageDefinition)))))
       (testing "of candidate instance members"
         (is (every? #(= 'toString (:member %))
                     (vals (:candidates (resolve-symbol ns 'toString))))))


### PR DESCRIPTION
Inspired by REBL, these are two features that would subsequently be available in CIDER inspector:

- `def` the currently inspected value as a var.
- prompt the user for an expression and eval it in the context where `v` is bound to the currently inspected value. Inspect the result just to be consistent.