### PR TITLE
Fix problematic double var lookup in xref/fn-refs+fn-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#135](https://github.com/clojure-emacs/orchard/issues/135): Fix problematic double var lookup in `orchard.xref/fn-refs`
+
 ## 0.7.3 (2021-10-02)
 
 ### Changes

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -48,6 +48,5 @@
   [var]
   (let [var (as-var var)
         all-vars (q/vars {:ns-query {:project? true} :private? true})
-        all-vals (map var-get all-vars)
-        deps-map (zipmap all-vars (map fn-deps all-vals))]
+        deps-map (zipmap all-vars (map fn-deps all-vars))]
     (map first (filter (fn [[_k v]] (contains? v var)) deps-map))))

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -20,6 +20,15 @@
            #{#'clojure.core/map #'clojure.core/filter
              #'clojure.core/even? #'clojure.core/range}))))
 
+;; The mere presence of this var can reproduce a certain issue. See:
+;; https://github.com/clojure-emacs/orchard/issues/135#issuecomment-939731698
+(def xxx 'foo/bar)
+
+;; Like the above, but programmatic, to ensure that we the presence of a .clj file named `foo`
+;; won't cause a false negative:
+(def yyy (symbol (str (gensym))
+                 (str (gensym))))
+
 (deftest fn-refs-test
   (testing "with a fn value"
     (is (= (xref/fn-refs dummy-fn) '()))


### PR DESCRIPTION
`fn-deps` already calls `as-val` which will resolve a var if it is given one, so
`fn-refs` does not need to call `(map var-get)` beforehand. Not doing this
presents issues when a var contains a symbol. This currently would result in the
symbol being treated as a var name, causing exceptions or incorrect results.

Closes #135 

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!
