### PR TITLE
[Fix #53] Have info resolve vars before aliases

### DIFF
--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -79,10 +79,10 @@
     (or
      ;; it's a special (special-symbol?)
      (m/special-sym-meta sym)
-     ;; it's an unqualified sym for an aliased var
-     (some-> ns (m/resolve-var unqualified-sym) (m/var-meta))
      ;; it's a var
      (some-> ns (m/resolve-var sym) (m/var-meta))
+     ;; it's an unqualified sym for an aliased var
+     (some-> ns (m/resolve-var unqualified-sym) (m/var-meta))
      ;; sym is an alias for another ns
      (some-> ns (m/resolve-aliases) (get sym) (m/ns-meta))
      ;; We use :unqualified-sym *exclusively* here because because our :ns is

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,6 +1,6 @@
 (ns ^{:doc "A test namespace"} orchard.test-ns
   (:refer-clojure :exclude [unchecked-byte while])
-  (:require [clojure.string]
+  (:require [clojure.string :refer [replace]]
             [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]])
   #?(:cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]])
      :clj  (:require [orchard.test-macros :as test-macros :refer [my-add]]))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -115,6 +115,31 @@
           (is (= expected (select-keys i [:ns :name :arglists])))
           (is (str/includes? (:file i) "test_ns_dep")))))))
 
+(deftest info-resolve-var-before-alias-test
+  (testing "resolve a fully qualified var before an alias - test for bug #53"
+    (let [expected '{:ns clojure.string
+                     :name replace
+                     :arglists ([s match replacement])}]
+      (testing "- :cljs"
+        (let [i (info/info 'orchard.test-ns 'clojure.string/replace *cljs-params*)]
+          (is (= expected (select-keys i [:ns :name :arglists])))))
+
+      (testing "- :clj"
+        (let [i (info/info 'orchard.test-ns 'clojure.string/replace)]
+          (is (= expected (select-keys i [:ns :name :arglists])))))))
+
+  (testing "resolve an unqualified alias instead of the var - test for bug #53"
+    (let [expected '{:ns clojure.string
+                     :name replace
+                     :arglists ([s match replacement])}]
+      (testing "- :cljs"
+        (let [i (info/info 'orchard.test-ns 'replace *cljs-params*)]
+          (is (= expected (select-keys i [:ns :name :arglists])))))
+
+      (testing "- :clj"
+        (let [i (info/info 'orchard.test-ns 'replace)]
+          (is (= expected (select-keys i [:ns :name :arglists]))))))))
+
 (deftest info-fully-qualified-var-test
   (testing "Fully-qualified var"
     (let [params '{:ns orchard.test-ns


### PR DESCRIPTION
The info function was resolving aliases, using the unqualified name, before
resolving vars. This was a problem and it has been fixed with this patch.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing