### PR TITLE
Fix bug that fails to parse version string without minor version

### DIFF
--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -88,16 +88,19 @@
               (last xs)))]
     (apply f (filter identity xs))))
 
-(def java-api-version
+(defn parse-java-version
+  "Parse a Java version string according to JEP 223 and return the appropriate version."
+  [java-ver]
   (try
-    (let [java-ver (System/getProperty "java.version")
-          [major minor _] (str/split java-ver #"\.")
-          major (Integer/parseInt major)
-          minor (Integer/parseInt minor)]
+    (let [[major minor _] (str/split java-ver #"\.")
+          major (Integer/parseInt major)]
       (if (> major 1)
         major
-        (or minor 7)))
+        (Integer/parseInt (or minor "7"))))
     (catch Exception _ 7)))
+
+(def java-api-version
+  (parse-java-version (System/getProperty "java.version")))
 
 (defmulti transform-value "Transform a value for output" type)
 

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -32,6 +32,10 @@
   (is (= (misc/update-keys str {:a :b :c :d :e :f})
          {":a" :b, ":c" :d, ":e" :f})))
 
+(deftest parse-java-version-test
+  (is (= (misc/parse-java-version "1.8.0") 8))
+  (is (= (misc/parse-java-version "11") 11)))
+
 (deftest macros-suffix-add-remove
   (testing "add-ns-macros"
     (is (nil? (misc/add-ns-macros nil)))


### PR DESCRIPTION
According to [JEP223](http://openjdk.java.net/jeps/223), the minor version and security level parts of a Java version string must be omitted when both numbers are zero.
However, the current implementation of `orchard.misc/java-api-version` doesn't seem to take into account such a case. In fact, on my environment (OpenJDK 11) it fails to parse the version string and returns a wrong version:

```
$ java -version
openjdk version "11" 2018-09-25
OpenJDK Runtime Environment 18.9 (build 11+28)
OpenJDK 64-Bit Server VM 18.9 (build 11+28, mixed mode)
```

```clojure
=> (System/getProperty "java.version")
"11"
=> (require '[orchard.misc :as misc])
nil
=> misc/java-api-version
7
```

This PR fixes the issue and makes `misc/java-api-version` return the correct version:

Oracle JDK 8:
```clojure
=> (System/getProperty "java.version")
"1.8.0_181"
=> (require '[orchard.misc :as misc])
nil
=> misc/java-api-version
8
```

OpenJDK 11:
```clojure
=> (System/getProperty "java.version")
"11"
=> (require '[orchard.misc :as misc])
nil
=> misc/java-api-version
11
```

Also, this should probably fix #56.