### PR TITLE
Fix javadoc urls on java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#83](https://github.com/clojure-emacs/orchard/pull/83): Ignore non file URLs when checking for directory or file extensions.
+* [#84](https://github.com/clojure-emacs/orchard/pull/84): Fix javadoc urls
 
 ## 0.5.6 (2020-02-14)
 

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -363,7 +363,9 @@
       (some (let [classname (.replaceAll path "/" ".")]
               (fn [[prefix url]]
                 (when (.startsWith classname prefix)
-                  (str url path))))
+                  (str (cond-> url
+                         (= 11 misc/java-api-version) (.replaceFirst "/java.base" ""))
+                       path))))
             @javadoc/*remote-javadocs*)
       path))
 

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -373,7 +373,8 @@
                   ;; 8. clojure 1.10.1 doesn't have 13. We just backport them
                   ;; regardless of clojure version
                   (zipmap ["java." "javax." "org.ietf.jgss." "org.omg." "org.w3c.dom." "org.xml.sax"]
-                          (repeat (backported-javadoc-bases misc/java-api-version)))))
+                          (repeat (or (backported-javadoc-bases misc/java-api-version)
+                                      (backported-javadoc-bases 11))))))
       path))
 
 ;;; ## Initialization

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -345,7 +345,7 @@
           (first ms)
           {:candidates (zipmap (map :class ms) ms)})))))
 
-(def backported-javadoc-bases
+(def javadoc-base-urls
   "Copied from clojure.java.javadoc. These are the base urls for
   javadocs from `clojure.java.javadoc/*core-java-api*`. It is here for
   two reasons:
@@ -373,8 +373,8 @@
                   ;; 8. clojure 1.10.1 doesn't have 13. We just backport them
                   ;; regardless of clojure version
                   (zipmap ["java." "javax." "org.ietf.jgss." "org.omg." "org.w3c.dom." "org.xml.sax"]
-                          (repeat (or (backported-javadoc-bases misc/java-api-version)
-                                      (backported-javadoc-bases 11))))))
+                          (repeat (or (javadoc-base-urls misc/java-api-version)
+                                      (javadoc-base-urls 11))))))
       path))
 
 ;;; ## Initialization

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -1,7 +1,6 @@
 (ns orchard.java-test
   (:require
    [clojure.java.io :as io]
-   [clojure.java.javadoc :as clojure.javadoc]
    [clojure.test :refer :all]
    [dynapath.util :as dp]
    [orchard.java :refer :all]
@@ -233,46 +232,35 @@
               (is (= (:javadoc (member-info 'java.util.Hashtable 'putAll))
                      "java.base/java/util/Hashtable.html#putAll(java.util.Map)")))))))))
 
-(def javadoc-bases
-  "Copied from clojure.java.javadoc. These are the base urls for
-  javadocs from `clojure.java.javadoc/*core-java-api*`"
-  {8 "http://docs.oracle.com/javase/8/docs/api/"
-   9 "http://docs.oracle.com/javase/9/docs/api/"
-   10 "http://docs.oracle.com/javase/10/docs/api/"
-   11 "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/"})
-
 (deftest resolve-javadoc-path-test
   (let [get-url (comp resolve-javadoc-path (partial apply javadoc-url))]
-    (when (= 8 misc/java-api-version)
-      (testing "Java 8 javadocs resolve to the correct urls"
-        (with-bindings {#'clojure.javadoc/*core-java-api* (javadoc-bases 8)}
-          (with-redefs [misc/java-api-version 8
-                        cache (atom {})]
-            (are [class url] (= url (get-url class))
-              ['java.lang.String]
-              "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html"
+    (testing "Java 8 javadocs resolve to the correct urls"
+      (with-redefs [misc/java-api-version 8
+                    cache (atom {})]
+        (are [class url] (= url (get-url class))
+          ['java.lang.String]
+          "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html"
 
-              ['java.lang.String 'contains nil]
-              "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#contains"
+          ['java.lang.String 'contains nil]
+          "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#contains"
 
-              ['java.lang.String 'contains ['java.lang.CharSequence]]
-              "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#contains-java.lang.CharSequence-")))))
+          ['java.lang.String 'contains ['java.lang.CharSequence]]
+          "https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#contains-java.lang.CharSequence-")))
 
     (when (>= misc/java-api-version 9)
       (testing "Java 9 javadocs resolve to the correct urls"
-        (with-bindings {#'clojure.javadoc/*core-java-api* (javadoc-bases 9)}
-          (with-redefs [misc/java-api-version 9
-                        cache (atom {})]
-            (testing "java.base modules resolve correctly"
-              (are [class url] (= url (get-url class))
-                ['java.lang.String]
-                "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html"
+        (with-redefs [misc/java-api-version 9
+                      cache (atom {})]
+          (testing "java.base modules resolve correctly"
+            (are [class url] (= url (get-url class))
+              ['java.lang.String]
+              "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html"
 
-                ['java.lang.String 'contains nil]
-                "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#contains"
+              ['java.lang.String 'contains nil]
+              "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#contains"
 
-                ['java.lang.String 'contains ['java.lang.CharSequence]]
-                "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#contains-java.lang.CharSequence-"))))))
+              ['java.lang.String 'contains ['java.lang.CharSequence]]
+              "https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#contains-java.lang.CharSequence-")))))
 
     ;; these tests require resolving module names so should only run on 11
     (when (= 11 misc/java-api-version)

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -287,7 +287,14 @@
               "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html#newHttpClient"
 
               ['java.net.http.HttpRequest 'newBuilder ['java.net.URI]]
-              "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html#newBuilder(java.net.URI)")))))))
+              "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html#newBuilder(java.net.URI)")))))
+
+    (testing "Allows for added javadocs"
+      (with-redefs [cache (atom {})]
+        (is (= "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/lambda/AWSLambdaClient.html"
+               (get-url ['com.amazonaws.services.lambda.AWSLambdaClient])))
+        (is (= "https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerConfig.html"
+               (get-url '[org.apache.kafka.clients.consumer.ConsumerConfig])))))))
 
 (deftest class-resolution-test
   (let [ns (ns-name *ns*)]

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -294,7 +294,12 @@
         (is (= "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/lambda/AWSLambdaClient.html"
                (get-url ['com.amazonaws.services.lambda.AWSLambdaClient])))
         (is (= "https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerConfig.html"
-               (get-url '[org.apache.kafka.clients.consumer.ConsumerConfig])))))))
+               (get-url '[org.apache.kafka.clients.consumer.ConsumerConfig])))))
+    (testing "Unrecognized java version doesn't blank out the javadocs"
+      (with-redefs [misc/java-api-version 12345
+                    cache (atom {})]
+        (is (= "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html"
+               (get-url ['java.lang.String])))))))
 
 (deftest class-resolution-test
   (let [ns (ns-name *ns*)]

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -295,11 +295,12 @@
                (get-url ['com.amazonaws.services.lambda.AWSLambdaClient])))
         (is (= "https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerConfig.html"
                (get-url '[org.apache.kafka.clients.consumer.ConsumerConfig])))))
-    (testing "Unrecognized java version doesn't blank out the javadocs"
-      (with-redefs [misc/java-api-version 12345
-                    cache (atom {})]
-        (is (= "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html"
-               (get-url ['java.lang.String])))))))
+    (when (>= misc/java-api-version 11)
+      (testing "Unrecognized java version doesn't blank out the javadocs"
+        (with-redefs [misc/java-api-version 12345
+                      cache (atom {})]
+          (is (= "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html"
+                 (get-url ['java.lang.String]))))))))
 
 (deftest class-resolution-test
   (let [ns (ns-name *ns*)]


### PR DESCRIPTION
the core-java-api url prefix used from clojure.java.javadoc includes
the java.base module so we just strip that out and use the module as
we had been doing

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings

Keep in mind that new orchard builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

Thanks!
