### PR TITLE
Fix clj meta java symbol

### DIFF
--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -72,9 +72,13 @@
      (m/special-sym-meta sym)
      ;; it's a var
      (some-> ns (m/resolve-var sym) (m/var-meta))
-     ;; it's an unqualified sym for an aliased var
+     ;; it's a Java constructor/static member symbol
+     (some-> ns (java/resolve-symbol sym))
+     ;; it's an unqualified sym maybe referred
      (some-> ns (m/resolve-var unqualified-sym) (m/var-meta))
-     ;; sym is an alias for another ns
+     ;; it's a Java class/record type symbol
+     (some-> ns (java/resolve-type unqualified-sym))
+     ;; it's an alias for another ns
      (some-> ns (m/resolve-aliases) (get sym) (m/ns-meta))
      ;; We use :unqualified-sym *exclusively* here because because our :ns is
      ;; too ambiguous.
@@ -83,9 +87,7 @@
      ;;
      ;;   (info '{:ns clojure.core :sym non-existing}) ;;=> {:author "Rich Hickey" :ns clojure.core ...}
      ;;
-     (some-> (find-ns unqualified-sym) (m/ns-meta))
-     ;; it's a Java class/member symbol...or nil
-     (some-> ns (java/resolve-symbol sym)))))
+     (some-> (find-ns unqualified-sym) (m/ns-meta)))))
 
 (defn cljs-meta
   {:added "0.5"}

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,5 +1,5 @@
 (ns ^{:doc "A test namespace"} orchard.test-ns
-  (:refer-clojure :exclude [unchecked-byte while])
+  (:refer-clojure :exclude [unchecked-byte while replace])
   (:require [clojure.string :refer [replace]]
             [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]]
             [orchard.test-no-defs :as no-defs])

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -327,8 +327,6 @@
 (deftest symbol-resolution-test
   (let [ns (ns-name *ns*)]
     (testing "Symbol resolution"
-      (testing "of classes/constructors"
-        (is (= 'java.lang.String (:class (resolve-symbol ns 'String)))))
       (testing "of unambiguous instance members"
         (is (= 'java.lang.SecurityManager
                (:class (resolve-symbol ns 'checkPackageDefinition)))))
@@ -372,3 +370,10 @@
         (is (nil? (resolve-symbol ns 'missingMethod)))
         (is (nil? (resolve-symbol ns '.missingDottedMethod)))
         (is (nil? (resolve-symbol ns '.random.bunch/of$junk)))))))
+
+(deftest type-resolution-test
+  (testing "Type resolution"
+    (testing "of Java classes/constructors in any namespace"
+      (is (= 'java.lang.String (:class (resolve-type (ns-name *ns*) 'String)))))
+    (testing "of deftype in clojure.core"
+      (is (= 'clojure.core.Eduction (:class (resolve-type 'clojure.core 'Eduction)))))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings

Here is the fix that seems to work. Please read the commit message, this is becoming black magic at this point and probably I will need to refactor stuff at some point.
I left the previous function name mostly untouched but given they return `info` candidates I really think that the `java/resolve-` prefix does not make too much sense. They probably belong to `orchard.info` but maybe this deserves another PR.


