### PR TITLE
`orchard.classpath`: don't fail on directories ending on .jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ autodoc.sh
 pom.xml
 pom.xml.asc
 *.jar
+!not-a.jar
 *.class
 .cljs_nashorn_repl/
 nashorn_code_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* Directories in the classpath having a file extension (such as .jar) will not confuse Orchard anymore, which had the potential to cause errors. 
+
 ## 0.7.0 (2021-04-13)
 
 ### New features

--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,8 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :jvm-opts ["-Dorchard.use-dynapath=true"]
+  :jvm-opts ["-Dorchard.use-dynapath=true"
+             "-Dclojure.main.report=stderr"]
 
   :profiles {
              ;; Clojure versions matrix
@@ -101,7 +102,8 @@
                                      [org.clojure/clojure "1.11.0-master-SNAPSHOT" :classifier "sources"]]}
 
              :test {:dependencies [[org.clojure/java.classpath "1.0.0"]]
-                    :resource-paths ["test-resources"]
+                    :resource-paths ["test-resources"
+                                     "not-a.jar"]
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
                     :jvm-opts ["-Dorchard.initialize-cache.silent=false"]}
 

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -38,12 +38,15 @@
   file extensions"
   [f & exts]
   (when-let [file (if (url? f)
-                    (when  (= (.getProtocol ^java.net.URL f) "file")
+                    (when (= (.getProtocol ^java.net.URL f) "file")
                       (io/as-file f))
                     (io/as-file f))]
-    (some (fn [ext]
-            (.endsWith (.. file getName toLowerCase) ext))
-          exts)))
+    (and
+     ;; Check for file-ness because having a specific extension implies we assume `f` is a file:
+     (not (directory? f))
+     (some (fn [ext]
+             (.endsWith (.. file getName toLowerCase) ext))
+           exts))))
 
 (defn clj-file?  [f] (file-ext? f ".clj" ".cljc"))
 (defn java-file? [f] (file-ext? f ".java"))


### PR DESCRIPTION
I recently hit the corner case of a directory named `foo.jar` which caused orchard to choke on it.

This PR proposes a fix.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
