### PR TITLE
Parallelize `orchard.namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `orchard.namespace` functionality is now parallelized when possible.
+
 ## 0.7.1 (2021-04-18)
 
 ### Bugs Fixed


### PR DESCRIPTION
Parallelizes `orchard.namespace` when it makes sense (namely, IO-heavy ops) and it's safe to do so (i.e., no code loading performed).

This matters particularly in projects with numerous namespaces and large classpaths.

Makes https://github.com/clojure-emacs/cider-nrepl/pull/701 more efficient, particularly when `(namespace/project-namespaces)` will be invoked slightly more often (since a `def` became a `defn`).
