### PR TITLE
`info`: don't use a fallback for ns-qualified symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#133](https://github.com/clojure-emacs/orchard/issues/133): `info:` don't fall back to `clojure.core` for fully-qualified symbols. 
+
 ## 0.7.2 (2021-09-30)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.7.3 (2021-10-02)
+
 ### Changes
 
 * [#133](https://github.com/clojure-emacs/orchard/issues/133): `info:` don't fall back to `clojure.core` for fully-qualified symbols. 

--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,19 @@ resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
 test:
-	lein with-profile +$(VERSION),$(TEST_PROFILES) test
+	lein with-profile -user,-dev,+$(VERSION),$(TEST_PROFILES) test
 
 test-watch: test-resources/clojuredocs/export.edn
 	lein with-profile +$(VERSION),$(TEST_PROFILES) test-refresh
 
 eastwood:
-	lein with-profile +$(VERSION),+eastwood,$(TEST_PROFILES) eastwood
+	lein with-profile -user,-dev,+$(VERSION),+eastwood,$(TEST_PROFILES) eastwood
 
 cljfmt:
-	lein with-profile +$(VERSION),+cljfmt cljfmt check
+	lein with-profile -user,-dev,+$(VERSION),+cljfmt cljfmt check
 
 kondo:
-	lein with-profile -dev,+clj-kondo run -m clj-kondo.main --lint src test src-jdk8 src-newer-jdks
+	lein with-profile -user,-dev,+clj-kondo run -m clj-kondo.main --lint src test src-jdk8 src-newer-jdks
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot
@@ -28,15 +28,18 @@ kondo:
 
 BUMP ?= patch
 
-release:
-	lein with-profile +$(VERSION) release $(BUMP)
+release: clean
+	lein with-profile -user,-dev,+$(VERSION) release $(BUMP)
 
 # Deploying requires the caller to set environment variables as
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
-deploy:
-	lein with-profile +$(VERSION) deploy clojars
+deploy: clean
+	lein with-profile -user,-dev,+$(VERSION) deploy clojars
+
+install: clean
+	lein with-profile -user,-dev,+$(VERSION) install
 
 clean:
-	lein clean
+	lein with-profile -user,-dev clean

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.7.2"]
+[cider/orchard "0.7.3"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
 
 ;;;; Project definition
 
-(defproject cider/orchard "0.7.2"
+(defproject cider/orchard "0.7.3"
   :description "A fertile ground for Clojure tooling"
   :url "https://github.com/clojure-emacs/orchard"
   :license {:name "Eclipse Public License"

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -63,7 +63,7 @@
 
 (defn clj-meta
   {:added "0.5"}
-  [{:keys [dialect ns sym computed-ns unqualified-sym] :as opts}]
+  [{:keys [dialect ns sym computed-ns unqualified-sym]}]
   {:pre [(= dialect :clj)]}
   (let [ns (or ns computed-ns)
         ns (or (when (some-> ns find-ns)

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -355,7 +355,10 @@
     (let [params '[{:sym orchard.test-ns/my-add},
 
                    {:ns orchard.test-ns
-                    :sym my-add}]
+                    :sym my-add},
+
+                   {:ns orchard.test-ns
+                    :sym orchard.test-ns/my-add}]
           expected '{:name my-add
                      :ns orchard.test-macros
                      :arglists ([a b])
@@ -363,13 +366,13 @@
                      :macro true}]
 
       (testing "- :cljs"
-        (is (= (take 2 (repeat expected))
+        (is (= (take 3 (repeat expected))
                (->> params
                     (map #(info/info* (merge *cljs-params* %)))
                     (map #(select-keys % [:ns :name :arglists :macro :file]))))))
 
       (testing "- :clj"
-        (is (= [{}, expected]
+        (is (= [{}, expected, {}]
                (->> params
                     (map #(info/info* %))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))))
@@ -479,6 +482,7 @@
     (are [input expected] (= expected
                              (select-keys (info/info* input)
                                           [:added :ns :name :file]))
+      {:ns current-ns :sym 'does-not-exist}             {}
       {:ns current-ns :sym 'some-var}                   '{:ns   orchard.info-test,
                                                           :name some-var,
                                                           :file "orchard/info_test.clj"}
@@ -497,6 +501,7 @@
                                                           :file  "clojure/string.clj"}
       {:ns current-ns :sym 'non.existing.ns/upper-case} {}
 
+      {:ns 'gibberish :sym 'does-not-exist}             {}
       {:ns 'gibberish :sym 'some-var}                   {}
       {:ns 'gibberish :sym 'replace-first}              {}
       {:ns 'gibberish :sym 'merge}                      '{:added "1.0"

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -470,6 +470,10 @@
 
 (def some-var nil)
 
+(def workaround
+  "Prevents a clj-kondo warning."
+  replace-first)
+
 (deftest info-undefined-namespace-test
   (let [current-ns (-> ::_ namespace symbol)]
     (are [input expected] (= expected

--- a/test/orchard/java/resource_test.clj
+++ b/test/orchard/java/resource_test.clj
@@ -8,6 +8,8 @@
 
 (deftest project-resources-test
   (testing "get the correct resources for the orchard project"
-    (let [resources (resource/project-resources)]
+    (let [resources (->> (resource/project-resources)
+                         (filter (fn [{:keys [relpath]}]
+                                   (= relpath "clojuredocs/test_export.edn"))))]
       (is (= "clojuredocs/test_export.edn" (-> resources first :relpath)))
       (is (= java.net.URL (-> resources first :url class))))))


### PR DESCRIPTION
* `info`: don't use a fallback for ns-qualified symbols
  * Closes https://github.com/clojure-emacs/orchard/issues/133
  * ℹ️ cider-nrepl will still need to get a couple tests adapted (and probably a couple more _added_)
* Add `make install` command
  * Also includes our usual refinements (`-user` etc).
* Unflake a test