### PR TITLE
Tell cljdoc to analyze API only under Clojure

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,1 @@
+{:cljdoc/languages ["clj"]}


### PR DESCRIPTION
Doesn't address #150 but should allow docs to build under cljdoc.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!
