### PR TITLE
Update namespace.clj

### DIFF
--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -112,9 +112,9 @@
         (apply concat)
         (pmap (fn [x]
                 (when (misc/clj-file? x)
-                  x)))
+                  (io/resource x))))
         (filter identity)
-        (pmap (comp read-namespace io/resource))
+        (pmap read-namespace)
         (filter identity)
         (sort)))
   ([]


### PR DESCRIPTION
io/resource may return nil in some situations (in my case it was emacs recovery file)
