### PR TITLE
Default to silent class cache initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+* The _class info cache_ is now initialized silently by default. This results in less confusing output.
+  * You can now `@orchard.java/cache-initializer` for deterministically waiting for this cache workload to complete.
+  * You can control its verbosity by setting `"-Dorchard.initialize-cache.silent=false"` (or `[...]=true`).
+
 ## 0.6.5 (2021-02-13)
 
 ### Bugs Fixed

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Just add `orchard` as a dependency and start hacking.
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
 functionality that's provided.
 
+## Configuration options
+
+So far, Orchard follows these options, which can be specified as Java system properties
+(which means that end users can choose to set them globally without fiddling with tooling internals):
+
+* `"-Dorchard.initialize-cache.silent=true"` (default: `true`)
+  * if false, the _class info cache_ initialization may print warnings (possibly spurious ones).
+
 ## History
 
 Originally [SLIME][] was the most

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,9 @@
                       :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]
                                      [org.clojure/clojure "1.11.0-master-SNAPSHOT" :classifier "sources"]]}
 
-             :test {:resource-paths ["test-resources"]}
+             :test {:resource-paths ["test-resources"]
+                    ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
+                    :jvm-opts ["-Dorchard.initialize-cache.silent=false"]}
 
              ;; Development tools
              :dev {:dependencies [[pjstadig/humane-test-output "0.10.0"]]

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -440,4 +440,4 @@
 
   This is a def for allowing others to wait for this workload to complete (can be useful sometimes)."
   (future
-   (initialize-cache!)))
+    (initialize-cache!)))

--- a/src/orchard/util/io.clj
+++ b/src/orchard/util/io.clj
@@ -1,0 +1,24 @@
+(ns orchard.util.io)
+
+(defn wrap-silently
+  "Middleware that executes `(f)` without printing to `System/out` or `System/err`.
+
+  (Note that `System/out` is different from `*out*`)"
+  [f]
+  (fn []
+    (let [old-out System/out
+          old-err System/err
+          ps (java.io.PrintStream. (proxy [java.io.OutputStream] []
+                                     (write
+                                       ([a])
+                                       ([a b c])
+                                       ([a b c d e]))))]
+      (try
+        (System/setOut ps)
+        (System/setErr ps)
+        (f)
+        (finally
+          (when (= ps System/out) ;; `System/out` may have changed in the meantime (in face of concurrency)
+            (System/setOut old-out))
+          (when (= ps System/err) ;; `System/err` may have changed in the meantime (in face of concurrency)
+            (System/setErr old-err)))))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -3,10 +3,13 @@
    [clojure.test :as test :refer [deftest is testing use-fixtures]]
    [clojure.string :as str]
    [orchard.info :as info]
+   [orchard.java :as java]
    [orchard.misc :as misc]
    [orchard.cljs.test-env :as test-env]
    [orchard.meta :as meta]
    [orchard.test-ns]))
+
+@java/cache-initializer ;; make tests more deterministic
 
 (def ^:dynamic *cljs-params*)
 


### PR DESCRIPTION
* Default to silent class cache initialization
  * Fixes clojure-emacs/refactor-nrepl#290
* Fix a flaky test ns
  * See, for example: https://app.circleci.com/pipelines/github/clojure-emacs/orchard/267/workflows/4655c622-a1f7-4ab1-804c-d15e62641154/jobs/2329

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
