### PR TITLE
[Fix #61] Avoid processing file info if there is no file entry

### DIFF
--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -167,22 +167,21 @@ resolved (real) namespace and name here"}
   in as :env key in params."
   [params]
   (let [params  (normalize-params params)
-        dialect (:dialect params)]
+        dialect (:dialect params)
+        meta    (cond
+                  (= dialect :clj)  (clj-meta params)
+                  (= dialect :cljs) (cljs-meta params))]
 
     ;; TODO split up responsability of finding meta and normalizing the meta map
     (some->
-     (cond
-       (= dialect :clj)  (clj-meta params)
-       (= dialect :cljs) (cljs-meta params))
+     meta
 
-     ;; do not merge see-also if the info was not found
      (merge (when-let [m (see-also params)]
               {:see-also m}))
 
-     (update :file (fn [file-path]
-                     (if (u/boot-project?)
-                       (cp/classpath-file-relative-path file-path)
-                       file-path))))))
+     (merge (when-let [file-path (:file meta)]
+              {:file (cond-> file-path
+                       (u/boot-project?) cp/classpath-file-relative-path)})))))
 
 (defn info
   "Provide the info map for the input ns and sym.

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -41,8 +41,7 @@
                :package orchard.test_ns
                :super java.lang.Object
                :interfaces (clojure.lang.IType)
-               :javadoc "orchard/test_ns/TestType.html"
-               :file nil}
+               :javadoc "orchard/test_ns/TestType.html"}
              (select-keys i [:ns :name :class :package :super :interfaces :arglists :javadoc :file]))))))
 
 (deftest info-defrecord-test
@@ -72,8 +71,7 @@
                               clojure.lang.IPersistentMap
                               java.util.Map
                               java.io.Serializable)
-                 :javadoc "orchard/test_ns/TestRecord.html"
-                 :file nil}
+                 :javadoc "orchard/test_ns/TestRecord.html"}
                (select-keys i [:ns :name :class :package :super :interfaces :arglists :javadoc :file])))))))
 
 (deftest info-special-form-test
@@ -367,6 +365,25 @@
                (->> params
                     (map #(info/info* %))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
+
+(deftest info-no-file-info-test
+  (testing "File info key does not exist should not resolve classpath - issue #61"
+    (let [params '{:sym finally}
+          expected '{:forms [(try expr* catch-clause* finally-clause?)],
+                     :doc "catch-clause => (catch classname name expr*)\n  finally-clause => (finally expr*)\n\n  Catches and handles Java exceptions.",
+                     :name finally,
+                     :special-form true,
+                     :url "https://clojure.org/special_forms#finally"}]
+      (testing "- boot project"
+        (with-redefs [orchard.misc/boot-project? (constantly true)]
+          (let [i (info/info* params)]
+            (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
+            (is (nil? (:file i))))))
+
+      (testing "- no boot project"
+        (let [i (info/info* params)]
+          (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
+          (is (nil? (:file i))))))))
 
 ;;;;;;;;;;;;;;;;;;
 ;; Clojure Only ;;


### PR DESCRIPTION
There was a `NullPointerException` caused by an unnecessary call to
`cp/classpath-file-relative-path`. That code path is now avoided and as a bonus
the file key is not merged at all.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing