### PR TITLE
Ignore non file URLs when checking for directory or file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#83](https://github.com/clojure-emacs/orchard/pull/83): Ignore non file URLs when checking for directory or file extensions.
+
 ## 0.5.6 (2020-02-14)
 
 ### Bugs fixed

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -20,16 +20,27 @@
   []
   (not (nil? (boot-fake-classpath))))
 
+(defn url?
+  "Check whether the argument is an url"
+  [u]
+  (instance? java.net.URL u))
+
 (defn directory?
-  "Whether the argument is a directory"
+  "Whether the argument is a directory or an url that points to a directory"
   [f]
-  (.isDirectory (io/as-file f)))
+  (if (url? f)
+    (and (= (.getProtocol ^java.net.URL f) "file")
+         (.isDirectory (io/as-file f)))
+    (.isDirectory (io/as-file f))))
 
 (defn file-ext?
   "Whether the argument's path ends in one of the specified case-insensitive
   file extensions"
   [f & exts]
-  (let [file (io/as-file f)]
+  (when-let [file (if (url? f)
+                    (when  (= (.getProtocol ^java.net.URL f) "file")
+                      (io/as-file f))
+                    (io/as-file f))]
     (some (fn [ext]
             (.endsWith (.. file getName toLowerCase) ext))
           exts)))

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -57,3 +57,11 @@
   (is (nil? (misc/namespace-sym nil)))
   (is (= 'unqualified (misc/namespace-sym 'unqualified)))
   (is (= 'qualified (misc/namespace-sym 'qualified/sym))))
+
+(deftest file-ext?
+  (is (misc/file-ext? (java.net.URL. "file:/tmp/foo.jar") ".jar"))
+  (is (not (misc/file-ext? (java.net.URL. "file:/tmp/foo.war") ".jar")))
+  (is (not (misc/file-ext? (java.net.URL. "jar:file:/tmp/foo.jar!/BOOT-INF/lib/test.jar") ".jar"))))
+
+(deftest directory?
+  (is (misc/directory? (.toURL (.toURI (java.io.File. ""))))))


### PR DESCRIPTION
In a URLClassLoader not all URLs have to be files or directories.
Eg. Spring boot's fat jars add entries like "jar:file:..." to the
classpath
