### PR TITLE
[inspector] Handle InaccessibleObjectException for foreign-module fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* [#81](https://github.com/clojure-emacs/orchard/issues/81): [Inspector] Handle InaccessibleObjectException on Java 9+.
+* [#80](https://github.com/clojure-emacs/orchard/issues/80): [Inspector] Render nils in data structures.
+
 ## 0.5.4 (2019-11-05)
 
 ### Bugs fixed

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -425,11 +425,19 @@
               (.getName f))
 
             (field-val [^Field f]
-              (try (.setAccessible f true)
-                   (catch java.lang.SecurityException e))
-              (try (.get f obj)
-                   (catch java.lang.IllegalAccessException e
-                     "Access denied.")))
+              (let [e (try (.setAccessible f true)
+                           nil
+                           (catch Exception e
+                             ;; We want to handle specifically SecurityException
+                             ;; and j.l.r.InaccessibleObjectException, but the
+                             ;; latter only comes with Java9+, so let's just
+                             ;; catch everything instead.
+                             e))]
+                (try (.get f obj)
+                     (catch java.lang.IllegalAccessException _
+                       (symbol
+                        (format "<Access denied%s>"
+                                (when e (str " (" (.getName (.getClass e)) ")"))))))))
 
             (render-fields [inspector section-name fields]
               (if (seq fields)


### PR DESCRIPTION
On Java9+, when trying to inspect an object of a class that comes from the other module, and that object has private fields, JVM will throw InaccessibleObjectException when the inspector tries to set those private fields to accessible. Unfortunately, there doesn't seem a generic way to work around this, so at least we want the inspector to not crash in such situations.

Here's what the inspector shows after the patch:

![image](https://user-images.githubusercontent.com/468477/71419337-9e7a4b80-2677-11ea-884e-354df785c615.png)