### PR TITLE
[Inspector] Configure truncation limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#111](https://github.com/clojure-emacs/orchard/pull/111): [Inspector] Configure truncation limits
+
+### Changes
+
 * The _class info cache_ is now initialized silently by default. This results in less confusing output.
   * You can now `@orchard.java/cache-initializer` for deterministically waiting for this cache workload to complete.
   * You can control its verbosity by setting `"-Dorchard.initialize-cache.silent=false"` (or `[...]=true`).


### PR DESCRIPTION
The limits after which the inspector truncates collection members are now
configurable. Previously they were hardcoded to 5 and 150 for collection and
atom (non-collection) members.

--------------------------------

Hi there!

I've been using cider-inspect to great effect recently. Occasionally, I run into cases where it would be really nice to see a collection like:

```
[[1 2 3 4 5 :some]
 [1 2 3 4 5 :important]
 [1 2 3 4 5 :thing]]
```

but it currently appears as:

```
Class: clojure.lang.PersistentVector
Contents: 
0. [ 1 2 3 4 5 ... ]
1. [ 1 2 3 4 5 ... ]
2. [ 1 2 3 4 5 ... ]
```

and I have to nav into each element one by one.

This change, and 2 more like it in cider-nrepl and cider, make the nested collection size limit configurable. While I was at it, I figured I might as well make the non-collection "atom" member sizes configurable too.

--------------------------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

