### PR TITLE
Fix large number of open files from java parser

### DIFF
--- a/src/orchard/java/parser.clj
+++ b/src/orchard/java/parser.clj
@@ -296,15 +296,17 @@
   {:pre [(symbol? klass)]}
   (try
     (when-let [path (source-path klass)]
-      (when-let [root (parse-java path (module-name klass))]
-        (assoc (->> (.getIncludedElements ^DocletEnvironment root)
-                    (filter #(#{ElementKind/CLASS
-                                ElementKind/INTERFACE
-                                ElementKind/ENUM}
-                              (.getKind ^Element %)))
-                    (map #(parse-info % root))
-                    (filter #(= klass (:class %)))
-                    (first))
-               :file path
-               :path (.getPath (io/resource path)))))
+      (when-let [^DocletEnvironment root (parse-java path (module-name klass))]
+        (try
+          (assoc (->> (.getIncludedElements root)
+                      (filter #(#{ElementKind/CLASS
+                                  ElementKind/INTERFACE
+                                  ElementKind/ENUM}
+                                (.getKind ^Element %)))
+                      (map #(parse-info % root))
+                      (filter #(= klass (:class %)))
+                      (first))
+                 :file path
+                 :path (.getPath (io/resource path)))
+          (finally (.close (.getJavaFileManager root))))))
     (catch Throwable _)))


### PR DESCRIPTION
There's a file manager that backs each DocletEnvironment. As part of
parsing the docs, a jars from the classpath are loaded into it.  If you
do not close the file manager after you're done with the
DocletEnvironment, they're held onto forever.

Especially due to the `(future)` in orchard.java which parses the docs
for a bunch of classes, this can quickly snowball into the maximum file
limit being reached.  It won't fail in the foreground, but further
attempts to open files will fail.

Closing the file manager is recommended in
https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/tools/JavaCompiler.html

I attempted to reuse a file manager, but it didn't seem to work
correctly between invocations.  Presumably because of compiler state or
something.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s) (Tricky one to test, probably not worth the effort)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings