### PR TITLE
Retain resource URL in java-parser results, improve caching

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,4 @@
 {:output {:progress true
           :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj"]}
- :linters {:unused-private-var {:level :warning :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}}}
-
+ :linters {:unused-private-var {:level :warning :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
+           :refer-all {:exclude [clojure.test]}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,4 @@
 {:output {:progress true
           :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj"]}
- :linters {:unused-private-var {:level :warning :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
-           :refer-all {:exclude [clojure.test]}}}
+ :linters {:unused-private-var {:level :warning
+                                :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#123](https://github.com/clojure-emacs/orchard/pull/123): Fix info lookups from namespaces that don't yet exist
 * [#125](https://github.com/clojure-emacs/orchard/issues/125): Don't fail if the classpath references a non-existing .jar
 * [#128](https://github.com/clojure-emacs/orchard/issues/128): Strengthen `apropos`
+* [#124](https://github.com/clojure-emacs/orchard/pull/124): Remove costly `io/resource` lookup
 
 ## 0.7.1 (2021-04-18)
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cljfmt:
 	lein with-profile -user,-dev,+$(VERSION),+cljfmt cljfmt check
 
 kondo:
-	lein with-profile -user,-dev,+clj-kondo run -m clj-kondo.main --lint src test src-jdk8 src-newer-jdks
+	lein with-profile -user,-dev,+clj-kondo run -m clj-kondo.main --lint src test src-jdk8 src-newer-jdks test-newer-jdks
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -14,5 +14,6 @@
 
 (cond->> ["dev" "src" "test"]
   jdk8?       (into ["src-jdk8"])
-  (not jdk8?) (into ["src-newer-jdks"])
+  (not jdk8?) (into ["src-newer-jdks"
+                     "test-newer-jdks"])
   true        (apply set-refresh-dirs))

--- a/project.clj
+++ b/project.clj
@@ -87,6 +87,9 @@
              "-Dclojure.main.report=stderr"]
 
   :source-paths ["src" "src-jdk8" "src-newer-jdks"]
+  :test-paths ~(cond-> ["test"]
+                 (not jdk8?)
+                 (conj "test-newer-jdks"))
 
   :profiles {
              ;; Clojure versions matrix
@@ -96,8 +99,8 @@
                                   [org.clojure/clojure "1.8.0" :classifier "sources"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [org.clojure/clojure "1.9.0" :classifier "sources"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]
-                                   [org.clojure/clojure "1.10.1" :classifier "sources"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
+                                   [org.clojure/clojure "1.10.3" :classifier "sources"]]}
              :master {:repositories [["snapshots"
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]

--- a/src-jdk8/orchard/java/legacy_parser.clj
+++ b/src-jdk8/orchard/java/legacy_parser.clj
@@ -270,13 +270,14 @@
   (try
     (let [path (source-path klass)]
       (when-let [root (parse-java path)]
-        (assoc (->> (map parse-info (.classes root))
-                    (filter #(= klass (:class %)))
-                    (first))
-               ;; relative path on the classpath
-               :file path
-               ;; Legacy key. Please do not remove - we don't do breaking changes!
-               :path (-> path io/resource .getPath)
-               ;; Full URL, e.g. file:.. or jar:...
-               :resource-url (io/resource path))))
+        (let [path-resource (io/resource path)]
+          (assoc (->> (map parse-info (.classes root))
+                      (filter #(= klass (:class %)))
+                      (first))
+                 ;; relative path on the classpath
+                 :file path
+                 ;; Legacy key. Please do not remove - we don't do breaking changes!
+                 :path (.getPath path-resource)
+                 ;; Full URL, e.g. file:.. or jar:...
+                 :resource-url path-resource))))
     (catch Abort _)))

--- a/src-jdk8/orchard/java/legacy_parser.clj
+++ b/src-jdk8/orchard/java/legacy_parser.clj
@@ -275,6 +275,8 @@
                     (first))
                ;; relative path on the classpath
                :file path
+               ;; Legacy key. Please do not remove - we don't do breaking changes!
+               :path (-> path io/resource .getPath)
                ;; Full URL, e.g. file:.. or jar:...
                :resource-url (io/resource path))))
     (catch Abort _)))

--- a/src-jdk8/orchard/java/legacy_parser.clj
+++ b/src-jdk8/orchard/java/legacy_parser.clj
@@ -273,6 +273,8 @@
         (assoc (->> (map parse-info (.classes root))
                     (filter #(= klass (:class %)))
                     (first))
+               ;; relative path on the classpath
                :file path
-               :path (. (io/resource path) getPath))))
+               ;; Full URL, e.g. file:.. or jar:...
+               :resource-url (io/resource path))))
     (catch Abort _)))

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -296,19 +296,20 @@
     (when-let [path (source-path klass)]
       (when-let [^DocletEnvironment root (parse-java path (module-name klass))]
         (try
-          (assoc (->> (.getIncludedElements root)
-                      (filter #(#{ElementKind/CLASS
-                                  ElementKind/INTERFACE
-                                  ElementKind/ENUM}
-                                (.getKind ^Element %)))
-                      (map #(parse-info % root))
-                      (filter #(= klass (:class %)))
-                      (first))
-                 ;; relative path on the classpath
-                 :file path
-                 ;; Legacy key. Please do not remove - we don't do breaking changes!
-                 :path (-> path io/resource .getPath)
-                 ;; Full URL, e.g. file:.. or jar:...
-                 :resource-url (io/resource path))
+          (let [path-resource (io/resource path)]
+            (assoc (->> (.getIncludedElements root)
+                        (filter #(#{ElementKind/CLASS
+                                    ElementKind/INTERFACE
+                                    ElementKind/ENUM}
+                                  (.getKind ^Element %)))
+                        (map #(parse-info % root))
+                        (filter #(= klass (:class %)))
+                        (first))
+                   ;; relative path on the classpath
+                   :file path
+                   ;; Legacy key. Please do not remove - we don't do breaking changes!
+                   :path (.getPath path-resource)
+                   ;; Full URL, e.g. file:.. or jar:...
+                   :resource-url path-resource))
           (finally (.close (.getJavaFileManager root))))))
     (catch Throwable _)))

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -306,6 +306,8 @@
                       (first))
                  ;; relative path on the classpath
                  :file path
+                 ;; Legacy key. Please do not remove - we don't do breaking changes!
+                 :path (-> path io/resource .getPath)
                  ;; Full URL, e.g. file:.. or jar:...
                  :resource-url (io/resource path))
           (finally (.close (.getJavaFileManager root))))))

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -304,7 +304,9 @@
                       (map #(parse-info % root))
                       (filter #(= klass (:class %)))
                       (first))
+                 ;; relative path on the classpath
                  :file path
-                 :path (.getPath (io/resource path)))
+                 ;; Full URL, e.g. file:.. or jar:...
+                 :resource-url (io/resource path))
           (finally (.close (.getJavaFileManager root))))))
     (catch Throwable _)))

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -195,3 +195,7 @@
   classes. If no source is available, return the relative path as is."
   [^String path]
   {:javadoc (java/resolve-javadoc-path path)})
+
+(comment
+  (info-java 'clojure.lang.RT 'baseLoader)
+  (file-info "clojure/core.clj"))

--- a/src/orchard/java/resource.clj
+++ b/src/orchard/java/resource.clj
@@ -15,7 +15,9 @@
     s))
 
 (defn project-resources
-  "Get a list of classpath resources."
+  "Get a list of classpath resources, i.e. files that are not clojure/java source
+  or class files. Only consider classpath entries that are directories, does not
+  consider jars."
   []
   (mapcat
    (fn [^File directory]
@@ -32,7 +34,7 @@
                    {:root directory
                     :file file
                     :relpath relpath
-                    :url (io/resource relpath)})))
+                    :url (io/as-url file)})))
           (remove #(.startsWith ^String (:relpath %) "META-INF/"))
           (remove #(re-matches #".*\.(clj[cs]?|java|class)" (:relpath %)))))
    (filter (memfn ^File isDirectory) (map io/as-file (cp/classpath (cp/boot-aware-classloader))))))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -3,7 +3,8 @@
   (:refer-clojure :exclude [update-keys update-vals])
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [orchard.util.io :as util.io]))
 
 (defn os-windows? []
   (.startsWith (System/getProperty "os.name") "Windows"))
@@ -31,7 +32,7 @@
   "Whether the argument is a directory or an url that points to a directory"
   [f]
   (if (url? f)
-    (and (= (.getProtocol ^java.net.URL f) "file")
+    (and (util.io/direct-url-to-file? f)
          (.isDirectory (io/as-file f)))
     (.isDirectory (io/as-file f))))
 
@@ -40,7 +41,7 @@
   file extensions"
   [f & exts]
   (when-let [file (if (url? f)
-                    (when (= (.getProtocol ^java.net.URL f) "file")
+                    (when (util.io/direct-url-to-file? f)
                       (io/as-file f))
                     (io/as-file f))]
     (and

--- a/src/orchard/util/io.clj
+++ b/src/orchard/util/io.clj
@@ -1,4 +1,10 @@
-(ns orchard.util.io)
+(ns orchard.util.io
+  "Utility functions for dealing with file system objects, and in/out streams."
+  (:require
+   [clojure.java.io :as io])
+  (:import
+   (java.io File)
+   (java.net URL JarURLConnection)))
 
 (defn wrap-silently
   "Middleware that executes `(f)` without printing to `System/out` or `System/err`.
@@ -22,3 +28,55 @@
             (System/setOut old-out))
           (when (= ps System/err) ;; `System/err` may have changed in the meantime (in face of concurrency)
             (System/setErr old-err)))))))
+
+(defn url-protocol
+  "Get the URL protocol as a string, e.g. http, file, jar."
+  [^java.net.URL url]
+  (.getProtocol url))
+
+(defn url-to-file-within-archive?
+  "Does this URL point to a file inside a jar (or zip) archive.
+  i.e. does it use the jar: protocol."
+  [^java.net.URL url]
+  (= "jar" (url-protocol url)))
+
+(defn resource-jarfile
+  "Given a jar:file:...!/... URL, return the location of the jar file on the
+  filesystem. Returns nil on any other URL."
+  ^File [^URL jar-resource]
+  (assert (= "jar" (url-protocol jar-resource)))
+  (let [^JarURLConnection conn (.openConnection jar-resource)
+        inner-url (.getJarFileURL conn)]
+    (when (= "file" (url-protocol inner-url))
+      (io/as-file inner-url))))
+
+(defn resource-artifact
+  "Return the File from which the given resource URL would be loaded.
+
+  For `file:` URLs returns the location of the resource itself, for
+  `jar:..!/...` URLs returns the location of the archive containing the
+  resource. Returns a fully qualified File, even when the URL is relative.
+  Throws when the URL is not a `file:` or `jar:` URL."
+  ^File [^java.net.URL resource]
+  (let [protocol (url-protocol resource)]
+    (case protocol
+      "file"
+      (io/as-file resource)
+      "jar"
+      (resource-jarfile resource)
+      #_else
+      (throw (ex-info (str "URLs with a " protocol
+                           " protocol can't be situated on the filesystem.")
+                      {:resource resource})))))
+
+(defprotocol LastModifiedTime
+  (last-modified-time [this]
+    "Return the last modified time of a File or resource URL."))
+
+(extend-protocol LastModifiedTime
+  java.net.URL
+  (last-modified-time [this]
+    (last-modified-time (resource-artifact this)))
+  java.io.File
+  (last-modified-time [this]
+    (.lastModified this)))

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -55,7 +55,8 @@
             :resource-url (java.net.URL. (str "file:"
                                               (System/getProperty "user.dir")
                                               "/test/orchard/java/DummyClass.java"))}
-           (parser/source-info 'orchard.java.DummyClass))))
+           (dissoc (parser/source-info 'orchard.java.DummyClass)
+                   :path))))
 
   (testing "java file in a jar"
     (let [rt-info (parser/source-info 'clojure.lang.RT)]

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.java.parser-test
-  (:require [orchard.misc :as misc]
-            [orchard.java.parser :as parser]
-            [clojure.test :refer :all]))
+  (:require
+   [orchard.java.parser :as parser]
+   [clojure.test :refer [deftest is testing]]))
 
 (defn compile-class-from-source
   "Compile a java file on the classpath.
@@ -55,10 +55,10 @@
             :resource-url (java.net.URL. (str "file:"
                                               (System/getProperty "user.dir")
                                               "/test/orchard/java/DummyClass.java"))}
-           ((resolve 'orchard.java.parser/source-info) 'orchard.java.DummyClass))))
+           (parser/source-info 'orchard.java.DummyClass))))
 
   (testing "java file in a jar"
-    (let [rt-info ((resolve 'orchard.java.parser/source-info) 'clojure.lang.RT)]
+    (let [rt-info (parser/source-info 'clojure.lang.RT)]
       (is (= {:file "clojure/lang/RT.java"}
              (select-keys rt-info [:file])))
       (is (re-find #"jar:file:/.*/.m2/repository/org/clojure/clojure/.*/clojure-.*-sources.jar!/clojure/lang/RT.java"

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -1,0 +1,65 @@
+(ns orchard.java.parser-test
+  (:require [orchard.misc :as misc]
+            [orchard.java.parser :as parser]
+            [clojure.test :refer :all]))
+
+(defn compile-class-from-source
+  "Compile a java file on the classpath.
+  Returns true if all went well."
+  [classname]
+  (let [compiler (javax.tools.ToolProvider/getSystemJavaCompiler)]
+    (.. compiler
+        (getTask
+         nil ;; out
+         nil ;; fileManager
+         nil ;; diagnosticListener
+         nil ;; compilerOptions
+         nil ;; classnames for annotation processing
+         ;; compilationUnits
+         [(.. compiler
+              (getStandardFileManager nil nil nil)
+              (getJavaFileForInput javax.tools.StandardLocation/CLASS_PATH
+                                   classname
+                                   javax.tools.JavaFileObject$Kind/SOURCE))])
+        call)))
+
+(deftest source-info-test
+  (is (compile-class-from-source "orchard.java.DummyClass"))
+
+  (testing "file on the filesystem"
+    (is (= {:class 'orchard.java.DummyClass,
+            :members
+            '{orchard.java.DummyClass
+              {[]
+               {:name orchard.java.DummyClass,
+                :type void,
+                :argtypes [],
+                :argnames [],
+                :doc nil,
+                :line 12,
+                :column 8}},
+              dummyMethod
+              {[]
+               {:name dummyMethod,
+                :type java.lang.String,
+                :argtypes [],
+                :argnames [],
+                :doc "Method-level docstring. @returns the string \"hello\"",
+                :line 18,
+                :column 3}}},
+            :doc
+            "Class level docstring.\n\n```\n   DummyClass dc = new DummyClass();\n```\n\n@author Arne Brasseur",
+            :line 12,
+            :column 1,
+            :file "orchard/java/DummyClass.java"
+            :resource-url (java.net.URL. (str "file:"
+                                              (System/getProperty "user.dir")
+                                              "/test/orchard/java/DummyClass.java"))}
+           ((resolve 'orchard.java.parser/source-info) 'orchard.java.DummyClass))))
+
+  (testing "java file in a jar"
+    (let [rt-info ((resolve 'orchard.java.parser/source-info) 'clojure.lang.RT)]
+      (is (= {:file "clojure/lang/RT.java"}
+             (select-keys rt-info [:file])))
+      (is (re-find #"jar:file:/.*/.m2/repository/org/clojure/clojure/.*/clojure-.*-sources.jar!/clojure/lang/RT.java"
+                   (str (:resource-url rt-info)))))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -218,7 +218,7 @@
 
 (deftype MyTestType [name]
   IMyTestType
-  (get-name [this] name))
+  (get-name [_this] name))
 
 (defmethod inspect/inspect-value MyTestType [obj]
   (str "#<MyTestType " (get-name obj) ">"))

--- a/test/orchard/java/DummyClass.java
+++ b/test/orchard/java/DummyClass.java
@@ -1,0 +1,21 @@
+package orchard.java;
+
+/**
+ * Class level docstring.
+ *
+ * <pre>
+ *   DummyClass dc = new DummyClass();
+ * </pre>
+ *
+ * @author Arne Brasseur
+ */
+public class DummyClass {
+  /**
+   * Method-level docstring.
+   *
+   * @returns the string "hello"
+   */
+  public String dummyMethod() {
+    return "hello";
+  }
+}

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -81,16 +81,17 @@
 (deftest map-structure-test
   (when jdk-parser?
     (testing "Parsed map structure = reflected map structure"
-      (let [cols #{:file :line :column :doc :argnames :argtypes :resource-url}
+      (let [cols #{:file :line :column :doc :argnames :argtypes :path :resource-url}
             keys= #(= (set (keys (apply dissoc %1 cols)))
                       (set (keys %2)))
             c1 (class-info* 'clojure.lang.Compiler)
             c2 (with-redefs [source-info (constantly nil)]
                  (class-info* 'clojure.lang.Compiler))]
         ;; Class info
-        (is (keys= c1 c2) (str "Difference: "
-                               (pr-str [(remove (set (keys c1)) (keys c2))
-                                        (remove (set (keys c2)) (keys c1))])))
+        (is (keys= c1 c2)
+            (str "Difference: "
+                 (pr-str [(remove (set (keys c1)) (keys c2))
+                          (remove (set (keys c2)) (keys c1))])))
         ;; Members
         (is (keys (:members c1)))
         (is (= (keys (:members c1))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -81,14 +81,16 @@
 (deftest map-structure-test
   (when jdk-parser?
     (testing "Parsed map structure = reflected map structure"
-      (let [cols #{:file :line :column :doc :argnames :argtypes :path}
+      (let [cols #{:file :line :column :doc :argnames :argtypes :resource-url}
             keys= #(= (set (keys (apply dissoc %1 cols)))
                       (set (keys %2)))
             c1 (class-info* 'clojure.lang.Compiler)
             c2 (with-redefs [source-info (constantly nil)]
                  (class-info* 'clojure.lang.Compiler))]
         ;; Class info
-        (is (keys= c1 c2))
+        (is (keys= c1 c2) (str "Difference: "
+                               (pr-str [(remove (set (keys c1)) (keys c2))
+                                        (remove (set (keys c2)) (keys c1))])))
         ;; Members
         (is (keys (:members c1)))
         (is (= (keys (:members c1))


### PR DESCRIPTION
This PR replaces #124, see there for previous discussion. 

The java parser/legacy-parser returns a resource's `:file`, actually a relative
path as a string, and `:path`, the relative path converted to absolute. It does
this conversion through an `io/resource` lookup to find the file system location
of the artifact. There are two issues with this:

1. The return value of `io/resource` is discarded, even though it is needed
later on in `orchard.java`, causing unnecessary resource lookups.

2. The path is obtained through `(.getPath (io/resource path))`, which yields
nonsensical results when used on resources that are inside a JAR.

This change keeps the `:file` returned from java-parser (relative path string),
but removes the `:path` value in favor of a `:resource-url`, i.e. the return
value of `(io/resource path)`. It then provides utility functions to work with
this resource URL directly, namely mapping it to a filesystem artifact, or
retrieving its modification time.

java.parser/parser already does a `io/resource` lookup for the resource it is
parsing, meaning it has a full URL (jar: or file:). By including this URL in the
map it returns callers can do further checks or operations on the resource
without having to re-scan the classpath.

This in turn allows us to simplify and optimize `orchard.java/class-info`. The
old version would call `io/resource` on each invocation, even when the result
was already cached, in order to find the artifact's modification time.

This can noticably speed up cider-nrepl's `"stacktrace"` op, which calls
`orchard.java/class-info` on each stack frame, in extreme cases taking multiple
seconds to analyze all stack frames and return a result. This leads to rather
jarring UX, with the stacktrace buffering popping up in Emacs seconds after the
evaluation and exception happened. This is exarcerbated when using the nREPL
sideloader, which adds overhead to each resource lookup.

This also makes the return value of java-parser more correct. As mentioned the
previous version would always call `(.getPath (io/resource path))`, but this
only makes sense for `file:` resources, not for `jar:` resources. For `file:`
URLs `.getPath` returns the path of the file. For `jar:` URLs it returns the
nested url+the jar entry, so a `file:` URL but with a dangling `!/jar/entry`.

Illustration of why calling `getPath` on `jar:` URLs is not useful:

```clojure
(io/resource "lambdaisland/witchcraft.clj")
;;=> #java.net.URL "file:/srv/mc/witchcraft/src/lambdaisland/witchcraft.clj"

(.getPath (io/resource "lambdaisland/witchcraft.clj"))
;;=> "/srv/mc/witchcraft/src/lambdaisland/witchcraft.clj"

(io/resource "clojure/lang/RT.class")
;;=> #java.net.URL "jar:file:/root/.m2/repository/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class"

(.getPath (io/resource "clojure/lang/RT.class"))
;;=> "file:/root/.m2/repository/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/clojure/lang/RT.class"
```

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!
