### PR TITLE
WIP: Add constructor info to arglists of Java classes

### DIFF
--- a/src/orchard/eldoc.clj
+++ b/src/orchard/eldoc.clj
@@ -3,6 +3,10 @@
   in editors."
   {:author "Bozhidar Batsov"})
 
+(def ^:private type-abbrevs
+  '{java.lang.Object obj
+    java.lang.String str})
+
 (defn- extract-arglists
   [info]
   (cond
@@ -15,7 +19,8 @@
                             (mapcat :arglists)
                             distinct
                             (sort-by count))
-    :else (:arglists info)))
+    :else (for [arglist (:arglists info)]
+            (mapv #(get type-abbrevs % %) arglist))))
 
 (defn- format-arglists [raw-arglists]
   (map #(mapv str %) raw-arglists))

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -257,13 +257,19 @@
   these for more convenient `jump` navigation."
   [class]
   (let [info (class-info class)
-        ctor (->> (get-in info [:members class])
-                  (vals)
-                  (sort-by :line)
-                  (filter :line)
-                  (first))]
-    (merge (dissoc info :members)
-           (select-keys ctor [:line :column]))))
+        ctors (vals (get-in info [:members class]))
+        first-ctor (->> ctors
+                        (sort-by :line)
+                        (filter :line)
+                        (first))]
+    (-> info
+        (dissoc :members)
+        (assoc :arglists
+               ;; (sort-by count)
+               (map #(if (:argnames %)
+                       (mapv (fn [n t] (symbol (str  t " " n))) (:argnames %) (:argtypes %))
+                       (:argtypes %)) ctors))
+        (merge (select-keys first-ctor [:line :column])))))
 
 (defn member-info
   "For the class and member symbols, return Java member info. If the member is


### PR DESCRIPTION
This is partly an issue report and partly showing the current state of my edits for discussion. 
Not suitable for merging as-is.

This change allows for java class constructors to provide the :arglists  key in the info op response. No other change in cider-nrepl or cider.el is needed, it can be previewed by overriding the below `type-info` function in the cider-nrepl inlined namepsace.

At first I added a separate :ctors key but this required many changes to client code, I think using the :arglists key is alright for this purpose. 


Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings

Keep in mind that new orchard builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

Thanks!
