### PR TITLE
[inspector] Render nil as nil inside data structures

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -204,6 +204,9 @@
 
 (defmulti inspect-value #'value-types)
 
+(defmethod inspect-value nil [value]
+  "nil")
+
 (defmethod inspect-value :atom [value]
   (truncate-string (pr-str value)))
 

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -15,7 +15,7 @@
 
 (def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"1\" 2) (:newline) (:newline) \"  Path: :a\")"])
 
-(def inspect-result-with-nil ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"1\" 1) (:newline) \"  \" \"1\" \". \" (:value \"2\" 2) (:newline) \"  \" \"2\" \". \" (:value \"\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline))"])
+(def inspect-result-with-nil ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"1\" 1) (:newline) \"  \" \"1\" \". \" (:value \"2\" 2) (:newline) \"  \" \"2\" \". \" (:value \"nil\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline))"])
 
 (def eval-and-inspect-result ["(\"Class\" \": \" (:value \"java.lang.String\" 0) (:newline) \"Value: \" \"\\\"1001\\\"\")"])
 


### PR DESCRIPTION
Before this change, `nil` inside data structures did not render at all. The change does not require changes in cider-nrepl or cider (however, maybe tests would have to be updated when cider-nrepl bumps orchard version).

Before:

![image](https://user-images.githubusercontent.com/468477/71418453-404b6980-2673-11ea-84b2-db78e40a97f7.png)

![image](https://user-images.githubusercontent.com/468477/71418468-4c372b80-2673-11ea-9533-8fbf01351755.png)

After:

![image](https://user-images.githubusercontent.com/468477/71418404-024e4580-2673-11ea-9914-c0c98dfce1bc.png)

![image](https://user-images.githubusercontent.com/468477/71418414-142fe880-2673-11ea-8709-bb5db5826475.png)


