### PR TITLE
Namespace alias support for `spec-list` and `spec-form`

### DIFF
--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -41,22 +41,43 @@
                     (str %))
                  form))
 
+(defn- ns-name->ns-alias
+  "Return mapping from full namespace name to its alias in the given namespace."
+  [^String ns]
+  (if ns
+    (reduce-kv (fn [m alias ns]
+                 (assoc m (name (ns-name ns)) (name alias)))
+               {}
+               (ns-aliases (symbol ns)))
+    {}))
+
 (defn spec-list
   "Retrieves a list of all specs in the registry, sorted by ns/name.
   If filter-regex is not empty, keep only the specs with that prefix."
-  [filter-regex]
-  (let [sorted-specs (->> (registry)
-                          keys
-                          (map str)
-                          sort)]
-    (if (not-empty filter-regex)
-      (filter (fn [spec-symbol-str]
-                (let [checkable-part (if (.startsWith ^String spec-symbol-str ":")
-                                       (subs spec-symbol-str 1)
-                                       spec-symbol-str)]
-                  (re-find (re-pattern filter-regex) checkable-part)))
-              sorted-specs)
-      sorted-specs)))
+  ([filter-regex]
+   (spec-list filter-regex nil))
+  ([filter-regex ns]
+   (let [ns-alias (ns-name->ns-alias ns)
+         sorted-specs (->> (registry)
+                           keys
+                           (mapcat (fn [kw]
+                                     ;; Return an aliased entry in the current ns (if any)
+                                     ;; with the fully qualified keyword
+                                     (let [keyword-ns (namespace kw)]
+                                       (if (= ns keyword-ns)
+                                         [(str kw) (str "::" (name kw))]
+                                         (if-let [alias (ns-alias keyword-ns)]
+                                           [(str kw) (str "::" alias "/" (name kw))]
+                                           [(str kw)])))))
+                           sort)]
+     (if (not-empty filter-regex)
+       (filter (fn [spec-symbol-str]
+                 (let [checkable-part (if (.startsWith ^String spec-symbol-str ":")
+                                        (subs spec-symbol-str 1)
+                                        spec-symbol-str)]
+                   (re-find (re-pattern filter-regex) checkable-part)))
+               sorted-specs)
+       sorted-specs))))
 
 (defn get-multi-spec-sub-specs
   "Given a multi-spec form, call its multi method methods to retrieve
@@ -109,15 +130,37 @@
                      form))
                  sub-form))
 
+(defn- expand-ns-alias
+  "Expand a possible ns aliased keyword into a fully qualified keyword."
+  [^String ns ^String spec-name]
+  (if (and ns (.startsWith spec-name "::"))
+    (let [slash (.indexOf spec-name "/")]
+      (if (= -1 slash)
+        ;; This is a keyword in the current namespace
+        (str ":" ns "/" (subs spec-name 2))
+
+        ;; This is a keyword in an aliased namespace
+        (let [[keyword-ns kw] (.split (subs spec-name 2) "/")
+              aliases (ns-aliases (symbol ns))
+              ns-name (some-> keyword-ns symbol aliases ns-name name)]
+          (if ns-name
+            (str ":" ns-name "/" kw)
+            spec-name))))
+
+    ;; Nothing to expand
+    spec-name))
+
 (defn spec-form
   "Given a spec symbol as a string, get the spec form and prepare it for
   a response."
-  [spec-name]
-  (when-let [spec (spec-from-string spec-name)]
-    (-> (form spec)
-        add-multi-specs
-        normalize-spec-form
-        str-non-colls)))
+  ([spec-name]
+   (spec-form spec-name nil))
+  ([spec-name ns]
+   (when-let [spec (spec-from-string (expand-ns-alias ns spec-name))]
+     (-> (form spec)
+         add-multi-specs
+         normalize-spec-form
+         str-non-colls))))
 
 (defn spec-example
   "Given a spec symbol as a string, returns a string with a pretty printed

--- a/test/orchard/spec_test.clj
+++ b/test/orchard/spec_test.clj
@@ -21,30 +21,34 @@
              :ret (clojure.core/fn [%] (clojure.core/> (:start %) (:end %)))
              :fn nil)))))
 
-(deftest spec-is-found-by-ns-alias
-  (testing "current ns keyword"
-    (testing "spec-list finds current ns keyword"
-      (eval '(clojure.spec.alpha/def ::foo string?))
-      (let [specs (into #{}
-                        (spec/spec-list "" "orchard.spec-test"))]
-        (is (specs "::foo") "Spec is found with current ns")
-        (is (specs ":orchard.spec-test/foo") "Spec is found with fully qualified name")))
+(def spec-available? (or (resolve (symbol "clojure.spec.alpha" "get-spec"))
+                         (resolve (symbol "clojure.spec" "get-spec"))))
 
-    (testing "spec-form finds current ns keyword"
-      (let [spec1 (spec/spec-form "::foo" "orchard.spec-test")
-            spec2 (spec/spec-form ":orchard.spec-test/foo" "orchard.spec-test")]
-        (is (= "clojure.core/string?" spec1 spec2) "Both return the same correct spec"))))
+(when spec-available?
+  (deftest spec-is-found-by-ns-alias
+    (testing "current ns keyword"
+      (testing "spec-list finds current ns keyword"
+        (eval '(clojure.spec.alpha/def ::foo string?))
+        (let [specs (into #{}
+                          (spec/spec-list "" "orchard.spec-test"))]
+          (is (specs "::foo") "Spec is found with current ns")
+          (is (specs ":orchard.spec-test/foo") "Spec is found with fully qualified name")))
 
-  (testing "ns aliased keyword"
-    (eval '(clojure.spec.alpha/def :orchard.spec/test-dummy boolean?))
-    (testing "spec-list finds keyword in aliased namespace"
+      (testing "spec-form finds current ns keyword"
+        (let [spec1 (spec/spec-form "::foo" "orchard.spec-test")
+              spec2 (spec/spec-form ":orchard.spec-test/foo" "orchard.spec-test")]
+          (is (= "clojure.core/string?" spec1 spec2) "Both return the same correct spec"))))
 
-      (let [specs (into #{}
-                        (spec/spec-list "" "orchard.spec-test"))]
-        (is (specs "::spec/test-dummy") "Spec is found with ns-aliased keyword")
-        (is (specs ":orchard.spec/test-dummy") "Spec is found with fully qualified name")))
+    (testing "ns aliased keyword"
+      (eval '(clojure.spec.alpha/def :orchard.spec/test-dummy boolean?))
+      (testing "spec-list finds keyword in aliased namespace"
 
-    (testing "spec-form finds keyword in aliased namespace"
-      (let [spec1 (spec/spec-form "::spec/test-dummy" "orchard.spec-test")
-            spec2 (spec/spec-form ":orchard.spec/test-dummy" "orchard.spec-test")]
-        (is (= "clojure.core/boolean?" spec1 spec2) "Both return the same correct spec")))))
+        (let [specs (into #{}
+                          (spec/spec-list "" "orchard.spec-test"))]
+          (is (specs "::spec/test-dummy") "Spec is found with ns-aliased keyword")
+          (is (specs ":orchard.spec/test-dummy") "Spec is found with fully qualified name")))
+
+      (testing "spec-form finds keyword in aliased namespace"
+        (let [spec1 (spec/spec-form "::spec/test-dummy" "orchard.spec-test")
+              spec2 (spec/spec-form ":orchard.spec/test-dummy" "orchard.spec-test")]
+          (is (= "clojure.core/boolean?" spec1 spec2) "Both return the same correct spec"))))))

--- a/test/orchard/spec_test.clj
+++ b/test/orchard/spec_test.clj
@@ -20,3 +20,31 @@
                     (clojure.core/fn [%] (clojure.core/< (:start %) (:end %))))
              :ret (clojure.core/fn [%] (clojure.core/> (:start %) (:end %)))
              :fn nil)))))
+
+(deftest spec-is-found-by-ns-alias
+  (testing "current ns keyword"
+    (testing "spec-list finds current ns keyword"
+      (eval '(clojure.spec.alpha/def ::foo string?))
+      (let [specs (into #{}
+                        (spec/spec-list "" "orchard.spec-test"))]
+        (is (specs "::foo") "Spec is found with current ns")
+        (is (specs ":orchard.spec-test/foo") "Spec is found with fully qualified name")))
+
+    (testing "spec-form finds current ns keyword"
+      (let [spec1 (spec/spec-form "::foo" "orchard.spec-test")
+            spec2 (spec/spec-form ":orchard.spec-test/foo" "orchard.spec-test")]
+        (is (= "clojure.core/string?" spec1 spec2) "Both return the same correct spec"))))
+
+  (testing "ns aliased keyword"
+    (eval '(clojure.spec.alpha/def :orchard.spec/test-dummy boolean?))
+    (testing "spec-list finds keyword in aliased namespace"
+
+      (let [specs (into #{}
+                        (spec/spec-list "" "orchard.spec-test"))]
+        (is (specs "::spec/test-dummy") "Spec is found with ns-aliased keyword")
+        (is (specs ":orchard.spec/test-dummy") "Spec is found with fully qualified name")))
+
+    (testing "spec-form finds keyword in aliased namespace"
+      (let [spec1 (spec/spec-form "::spec/test-dummy" "orchard.spec-test")
+            spec2 (spec/spec-form ":orchard.spec/test-dummy" "orchard.spec-test")]
+        (is (= "clojure.core/boolean?" spec1 spec2) "Both return the same correct spec")))))


### PR DESCRIPTION

Added support for resolving namespace aliased keywords for the current namespace.

Changes:

- `spec-list` will return "::some-ns-alias/some-keyword" completions in addition to the fully qualified names for specs in namespaces that have an alias in the given ns.
- `spec-list` will return "::some-keyword" completions in addition to the fully qualified names for specs in the given ns.
- `spec-form` will expand both ns aliases before resolving the spec
- added tests for ns alias functionality

I will add a separate PR for CIDER to add `(cider-current-ns)` for `spec-list` and `spec-form` requests in `cider-client.el` if this is accepted.