### PR TITLE
Make `classpath-seq` handle non-existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 * [#123](https://github.com/clojure-emacs/orchard/pull/123): Fix info lookups from namespaces that don't yet exist
+* [#125](https://github.com/clojure-emacs/orchard/pull/125): Don't fail if the classpath references a non-existing .jar
 
 ## 0.7.1 (2021-04-18)
 

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,8 @@
 
              :test {:dependencies [[org.clojure/java.classpath "1.0.0"]]
                     :resource-paths ["test-resources"
-                                     "not-a.jar"]
+                                     "not-a.jar"
+                                     "does-not-exist.jar"]
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
                     :jvm-opts ["-Dorchard.initialize-cache.silent=false"]}
 

--- a/project.clj
+++ b/project.clj
@@ -121,16 +121,16 @@
                                 (pjstadig.humane-test-output/activate!)]
                    :test-refresh {:changes-only true}}
 
-             :cljfmt {:plugins [[lein-cljfmt "0.6.4"]]
+             :cljfmt {:plugins [[lein-cljfmt "0.8.0"]]
                       :cljfmt {:indents {as-> [[:inner 0]]
                                          with-debug-bindings [[:inner 0]]
                                          merge-meta [[:inner 0]]
                                          letfn [[:block 1] [:inner 2]]}}}
 
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.03.31"]]}]
+                         {:dependencies [[clj-kondo "2021.09.15"]]}]
 
-             :eastwood  {:plugins  [[jonase/eastwood "0.9.6"]]
+             :eastwood  {:plugins  [[jonase/eastwood "0.9.9"]]
                          :eastwood {:exclude-namespaces [~(if jdk8?
                                                             'orchard.java.parser
                                                             'orchard.java.legacy-parser)]}}})

--- a/src/orchard/java/classpath.clj
+++ b/src/orchard/java/classpath.clj
@@ -84,10 +84,16 @@
   as relative paths."
   [^URL url]
   (let [f (io/as-file url)]
-    (if (misc/archive? url)
+    (cond
+      (not (.exists f))
+      []
+
+      (misc/archive? url)
       (->> (enumeration-seq (.entries (JarFile. f)))
            (filter #(not (.isDirectory ^JarEntry %)))
            (map #(.getName ^JarEntry %)))
+
+      :else
       (->> (file-seq f)
            (filter #(not (.isDirectory ^File %)))
            (map #(.getPath (.relativize (.toURI url) (.toURI ^File %))))))))

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -20,7 +20,6 @@
 ;; clojure version                                                  ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
 (defn get-spec [v] (spec "get-spec" v))
 
 (defn describe [s] (spec "describe" s))


### PR DESCRIPTION
* Make `classpath-seq` handle non-existing files
  * Fixes https://github.com/clojure-emacs/orchard/issues/125
* Upgrade linters
