### PR TITLE
Add ability to skip dynapath-based functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ commands:
           command: |
             sudo apt-get install make
       - run:
-          name: Install clj-kondo
-          command: |
-           sudo curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo && sudo chmod +x install-clj-kondo && sudo ./install-clj-kondo
-      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>
@@ -210,10 +206,6 @@ workflows:
           jdk_version: openjdk11
           steps:
             - run:
-                name: Running Eastwood
-                command: |
-                  make eastwood
-            - run:
                 name: Running cljfmt
                 command: |
                   make cljfmt
@@ -221,6 +213,10 @@ workflows:
                 name: Running clj-kondo
                 command: |
                   make kondo
+            - run:
+                name: Running Eastwood
+                command: |
+                  make eastwood
       # - util_job:
       #     name: Code coverage
       #     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ executors:
     docker:
       - image: circleci/clojure:openjdk-11-lein-2.9.1
     <<: *defaults
-  openjdk15:
+  openjdk16:
     docker:
-      - image: circleci/clojure:openjdk-15-lein-2.9.5-buster
+      - image: circleci/clojure:openjdk-16-lein-2.9.5-buster
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -114,9 +114,13 @@ jobs:
       clojure_version:
         description: Version of Clojure to test against
         type: string
+      test_profiles:
+        description: Maps directly to the TEST_PROFILES var in Makefile
+        type: string
     executor: << parameters.jdk_version >>
     environment:
       VERSION: << parameters.clojure_version >>
+      TEST_PROFILES: << parameters.test_profiles >>
     steps:
       - checkout
       - with_cache:
@@ -146,53 +150,11 @@ workflows:
   ci-test-matrix:
     jobs:
       - test_code:
-          name: Java 8, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 8, Clojure master
-          clojure_version: "master"
-          jdk_version: openjdk8
-      - test_code:
-          name: Java 11, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 11, Clojure master
-          clojure_version: "master"
-          jdk_version: openjdk11
-      - test_code:
-          name: Java 15, Clojure 1.8
-          clojure_version: "1.8"
-          jdk_version: openjdk15
-      - test_code:
-          name: Java 15, Clojure 1.9
-          clojure_version: "1.9"
-          jdk_version: openjdk15
-      - test_code:
-          name: Java 15, Clojure 1.10
-          clojure_version: "1.10"
-          jdk_version: openjdk15
-      - test_code:
-          name: Java 15, Clojure master
-          clojure_version: "master"
-          jdk_version: openjdk15
+          matrix:
+            parameters:
+              jdk_version: [openjdk8, openjdk11, openjdk16]
+              clojure_version: ["1.8", "1.9", "1.10", "master"]
+              test_profiles: ["+test", "+test,+no-dynapath"]
       - util_job:
           name: Code Linting, JDK8 (Eastwood only)
           jdk_version: openjdk8

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /checkouts
 /classes
 /gh-pages
+/unzipped-jdk-source
 /target
 autodoc.sh
 pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* [#113](https://github.com/clojure-emacs/orchard/issues/113) Add ability to skip functionality that works by altering the classpath
+  * You an opt in to this choice by setting `"-Dorchard.use-dynapath=false"`.
 * The _class info cache_ is now initialized silently by default. This results in less confusing output.
   * You can now `@orchard.java/cache-initializer` for deterministically waiting for this cache workload to complete.
   * You can control its verbosity by setting `"-Dorchard.initialize-cache.silent=false"` (or `[...]=true`).

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cljfmt:
 	lein with-profile +$(VERSION),+cljfmt cljfmt check
 
 kondo:
-	clj-kondo --lint src test
+	lein with-profile -dev,+clj-kondo run -m clj-kondo.main --lint src test
 
 # Cloverage can't handle some of the code in this project.  For now we
 # must filter problematic namespaces (`-e`) and tests (`-t`) from

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION ?= 1.10
 
-TEST_PROFILES := +test
+TEST_PROFILES ?= +test
 
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn

--- a/README.md
+++ b/README.md
@@ -91,8 +91,13 @@ functionality that's provided.
 So far, Orchard follows these options, which can be specified as Java system properties
 (which means that end users can choose to set them globally without fiddling with tooling internals):
 
+* `"-Dorchard.use-dynapath=false"` (default: true)
+  * if `false`, all features that currently depend on dynapath (and therefore alter the classpath) will be disabled.
+  * This is a way to avoid a number of known issues: [#103](https://github.com/clojure-emacs/orchard/issues/103), [#105](https://github.com/clojure-emacs/orchard/issues/105), [#112](https://github.com/clojure-emacs/orchard/pull/112).
+  * Note that if this option is `false`, Orchard clients will have to figure out themselves a way to e.g. fetch Java sources.
+    * It is foreseen that soon enough this will be reliably offered as a Lein plugin.
 * `"-Dorchard.initialize-cache.silent=true"` (default: `true`)
-  * if false, the _class info cache_ initialization may print warnings (possibly spurious ones).
+  * if `false`, the _class info cache_ initialization may print warnings (possibly spurious ones).xx
 
 ## History
 

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,61 @@
+;;;; The following code allows to add the JDK sources without `dynapath` being present.
+
+(require '[clojure.java.io :as io])
+
+(import '[java.util.zip ZipInputStream]
+        '[java.io FileOutputStream])
+
+(defmacro while-let [[sym expr] & body]
+  `(loop [~sym ~expr]
+     (when ~sym
+       ~@body
+       (recur ~expr))))
+
+(defn jdk-find [f]
+  (let [home (io/file (System/getProperty "java.home"))
+        parent (.getParentFile home)
+        paths [(io/file home f)
+               (io/file home "lib" f)
+               (io/file parent f)
+               (io/file parent "lib" f)]]
+    (->> paths (filter #(.canRead ^java.io.File %)) first str)))
+
+(def jdk-sources
+  (let [java-path->zip-path (fn [path]
+                              (some-> (io/resource path)
+                                      ^java.net.JarURLConnection (. openConnection)
+                                      (. getJarFileURL)
+                                      io/as-file
+                                      str))]
+    (or (java-path->zip-path "java.base/java/lang/Object.java") ; JDK9+
+        (java-path->zip-path "java/lang/Object.java")           ; JDK8-
+        (jdk-find "src.zip"))))
+
+(defn uncompress [path target]
+  (let [zis (-> target io/input-stream ZipInputStream.)]
+    (while-let [entry (-> zis .getNextEntry)]
+      (let [size (-> entry .getSize)
+            bytes (byte-array 1024)
+            dest (->> entry .getName (io/file path))
+            dir (-> entry .getName (clojure.string/split #"/") butlast)
+            _ (->> (clojure.string/join "/" dir) (java.io.File. path) .mkdirs)
+            output (FileOutputStream. dest)]
+        (loop [len (-> zis (.read bytes))]
+          (when (pos? len)
+            (-> output (.write bytes 0 len))
+            (recur (-> zis (.read bytes)))))
+        (-> output .close)))))
+
+(defn unzipped-jdk-source []
+  (let [choice jdk-sources]
+    (when-not (-> "unzipped-jdk-source" io/file .exists)
+      (-> "unzipped-jdk-source" io/file .mkdirs)
+      ;; For some reason simply adding a .zip to the classpath doesn't work, so one has to uncompress the contents:
+      (uncompress "./unzipped-jdk-source/" choice))
+    "unzipped-jdk-source"))
+
+(def jdk8? (->> "java.version" System/getProperty (re-find #"^1.8.")))
+
 (defproject cider/orchard "0.6.5"
   :description "A fertile ground for Clojure tooling"
   :url "https://github.com/clojure-emacs/orchard"
@@ -23,6 +81,8 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
+  :jvm-opts ["-Dorchard.use-dynapath=true"]
+  
   :profiles {
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.10.1"]
@@ -38,9 +98,16 @@
                       :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]
                                      [org.clojure/clojure "1.11.0-master-SNAPSHOT" :classifier "sources"]]}
 
-             :test {:resource-paths ["test-resources"]
+             :test {:dependencies [[org.clojure/java.classpath "1.0.0"]]
+                    :resource-paths ["test-resources"]
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
                     :jvm-opts ["-Dorchard.initialize-cache.silent=false"]}
+
+             :no-dynapath {:jvm-opts ["-Dorchard.use-dynapath=false"]
+                           :resource-paths [~(unzipped-jdk-source)]
+                           :plugins ~(if jdk8?
+                                       '[[lein-jdk-tools "0.1.1"]]
+                                       [])}
 
              ;; Development tools
              :dev {:dependencies [[pjstadig/humane-test-output "0.10.0"]]
@@ -63,8 +130,6 @@
                          {:dependencies [[clj-kondo "2021.03.31"]]}]
              
              :eastwood  {:plugins  [[jonase/eastwood "0.4.0"]]
-                         :eastwood {:exclude-namespaces [~(if (-> "java.version"
-                                                                  System/getProperty
-                                                                  (.contains "1.8."))
+                         :eastwood {:exclude-namespaces [~(if jdk8?
                                                             'orchard.java.parser
                                                             'orchard.java.legacy-parser)]}}})

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,10 @@
                                          with-debug-bindings [[:inner 0]]
                                          merge-meta [[:inner 0]]
                                          letfn [[:block 1] [:inner 2]]}}}
-
+             
+             :clj-kondo [:test
+                         {:dependencies [[clj-kondo "2021.03.31"]]}]
+             
              :eastwood  {:plugins  [[jonase/eastwood "0.4.0"]]
                          :eastwood {:exclude-namespaces [~(if (-> "java.version"
                                                                   System/getProperty

--- a/test/orchard/java/classpath_test/third_party_compat_test.clj
+++ b/test/orchard/java/classpath_test/third_party_compat_test.clj
@@ -1,0 +1,13 @@
+(ns orchard.java.classpath-test.third-party-compat-test
+  (:require
+   [orchard.java]
+   [clojure.java.classpath]
+   [clojure.test :refer [deftest is]]))
+
+;; make this namespace's tests deterministic:
+@orchard.java/cache-initializer
+
+(when-not orchard.java/add-java-sources-via-dynapath?
+  (deftest works
+    (is (seq (clojure.java.classpath/classpath-directories))
+        "The presence of `clojure.java` does not affect third-party libraries")))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -9,8 +9,11 @@
 
 (def jdk-parser? (or (>= misc/java-api-version 9) jdk-tools))
 
-(when-not jdk-parser? (println "No JDK parser available!"))
-(when-not jdk-sources (println "No JDK sources available!"))
+(assert jdk-parser? "No JDK parser available!")
+(assert (if orchard.java/add-java-sources-via-dynapath?
+          jdk-sources
+          true)
+        "No JDK sources available!")
 
 (javadoc/add-remote-javadoc "com.amazonaws." "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/")
 (javadoc/add-remote-javadoc "org.apache.kafka." "https://kafka.apache.org/090/javadoc/")
@@ -25,7 +28,8 @@
                              (dp/all-classpath-urls)
                              (set))]
       (testing "of defined vars"
-        (is (= jdk-sources jdk-sources-path))
+        (when orchard.java/add-java-sources-via-dynapath?
+          (is (= jdk-sources jdk-sources-path)))
         (is (= jdk-tools jdk-tools-path)))
       (testing "of dynamically added classpath entries"
         (is (= jdk-sources (classpath-urls jdk-sources)))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/orchard/issues/113
Closes https://github.com/clojure-emacs/orchard/pull/112

The disabling is opt-in, i.e. nothing is changed (relative to current behavior) by default.

In order to exercise the proposed changes properly (and also, to prove that a plugin-based approach can work), it is proposed that the build matrix exercises both the dynapath and no-dynapath choices.

⚠️ Between and a tenative addition of JDK16 to the matrix, the matrix would become quite extensive - perhaps a bit over the top?

Green build in my account:

![image](https://user-images.githubusercontent.com/1162994/114304280-90ea0e80-9ad2-11eb-9d30-4cbd3a1b13ca.png)

⚠️ for the no-dynapath choice _and_ JDK 8, a CI job will take 3m instead of 30-60s. Seems a legit issue, can investigate.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
