### PR TITLE
[Fix #52] Use boot-hack-classloader in file-info

### DIFF
--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -201,7 +201,7 @@ resolved (real) namespace and name here"}
   (java/member-info class member))
 
 (defn- resource-full-path [relative-path]
-  (io/resource relative-path (cp/context-classloader)))
+  (io/resource relative-path (cp/boot-aware-classloader)))
 
 (defn resource-path
   "If it's a resource, return a tuple of the relative path and the full resource path."


### PR DESCRIPTION
This patch brings a couple more boot hacks that were previously baked in the
cider-nrepl resource middleware into orchard. This enables the `info/file-info`
method to correctly resolve file resources.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] All tests are passing