### PR TITLE
Move resource op from cider-nrepl and refactor

### DIFF
--- a/src/orchard/resource.clj
+++ b/src/orchard/resource.clj
@@ -1,0 +1,71 @@
+(ns orchard.resource
+  "Resolve JVM resource-related information."
+  {:added "0.5.0"}
+  (:require
+   [clojure.java.io :as io]
+   [orchard.classpath :as cp]))
+
+(defn- trim-leading-separator
+  "Trim the java.io.File/separator at the beginning of s."
+  [s]
+  (if (.startsWith s java.io.File/separator)
+    (subs s 1)
+    s))
+
+(defn project-resources
+  "Get a list of classpath resources."
+  []
+  (mapcat
+   (fn [directory]
+     (->> directory
+          (file-seq)
+          (filter (memfn isFile))
+          (map (fn [file]
+                 (let [relpath (-> file
+                                   (.getPath)
+                                   (.replaceFirst
+                                    (.getPath directory)
+                                    "")
+                                   (trim-leading-separator))]
+                   {:root directory
+                    :file file
+                    :relpath relpath
+                    :url (io/resource relpath)})))
+          (remove #(.startsWith (:relpath %) "META-INF/"))
+          (remove #(re-matches #".*\.(clj[cs]?|java|class)" (:relpath %)))))
+   (filter (memfn isDirectory) (map io/as-file (cp/classpath (cp/boot-aware-classloader))))))
+
+(defn resource-full-path [relative-path]
+  (io/resource relative-path (cp/boot-aware-classloader)))
+
+(defn resource-path-tuple
+  "If it's a resource, return a tuple of the relative path and the full
+  resource path."
+  [path]
+  (or (if-let [full (resource-full-path path)]
+        [path full])
+      (if-let [[_ relative] (re-find #".*jar!/(.*)" path)]
+        (if-let [full (resource-full-path relative)]
+          [relative full]))
+      ;; handles load-file on jar resources from a cider buffer
+      (if-let [[_ relative] (re-find #".*jar:(.*)" path)]
+        (if-let [full (resource-full-path relative)]
+          [relative full]))))
+
+(defn resource-path
+  "Return the resource path for the given name."
+  {:added "0.5.0"}
+  [name]
+  (some-> name (resource-full-path) (.getPath)))
+
+(defn resource-maps
+  "Return a seq of resource maps:
+
+    {:file    \"the absolute path to the resource\"
+     :relpath \"the path of the resource relative to the classpath\"}
+
+  If the project does not contain resources, it returns nil."
+  {:added "0.5.0"}
+  []
+  (map #(select-keys % [:file :relpath])
+       (project-resources)))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -474,8 +474,7 @@
   (is (= (class (file "orchard/test_ns.cljc"))
          java.net.URL))
   (is (relative "clojure/core.clj"))
-  (is (nil? (relative "notclojure/core.clj")))
-  (is (nil? (info/resource-path "jar:file:fake.jar!/fake/file.clj"))))
+  (is (nil? (relative "notclojure/core.clj"))))
 
 (deftest qualify-sym-test
   (is (= '+ (info/qualify-sym nil '+)))

--- a/test/orchard/resource_test.clj
+++ b/test/orchard/resource_test.clj
@@ -1,0 +1,12 @@
+(ns orchard.resource-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [orchard.resource :as resource]))
+
+(deftest resource-path-tuple-test
+  (is (nil? (resource/resource-path-tuple "jar:file:fake.jar!/fake/file.clj"))))
+
+(deftest project-resources-test
+  (testing "get the correct resources for the orchard project"
+    (is (= "see-also.edn" (-> (resource/project-resources) first :relpath)))
+    (is (= java.net.URL (-> (resource/project-resources) first :url class)))))


### PR DESCRIPTION
This patch brings in orchard the code necessary for resource resolution and
does a bit of refactoring: javadoc is now in `orchard.java`, where it belongs,
and a new `orchard.java.resource` namespace has been created containing the
actual reusable resource code.


Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing