### PR TITLE
Fix a NPE in `cljs.analysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Fix a NullPointerException in `orchard.cljs.analysis`. 
+
 ## 0.9.0 (2022-01-10)
 
 ### Changes

--- a/src/orchard/cljs/analysis.cljc
+++ b/src/orchard/cljs/analysis.cljc
@@ -11,7 +11,7 @@
         (remove (fn [[ns-sym ns]]
                   ;; Remove pseudo-namespaces that the cljs analyzer
                   ;; started returning at some point:
-                  (or (-> ns-sym name (.startsWith "goog."))
+                  (or (some-> ns-sym name (.startsWith "goog."))
                       ;; recent CLJS versions include data about macro namespaces in the
                       ;; compiler env, but we should not include them in completions or pass
                       ;; them to format-ns unless they're actually required (which is handled

--- a/test/orchard/cljs/analysis_test.clj
+++ b/test/orchard/cljs/analysis_test.clj
@@ -1,0 +1,9 @@
+(ns orchard.cljs.analysis-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [orchard.cljs.analysis :as sut]))
+
+;; Covers a NPE caught in the wild: https://gist.github.com/dgtized/aa046d06c921d4cb9f7dc51ea2729459
+(deftest all-ns-test
+  (testing "Handles nil-valued maps gracefully"
+    (is (sut/all-ns {:cljs.analyzer/namespaces {nil nil}}))))


### PR DESCRIPTION
We got this error report https://gist.github.com/dgtized/aa046d06c921d4cb9f7dc51ea2729459 which can be reproduced by running cider-connect-cljs against https://github.com/dgtized/shimmers/tree/22f47d2d148ca7e52aa5a6e4f6e48b166c0abcd5.