### PR TITLE
Truncate maps in inspector according to config

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -205,6 +205,7 @@
     (atom? value)                                  :atom
     (and (instance? Seqable value) (empty? value)) :seq-empty
     (and (map? value) (short? value))              :map
+    (map-entry? value)                             :map-entry
     (map? value)                                   :map-long
     (and (vector? value) (short? value))           :vector
     (vector? value)                                :vector-long
@@ -230,19 +231,17 @@
 (defmethod inspect-value :atom [value]
   (truncate-string (pr-str value)))
 
+(defmethod inspect-value :map-entry [[k v]]
+  (str (inspect-value k) " " (inspect-value v)))
+
 (defmethod inspect-value :seq-empty [value]
   (pr-str value))
 
 (defmethod inspect-value :map [value]
-  (->> value
-       (map (fn [[k v]]
-              (str (inspect-value k) " " (inspect-value v))))
-       (s/join ", ")
-       (format "{ %s }")))
+  (safe-pr-seq value ", " "{ %s }"))
 
 (defmethod inspect-value :map-long [value]
-  (let [[k v] (first value)]
-    (str "{ " (inspect-value k) " " (inspect-value v) ", ... }")))
+  (safe-pr-seq (take *max-coll-size* value) ", " "{ %s ... }"))
 
 (defmethod inspect-value :vector [value]
   (safe-pr-seq value "[ %s ]"))

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -241,7 +241,7 @@
   (safe-pr-seq value ", " "{ %s }"))
 
 (defmethod inspect-value :map-long [value]
-  (safe-pr-seq (take *max-coll-size* value) ", " "{ %s ... }"))
+  (safe-pr-seq (take *max-coll-size* value) ", " "{ %s, ... }"))
 
 (defmethod inspect-value :vector [value]
   (safe-pr-seq value "[ %s ]"))
@@ -274,7 +274,7 @@
 
 (defmethod inspect-value :array-long [value]
   (let [ct (.getName (or (.getComponentType (class value)) Object))]
-    (safe-pr-seq (take *max-coll-size* value) ", " (str ct "[] { %s ... }"))))
+    (safe-pr-seq (take *max-coll-size* value) ", " (str ct "[] { %s, ... }"))))
 (defmethod inspect-value java.lang.Class [value]
   (pr-str value))
 

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -259,13 +259,13 @@
       "#{ :a }" #{:a}
       "( 1 1 1 1 1 ... )" (repeat 1)
       "[ ( 1 1 1 1 1 ... ) ]" [(repeat 1)]
-      "{ :a { ( 0 1 2 3 4 ... ) 1, 2 3, 4 5, 6 7, 8 9 ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
+      "{ :a { ( 0 1 2 3 4 ... ) 1, 2 3, 4 5, 6 7, 8 9, ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
       "( 1 2 3 )" (lazy-seq '(1 2 3))
       "( 1 1 1 1 1 ... )" (java.util.ArrayList. (repeat 100 1))
       "( 1 2 3 )" (java.util.ArrayList. [1 2 3])
       "{ :a 1, :b 2 }" (java.util.HashMap. {:a 1 :b 2})
       "long[] { 1, 2, 3, 4 }" (long-array [1 2 3 4])
-      "java.lang.Long[] { 0, 1, 2, 3, 4 ... }" (into-array Long (range 10))
+      "java.lang.Long[] { 0, 1, 2, 3, 4, ... }" (into-array Long (range 10))
       "#<MyTestType test1>" (MyTestType. "test1")))
 
   (testing "inspect-value adjust length and size"
@@ -279,12 +279,12 @@
         "( :a :b )" '(:a :b)
         "[ 1 2 ... ]" [1 2 3]
         "{ :a 1, :b 2 }" {:a 1 :b 2}
-        "{ :a 1, :b 2 ... }" {:a 1 :b 2 :c 3}
-        "{ :a 1, :b 2 ... }" (sorted-map :d 4 :b 2 :a 1 :c 3)
+        "{ :a 1, :b 2, ... }" {:a 1 :b 2 :c 3}
+        "{ :a 1, :b 2, ... }" (sorted-map :d 4 :b 2 :a 1 :c 3)
         "( 1 1 ... )" (repeat 1)
         "[ ( 1 1 ... ) ]" [(repeat 1)]
-        "{ :a { ( 0 1 ... ) \"ab..., 2 3 ... } }" {:a {(range 10) "abcdefg", 2 3, 4 5, 6 7, 8 9, 10 11}}
-        "java.lang.Long[] { 0, 1 ... }" (into-array Long (range 10))))
+        "{ :a { ( 0 1 ... ) \"ab..., 2 3, ... } }" {:a {(range 10) "abcdefg", 2 3, 4 5, 6 7, 8 9, 10 11}}
+        "java.lang.Long[] { 0, 1, ... }" (into-array Long (range 10))))
     (binding [inspect/*max-coll-size* 6]
       (are [result form] (= result (inspect/inspect-value form))
         "[ ( 1 1 1 1 1 1 ... ) ]" [(repeat 1)]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -259,7 +259,7 @@
       "#{ :a }" #{:a}
       "( 1 1 1 1 1 ... )" (repeat 1)
       "[ ( 1 1 1 1 1 ... ) ]" [(repeat 1)]
-      "{ :a { ( 0 1 2 3 4 ... ) 1, ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
+      "{ :a { ( 0 1 2 3 4 ... ) 1, 2 3, 4 5, 6 7, 8 9 ... } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
       "( 1 2 3 )" (lazy-seq '(1 2 3))
       "( 1 1 1 1 1 ... )" (java.util.ArrayList. (repeat 100 1))
       "( 1 2 3 )" (java.util.ArrayList. [1 2 3])
@@ -279,9 +279,11 @@
         "( :a :b )" '(:a :b)
         "[ 1 2 ... ]" [1 2 3]
         "{ :a 1, :b 2 }" {:a 1 :b 2}
+        "{ :a 1, :b 2 ... }" {:a 1 :b 2 :c 3}
+        "{ :a 1, :b 2 ... }" (sorted-map :d 4 :b 2 :a 1 :c 3)
         "( 1 1 ... )" (repeat 1)
         "[ ( 1 1 ... ) ]" [(repeat 1)]
-        "{ :a { ( 0 1 ... ) \"ab..., ... } }" {:a {(range 10) "abcdefg", 2 3, 4 5, 6 7, 8 9, 10 11}}
+        "{ :a { ( 0 1 ... ) \"ab..., 2 3 ... } }" {:a {(range 10) "abcdefg", 2 3, 4 5, 6 7, 8 9, 10 11}}
         "java.lang.Long[] { 0, 1 ... }" (into-array Long (range 10))))
     (binding [inspect/*max-coll-size* 6]
       (are [result form] (= result (inspect/inspect-value form))


### PR DESCRIPTION
Extends #111 to make maps truncate the same way as other collections, 
showing `*max-coll-size*` number of elements if they are too long.

----
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!
