### PR TITLE
Remove test-refresh, humane-test-output

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
                                          letfn [[:block 1] [:inner 2]]}}}
 
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.09.15"]]}]
+                         {:dependencies [[clj-kondo "2021.10.19"]]}]
 
              :eastwood  {:plugins  [[jonase/eastwood "0.9.9"]]
                          :eastwood {:exclude-namespaces [~(if jdk8?

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -1,4 +1,6 @@
 (ns orchard.misc
+  ;; These will be added in clojure 1.11:
+  (:refer-clojure :exclude [update-keys update-vals])
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]))


### PR DESCRIPTION
* Remove test-refresh, humane-test-output
  * These can always be added in a personal profile, otherwise it's a quite subjective choice that isn't present in the other clojure-emacs projects.
  * It seems more desirable to keep CI builds understandable / reproducible for everyone, for every project.
* Update clj-kondo
