### PR TITLE
CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,19 @@ commands:
     description: |
       Run a set of steps with Maven dependencies and Clojure classpath cache
       files cached.
-      This command restores ~/.m2 and .cpcache if they were previously cached,
+      This command restores ~/.m2, .cpcache and such if they were previously cached,
       then runs the provided steps, and finally saves the cache.
       The cache-key is generated based on the contents of `deps.edn` present in
       the `working_directory`.
     parameters:
       steps:
         type: steps
+      jdk_version:
+        description: Will be used as part of the cache key. Especially important for unzipped-jdk-source
+        type: string
+      clojure_version:
+        description: Will be used as part of the cache key. Especially important for unzipped-jdk-source
+        type: string
       files:
         description: Files to consider when creating the cache key
         type: string
@@ -92,14 +98,14 @@ commands:
               find . -name $file -exec cat {} +
             done | shasum | awk '{print $1}' > /tmp/clojure_cache_seed
       - restore_cache:
-          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+          key: clojure-<< parameters.cache_version >>-<< parameters.jdk_version >>-<< parameters.clojure_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - ~/.m2
             - .cpcache
-            - repo
-          key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+            - unzipped-jdk-source
+          key: clojure-<< parameters.cache_version >>-<< parameters.jdk_version >>-<< parameters.clojure_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
 # The jobs are relatively simple. One runs utility commands against
 # latest stable JDK + Clojure, the other against specified versions
@@ -122,7 +128,9 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: "1.10"
+          cache_version: "util-job-v1"
+          jdk_version: << parameters.jdk_version >>
+          clojure_version: "1.10"
           steps: << parameters.steps >>
 
 
@@ -146,7 +154,9 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: << parameters.clojure_version >>
+          jdk_version: << parameters.jdk_version >>
+          clojure_version: << parameters.clojure_version >>
+          cache_version: "test_code-v2"
           steps:
             - run:
                 name: Running tests

--- a/project.clj
+++ b/project.clj
@@ -47,12 +47,12 @@
         (-> output .close)))))
 
 (defn unzipped-jdk-source []
-  (let [choice jdk-sources]
-    (when-not (-> "unzipped-jdk-source" io/file .exists)
+  (when-not (-> "unzipped-jdk-source" io/file .exists)
+    (let [choice jdk-sources]
       (-> "unzipped-jdk-source" io/file .mkdirs)
       ;; For some reason simply adding a .zip to the classpath doesn't work, so one has to uncompress the contents:
-      (uncompress "./unzipped-jdk-source/" choice))
-    "unzipped-jdk-source"))
+      (uncompress "./unzipped-jdk-source/" choice)))
+  "unzipped-jdk-source")
 
 (def jdk8? (->> "java.version" System/getProperty (re-find #"^1.8.")))
 


### PR DESCRIPTION
* Remove `repo` caching
  * See https://github.com/clojure-emacs/cider-nrepl/commit/178556ebfeaf8719e197b7b6e128efe5f85f1a50#diff-f3e9d251e83fc546f51aa7cfc8ae605d64f20c232423c4b4eaf968f227b09ac6
* Cache the uncompressed JDK sources (see `project.clj`, JDK-8 only)
* CI: Use the JDK as part of the cache key
  * Especially important for the `unzipped-jdk-source` stuff.