### PR TITLE
Add handling for java version strings with $OPT chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+### Bugs fixed
 * [#82](https://github.com/clojure-emacs/orchard/pull/82/): Correctly parse Java version strings that contain $OPT segments after the version numbers
 
 ## 0.5.5 (2019-12-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#82](https://github.com/clojure-emacs/orchard/pull/82/): Correctly parse Java version strings that contain $OPT segments after the version numbers
+
 ## 0.5.5 (2019-12-30)
 
 ### Bugs fixed

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -92,7 +92,8 @@
   "Parse a Java version string according to JEP 223 and return the appropriate version."
   [java-ver]
   (try
-    (let [[major minor _] (str/split java-ver #"\.")
+    (let [[no-opt _] (str/split java-ver #"-")
+          [major minor _] (str/split no-opt #"\.")
           major (Integer/parseInt major)]
       (if (> major 1)
         major

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -92,6 +92,8 @@
   "Parse a Java version string according to JEP 223 and return the appropriate version."
   [java-ver]
   (try
+    ;; the no-opt split is because a java version string can end with
+    ;; an optional string consisting of a hyphen followed by other characters
     (let [[no-opt _] (str/split java-ver #"-")
           [major minor _] (str/split no-opt #"\.")
           major (Integer/parseInt major)]

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -34,7 +34,8 @@
 
 (deftest parse-java-version-test
   (is (= (misc/parse-java-version "1.8.0") 8))
-  (is (= (misc/parse-java-version "11") 11)))
+  (is (= (misc/parse-java-version "11") 11))
+  (is (= (misc/parse-java-version "14-ea") 14)))
 
 (deftest macros-suffix-add-remove
   (testing "add-ns-macros"


### PR DESCRIPTION
## Motivation
See comment here: https://github.com/clojure-emacs/orchard/pull/57#issuecomment-580518531

It's currently causing cider to fail for me when I jack in, and the traceback includes orchard failing to get the correct version string.

## Changes
* Add a test for a java version string with a $OPT chunk
* Fix the test by lopping off the $OPT in the `let` clause of `parse-java-version`

## Notes
I'm still pretty new to clojure, so if there's a more sane/elegant/appropriate way to lop off the $OPT bit, please let me know.