### PR TITLE
[WIP] Fix bug with no `:file` for `info` on namespaces w/o defs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml
 pom.xml.asc
 *.jar
 *.class
+.cljs_nashorn_repl/
+nashorn_code_cache/

--- a/src/orchard/cljs/meta.cljc
+++ b/src/orchard/cljs/meta.cljc
@@ -4,16 +4,30 @@
    :added "0.5.0"}
   (:require
    [orchard.cljs.analysis :as a #?@(:cljs [:include-macros true])]
-   [orchard.misc :as misc #?@(:cljs [:include-macros true])]))
+   [orchard.misc :as misc #?@(:cljs [:include-macros true])]
+   [orchard.namespace :as ns]))
+
+(defn normalize-ns-file
+  "Helps `normalize-ns-meta` to extract the file from the meta data"
+  [meta]
+  (or (some-> meta
+              :defs
+              first
+              second
+              :file)
+      (some-> meta
+              :name
+              ns/canonical-source
+              .getPath)))
 
 (defn normalize-ns-meta
   "Normalize cljs namespace metadata to look like a clj."
   [meta]
   (merge (select-keys meta [:doc :author])
-         (when-let [n (:name meta)]
-           {:ns n})
-         {:file (-> meta :defs first second :file)
-          :line 1}))
+         {:file (normalize-ns-file meta)
+          :line 1
+          :name (:name meta)
+          :ns (:name meta)}))
 
 (defn normalize-macro-ns
   "Normalize cljs namespace macro metadata to look like clj."

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -12,15 +12,6 @@
    [orchard.misc :as misc]
    [orchard.java.resource :as resource]))
 
-(defn normalize-ns-meta
-  "Normalize cljs namespace metadata to look like a clj."
-  [meta]
-  (merge (select-keys meta [:doc :author])
-         {:file (-> meta :defs first second :file)
-          :line 1
-          :name (:name meta)
-          :ns (:name meta)}))
-
 (defn qualify-sym
   "Qualify a symbol, if any in :sym, with :ns.
 
@@ -107,11 +98,11 @@
              (cljs-meta/normalize-var-meta))
      ;; an NS
      (some->> (cljs-ana/find-ns env sym)
-              (normalize-ns-meta))
+              (cljs-meta/normalize-ns-meta))
      ;; ns alias
      (some->> (cljs-ana/ns-alias env sym context-ns)
               (cljs-ana/find-ns env)
-              (normalize-ns-meta))
+              (cljs-meta/normalize-ns-meta))
      ;; macro ns
      (some->> (find-ns unqualified-sym)
               (cljs-meta/normalize-macro-ns env))

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -268,11 +268,15 @@
      (meta ns)
      {:ns (ns-name ns)
       :name (ns-name ns)
-      :file (-> (ns-publics ns)
-                first
-                second
-                var-meta
-                :file)
+      :file (or 
+             (-> (ns-publics ns)
+                 first
+                 second
+                 var-meta
+                 :file)
+             (->
+              (ns/canonical-source ns)
+              .getPath))
       :line 1})))
 
 ;;; ## Manipulation

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -261,6 +261,17 @@
                    :form form
                    :code code)))))))
 
+(defn ns-file
+  "Finds the path to the file defining this `ns`"
+  [ns]
+  (or (some-> (ns-publics ns)
+              first
+              second
+              var-meta
+              :file)
+      (some-> (ns/canonical-source ns)
+              .getPath)))
+
 (defn ns-meta
   [ns]
   (when ns
@@ -268,15 +279,7 @@
      (meta ns)
      {:ns (ns-name ns)
       :name (ns-name ns)
-      :file (or 
-             (-> (ns-publics ns)
-                 first
-                 second
-                 var-meta
-                 :file)
-             (->
-              (ns/canonical-source ns)
-              .getPath))
+      :file (ns-file ns)
       :line 1})))
 
 ;;; ## Manipulation

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -31,7 +31,8 @@
                  (str/replace "-" "_")
                  (str/replace "." "/"))]
     (or (io/resource (str path ".clj"))
-        (io/resource (str path ".cljc")))))
+        (io/resource (str path ".cljc"))
+        (io/resource (str path ".cljs")))))
 
 ;;; Namespace Loading
 

--- a/test-resources/orchard/cljs/test_canonical_source.cljs
+++ b/test-resources/orchard/cljs/test_canonical_source.cljs
@@ -1,0 +1,4 @@
+(ns orchard.cljs.test-canonical-source
+  "orchard.namespace/canocical-source should handle `.cljs` files")
+
+(def all-the-things 42)

--- a/test-resources/orchard/test_no_defs.cljc
+++ b/test-resources/orchard/test_no_defs.cljc
@@ -1,0 +1,2 @@
+(ns ^{:doc "Namespace w/o any `def`s, issue #75"}
+ orchard.test-no-defs)

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,7 +1,8 @@
 (ns ^{:doc "A test namespace"} orchard.test-ns
   (:refer-clojure :exclude [unchecked-byte while])
   (:require [clojure.string :refer [replace]]
-            [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]])
+            [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]]
+            [orchard.test-no-defs :as no-defs])
   #?(:cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]])
      :clj  (:require [orchard.test-macros :as test-macros :refer [my-add]]))
   #?(:cljs (:import [goog.ui IdGenerator])))

--- a/test/orchard/cljs/env_test.cljc
+++ b/test/orchard/cljs/env_test.cljc
@@ -10,6 +10,7 @@
       (is (empty? (set/difference (set (keys (a/all-ns env)))
                                   '#{orchard.test-ns
                                      orchard.test-ns-dep
+                                     orchard.test-no-defs
                                      orchard.test-macros
                                      cljs.core
                                      cljs.user

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -179,7 +179,7 @@
   (testing "Resolution from current namespace - issue #28 from cljs-tooling"
     (let [i (info/info* (merge *cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
       (is (= '{:arglists ([])
-               :line 14
+               :line 15
                :column 1
                :ns orchard.test-ns
                :name issue-28}
@@ -389,13 +389,14 @@
   (testing "File resolves, issue #75"
     (let [params '{:ns orchard.test-ns
                    :sym orchard.test-no-defs}
+          cljs-merged-params (merge *cljs-params* params)
           f "orchard/test_no_defs.cljc"]
       
       (testing "- :cljs"
-        (is (= f (:file (info/info* (merge *cljs-params* params))))))
+        (is (.endsWith (:file (info/info* cljs-merged-params)) f)))
 
       (testing "- :clj"
-        (is (= f (:file (info/info* params))))))))
+        (is (.endsWith (:file (info/info* params)) f))))))
 
 ;;;;;;;;;;;;;;;;;;
 ;; Clojure Only ;;

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -391,7 +391,6 @@
                    :sym orchard.test-no-defs}
           cljs-merged-params (merge *cljs-params* params)
           f "orchard/test_no_defs.cljc"]
-      
       (testing "- :cljs"
         (is (.endsWith (:file (info/info* cljs-merged-params)) f)))
 

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -385,6 +385,18 @@
           (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
           (is (nil? (:file i))))))))
 
+(deftest file-resolution-no-defs-issue-75-test
+  (testing "File resolves, issue #75"
+    (let [params '{:ns orchard.test-ns
+                   :sym orchard.test-no-defs}
+          f "orchard/test_no_defs.cljc"]
+      
+      (testing "- :cljs"
+        (is (= f (:file (info/info* (merge *cljs-params* params))))))
+
+      (testing "- :clj"
+        (is (= f (:file (info/info* params))))))))
+
 ;;;;;;;;;;;;;;;;;;
 ;; Clojure Only ;;
 ;;;;;;;;;;;;;;;;;;

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -110,3 +110,14 @@
     (docs/clean-cache!)
     (testing "Including see-also is skipped"
       (is (not (contains? (m/var-meta (resolve 'clojure.set/union)) :see-also))))))
+
+(deftest ns-meta-test
+  (testing "Includes a non-nil :file"
+    (is (some-> 'orchard.test-ns-dep
+                (find-ns)
+                (m/ns-meta)
+                :file))
+    (is (some-> 'orchard.test-no-defs ;; issue #75
+                (find-ns)
+                (m/ns-meta)
+                :file))))

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -111,13 +111,22 @@
     (testing "Including see-also is skipped"
       (is (not (contains? (m/var-meta (resolve 'clojure.set/union)) :see-also))))))
 
+(deftest ns-file-test
+  (testing "Resolves the file path"
+    (let [nss '[orchard.test-ns-dep orchard.test-no-defs]
+          endings ["test_ns_dep.cljc" "test_no_defs.cljc"]]
+      (is (every? true? (map #(.endsWith (m/ns-file %1) %2) nss endings))))))
+
 (deftest ns-meta-test
-  (testing "Includes a non-nil :file"
-    (is (some-> 'orchard.test-ns-dep
-                (find-ns)
-                (m/ns-meta)
-                :file))
-    (is (some-> 'orchard.test-no-defs ;; issue #75
-                (find-ns)
-                (m/ns-meta)
-                :file))))
+  (let [ns 'orchard.test-ns-dep
+        ns-meta (m/ns-meta ns)]
+    (testing "Includes correct `:ns`"
+      (is (= ns (:ns ns-meta))))
+    (testing "Includes correct `:name`"
+      (is (= ns (:name ns-meta))))
+    (testing "Includes correct `:file`"
+      (is (= (m/ns-file ns) (:file ns-meta))))
+    (testing "Includes `:line 1`"
+      (is (= 1 (:line ns-meta))))
+    (testing "Does not include anything else"
+      (is (= 4 (count (keys ns-meta)))))))

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -74,7 +74,8 @@
                  clojure.string
                  clojure.test
                  orchard.misc
-                 orchard.namespace]]
+                 orchard.namespace
+                 orchard.cljs.test-canonical-source]]
       (testing "namespace symbols to source files"
         (is (every? identity (map n/canonical-source nses))))
       (testing "source files to namespace symbols"


### PR DESCRIPTION
Sending this PR in to get feedback.

The problem with `:file` entries being `nil` for namespaces where there are no `def`s is that `orchard.meta/ns-meta` relies on `clojure.core/ns-publics` to first pick out some of the `def`:ed vars in order to use `var-meta` on them.

In this PR I use a backup method for when `ns-publics` return an empty map.

However, in `orchard.info-test/file-resolution-no-defs-issue-75-test` I still get a `nil` back for the `:cljs` test. I have yet failed to figure that out. Any feedback on that is very welcome.

I'd also want some general feedback, as I am planning to try contribute to this library more, and I need to learn the best ways to do that. Cheers!

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings


