### PR TITLE
Demonstrate an incompatibility with clojure.java.classpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
 test:
-	lein with-profile +$(VERSION),$(TEST_PROFILES) test
+	lein with-profile +$(VERSION),$(TEST_PROFILES) test :only orchard.java.classpath-test.repro
 
 test-watch: test-resources/clojuredocs/export.edn
 	lein with-profile +$(VERSION),$(TEST_PROFILES) test-refresh

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
   :scm {:name "git" :url "https://github.com/clojure-emacs/orchard"}
 
   :dependencies [[org.tcrawley/dynapath "1.1.0"]
-                 [org.clojure/clojurescript "1.10.520"]]
+                 [org.clojure/clojurescript "1.10.520"]
+                 [org.clojure/java.classpath "1.0.0"]]
   :exclusions [org.clojure/clojure] ; see versions matrix below
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]}

--- a/test/orchard/java/classpath_test/repro.clj
+++ b/test/orchard/java/classpath_test/repro.clj
@@ -1,0 +1,14 @@
+(ns orchard.java.classpath-test.repro
+  (:require
+   [clojure.java.classpath]
+   [clojure.test :refer [are deftest is join-fixtures testing use-fixtures]]))
+
+(deftest works
+  (is (seq (clojure.java.classpath/classpath-directories))
+      "This test should pass")
+
+  (require 'orchard.java)
+  @@(resolve 'orchard.java/cache-initializer)
+
+  (is (seq (clojure.java.classpath/classpath-directories))
+      "This test is expected to fail, because `orchard.java` performs side-effects that affect classloading matters."))


### PR DESCRIPTION
> See also: https://github.com/clojure-emacs/cider-nrepl/pull/668
> See also: https://github.com/clojure-emacs/orchard/issues/103

This PR intends to demonstrate as precisely/isolatedly as possible how the current implementation of `orchard.java` creates issues for _outside_ libraries such as clojure.java.classpath, and transitively, clojure.tools.namespace.

As predicted, it fails for JDK >= 11:

![image](https://user-images.githubusercontent.com/1162994/114293043-2796db00-9a93-11eb-8885-dd28118630a7.png)

FWIW, I tried to actually fix the issue, for example using this pattern seemed promising:

```clj
(let [c (current-classloader)]
  (try
    ...
    (finally
      (set-classloader c))))
```

No luck though.