### PR TITLE
Catch LinkageError when calling Class/forName

### DIFF
--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -162,7 +162,8 @@
   first by name, and then by argument types to list all overloads."
   [class]
   (when-let [^Class c (try (Class/forName (str class))
-                           (catch Exception _))]
+                           (catch Exception _)
+                           (catch LinkageError _))]
     (let [r (JavaReflector. (.getClassLoader c))] ; for dynamically loaded classes
       (util/deep-merge (reflect-info (r/reflect c :reflector r))
                        (source-info class)


### PR DESCRIPTION
Fixes clojure-emacs/cider#2562. See https://docs.oracle.com/javase/specs/jls/se8/html/jls-12.html#jls-12.2 for a far more exhaustive discussion of what is actually going on during class loading/initialisation, and why we might need to guard against these errors when calling `Class/forName` – especially when native libraries are involved.