### PR TITLE
Add Datafy and Nav support to the inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#161](https://github.com/clojure-emacs/orchard/pull/161): Add Datafy section to inspector and align section headers
+  * Add a `Datafy` section to the inspector. For more details, take a
+    look at the
+    [Datafiable](https://github.com/clojure-emacs/orchard/blob/master/doc/inspector.org#datafiable)
+    and
+    [Navigable](https://github.com/clojure-emacs/orchard/blob/master/doc/inspector.org#navigable)
+    sections of the Orchard inspector
+    [docs](https://github.com/clojure-emacs/orchard/blob/master/doc/inspector.org).
+  * Align all section headers to start with `---`.
+
 ## 0.9.2 (2022-02-22)
 
 * Guard against OOMs in `orchard.java/member-info`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Right now `orchard` provides functionality like:
 
 * enhanced apropos
 * classpath utils (alternative for `java.classpath`)
-* value inspector
+* value [inspector](https://github.com/clojure-emacs/orchard/blob/master/doc/inspector.org)
 * Java class handling utilities
 * Utilities for dealing with metadata
 * Namespace utilities

--- a/doc/inspector.org
+++ b/doc/inspector.org
@@ -1,0 +1,648 @@
+* The Orchard Inspector
+
+The Orchard Inspector provides functionality to inspect Clojure and
+Java objects and is a useful tool for debugging large data
+structures. It is inspired by the [[https://slime.common-lisp.dev/doc/html/Inspector.html][Slime Inspector]] for Common LISP and
+is used in the [[https://github.com/clojure-emacs/cider-nrepl][Cider NREPL middleware]] to power the [[https://docs.cider.mx/cider/debugging/inspector.html][Cider Inspector]].
+
+** Usage
+
+The Orchard inspector is a Clojure map that implements a stack and
+holds information about an inspected object. The =orchard.inspect=
+namespace provides functions to create the inspector data structure
+and to manipulate it, such as drilling down into an object, moving up
+and down the stack, configuring the inspector and paginating large
+collections.
+
+#+begin_src clojure :exports code :results silent
+  (require '[orchard.inspect :as inspect])
+#+end_src
+
+*** The inspector data structure
+
+To create the inspector data structure we can use the =inspect/fresh=
+function. It returns an empty inspector initialized with the value
+=nil= that looks like this:
+
+#+begin_src clojure :exports both :results pp :wrap example
+  (inspect/fresh)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+  {:path [],
+   :index [],
+   :pages-stack [],
+   :value nil,
+   :page-size 32,
+   :counter 0,
+   :rendered ("nil" (:newline)),
+   :stack [],
+   :indentation 0,
+   :current-page 0}
+#+end_example
+
+The map contains the following keys:
+
+- =:path= is a vector that contains a symbolic path to the currently
+  inspected object.
+
+- =:index= is a vector that holds the inspect-able objects that were
+  rendered at the current stack level. These are the objects into
+  which we can drill down to.
+
+- =:pages-stack= is a vector of page numbers, which is used to
+  paginate collections.
+
+- =:value= is the currently inspected object. The empty inspector has
+  this value always set to =nil=.
+
+- =:page-size= controls how many elements should be rendered per page.
+
+- =:counter= is a number that gets incremented when a new object is
+  added to the =index=.
+
+- =:rendered= is a list of instructions on how to render the currently
+  inspected object on the client (e.g in the Cider inspector). Here
+  the list =("nil" (:newline))= instructs the client to render the
+  string =nil= followed by a newline.
+
+- =:stack= is the stack of inspected objects. When drilling down into
+  an object the new object will be pushed onto that stack.
+
+- =:indentation= is the number of spaces used for padding on the left
+  side and is used by some render functions.
+
+- =:current-page= is the current page number used when paginating
+  collections.
+
+*** Inspecting an object
+
+Let's inspect a more interesting object. To start the inspection we
+can use the =inspect/start= function with the inspector and the object
+we want to inspect as its arguments. This will modify the inspector
+data structure in the following way:
+
+#+begin_src clojure :exports both :results pp :wrap example
+  (-> (inspect/fresh)
+      (inspect/start {:a {:b 1}}))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+{:path [],
+ :index [clojure.lang.PersistentArrayMap :a {:b 1}],
+ :pages-stack [],
+ :value {:a {:b 1}},
+ :page-size 32,
+ :counter 3,
+ :rendered
+ ("Class" ": " (:value "clojure.lang.PersistentArrayMap" 0)
+  (:newline)
+  (:newline)
+  "--- Contents:"
+  (:newline)
+  "  " (:value ":a" 1) " = " (:value "{ :b 1 }" 2)
+  (:newline)),
+ :stack [],
+ :indentation 0,
+ :current-page 0}
+#+end_example
+
+The inspected object ={:a {:b 1}}= has been added to the =:value=
+key. The objects, into which we can drill down to, have been added to
+the =:index=, and the =:counter= has been increased by the sum of
+those objects.
+
+Since we are inspecting a Clojure map, the inspector dispatched to a
+render function that knows how to render a Clojure map. The inspector
+has render functions for different kinds of objects, and what is added
+to the =:index= depends on those render functions.
+
+The render function for Clojure maps has been implemented in a way
+that shows the class of the map and the its keys and values. When
+displayed on a client this will look like this:
+
+#+begin_example
+Class: clojure.lang.PersistentArrayMap
+
+--- Contents:
+  :a = { :b 1 }
+#+end_example
+
+The class of the map, their keys and their values are inspect-able
+objects by themselves. The instructions under the =:rendered= key now
+contain lists starting with a =:value= keyword, such as =(:value
+"clojure.lang.PersistentArrayMap" 0)=. These lists represent objects,
+into which can be drilled down to. The first element of those lists
+tells the client that the element should be rendered as an
+inspect-able object. The 2nd element is it's textual representation
+and the 3rd element is the position of the object in the =:index=.
+
+*** Drilling into an object
+
+To drill down into an object we can use the =inspect/down=
+function. After inspecting the object ={:a {:b 1}}= the =:index= is
+set to =[clojure.lang.PersistentArrayMap :a {:b 1}]=. Passing =2= (the
+position in the index) as the argument to the =inspect/down= function
+means the next object that is going to be inspected is ={:b 1}=.
+
+#+begin_src clojure :exports both :results pp :wrap example
+  (-> (inspect/fresh)
+      (inspect/start {:a {:b 1}})
+      (inspect/down 2))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+{:path [:a],
+ :index [clojure.lang.PersistentArrayMap :b 1],
+ :pages-stack [0],
+ :value {:b 1},
+ :page-size 32,
+ :counter 3,
+ :rendered
+ ("Class" ": " (:value "clojure.lang.PersistentArrayMap" 0)
+  (:newline)
+  (:newline)
+  "--- Contents:"
+  (:newline)
+  "  " (:value ":b" 1) " = " (:value "1" 2)
+  (:newline)
+  (:newline)
+  "--- Path:"
+  (:newline)
+  "  " ":a"),
+ :stack [{:a {:b 1}}],
+ :indentation 0,
+ :current-page 0}
+#+end_example
+
+We can see that the inspected object ={:b 1}= has been added to the
+=:value= key and got rendered under the =:rendered= key. The previous
+object has been pushed onto the =:stack=, and =:path= has been updated
+with the instructions that describe how to get from the original
+object to the object we drilled down to. =:counter= is again set to
+=3= because the inspector dispatched to the render function for maps,
+which renders the class of the map and it's keys and values as
+inspected-able objects.
+
+** Spec
+
+The following section describes how the Orchard Inspector renders
+different kinds of objects.
+
+*** Class
+
+Classes are rendered with their name, the implemented interfaces, the
+available constructors, their fields and methods. In Clojure versions
+>= 1.10 an optional =Datafy= section is added.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print Boolean)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: java.lang.Class
+
+--- Interfaces:
+  java.io.Serializable
+  java.lang.Comparable
+
+--- Constructors:
+  public java.lang.Boolean(boolean)
+  public java.lang.Boolean(java.lang.String)
+
+--- Fields:
+  public static final java.lang.Boolean java.lang.Boolean.FALSE
+  public static final java.lang.Boolean java.lang.Boolean.TRUE
+  public static final java.lang.Class java.lang.Boolean.TYPE
+
+--- Methods:
+  public boolean java.lang.Boolean.booleanValue()
+  public static int java.lang.Boolean.compare(boolean,boolean)
+  public int java.lang.Boolean.compareTo(java.lang.Boolean)
+  public int java.lang.Boolean.compareTo(java.lang.Object)
+  public boolean java.lang.Boolean.equals(java.lang.Object)
+  public static boolean java.lang.Boolean.getBoolean(java.lang.String)
+  public final native java.lang.Class java.lang.Object.getClass()
+  public int java.lang.Boolean.hashCode()
+  public static int java.lang.Boolean.hashCode(boolean)
+  public static boolean java.lang.Boolean.logicalAnd(boolean,boolean)
+  public static boolean java.lang.Boolean.logicalOr(boolean,boolean)
+  public static boolean java.lang.Boolean.logicalXor(boolean,boolean)
+  public final native void java.lang.Object.notify()
+  public final native void java.lang.Object.notifyAll()
+  public static boolean java.lang.Boolean.parseBoolean(java.lang.String)
+  public java.lang.String java.lang.Boolean.toString()
+  public static java.lang.String java.lang.Boolean.toString(boolean)
+  public static java.lang.Boolean java.lang.Boolean.valueOf(boolean)
+  public static java.lang.Boolean java.lang.Boolean.valueOf(java.lang.String)
+  public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
+  public final void java.lang.Object.wait() throws java.lang.InterruptedException
+  public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
+
+--- Datafy:
+  :bases = #{ java.lang.Object java.lang.Comparable java.io.Serializable }
+  :flags = #{ :public :final }
+  :members = { FALSE [ { :name FALSE, :type java.lang.Boolean, :declaring-class java.lang.Boolean, :flags #{ :public :static :final } } ], TRUE [ { :name TRUE, :type java.lang.Boolean, :declaring-class java.lang.Boolean, :flags #{ :public :static :final } } ], TYPE [ { :name TYPE, :type java.lang.Class, :declaring-class java.lang.Boolean, :flags #{ :public :static :final } } ], booleanValue [ { :name booleanValue, :return-type boolean, :declaring-class java.lang.Boolean, :parameter-types [], :exception-types [], ... } ], compare [ { :name compare, :return-type int, :declaring-class java.lang.Boolean, :parameter-types [ boolean boolean ], :exception-types [], ... } ], ... }
+  :name = java.lang.Boolean
+#+end_example
+
+*** Datafiable
+
+Objects implementing the [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L182][Datafiable]] protocol are rendered with an
+optional =Datafy= section. The section shows the result of calling the
+=datafy= function on the object, navigating 1 level into the children
+using =nav= and calling =datafy= again on them.
+
+Since the [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L182][Datafiable]] protocol is implemented for every object, this
+section will only be rendered if the datafy-ed version of the object
+is different than the original object.
+
+Minimum requirement for this feature is a Clojure version >= 1.10.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (-> {:name "John Doe"}
+      (with-meta {'clojure.core.protocols/datafy
+                  (fn [x] (assoc x :class (.getSimpleName (class x))))})
+      (inspect/inspect-print))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentArrayMap
+
+--- Meta Information:
+  clojure.core.protocols/datafy = user$eval11033$fn__11034@213a1033
+
+--- Contents:
+  :name = "John Doe"
+
+--- Datafy:
+  :name = "John Doe"
+  :class = "PersistentArrayMap"
+#+end_example
+
+*** Keyword
+
+Clojure keywords are rendered with their class name, their printed
+value, and the instance and static fields.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print :abc/def)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Keyword
+Value: ":abc/def"
+
+--- Fields:
+  "_str" = ":abc/def"
+  "hasheq" = -1043781166
+  "sym" = abc/def
+
+--- Static fields:
+  "rq" = java.lang.ref.ReferenceQueue@7849a4c3
+  "table" = { returns java.lang.ref.WeakReference@1b9ad0c1, dialect java.lang.ref.WeakReference@542db2ec, existing java.lang.ref.WeakReference@17d434cf, clojure.core.logic/unify-with-pmap* java.lang.ref.WeakReference@4d5b7e61, patch java.lang.ref.WeakReference@7239d9d7, ... }
+#+end_example
+
+*** Number
+
+Numbers keywords are rendered with their class name, their printed
+value, and the instance and static fields.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print 1)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: java.lang.Long
+Value: "1"
+
+--- Fields:
+  "value" = 1
+
+--- Static fields:
+  "BYTES" = 8
+  "MAX_VALUE" = 9223372036854775807
+  "MIN_VALUE" = -9223372036854775808
+  "SIZE" = 64
+  "TYPE" = long
+  "serialVersionUID" = 4290774380558885855
+#+end_example
+
+*** List
+
+Lists are rendered with their class name, the number of list items
+and the paginated items in tabular form.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print (list :a :b))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentList
+
+--- Contents:
+  0. :a
+  1. :b
+#+end_example
+
+*** Map
+
+Maps are rendered with their class name, the number of map entries
+and the map entries in tabular form.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print {:a 1 :b 2})
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentArrayMap
+
+--- Contents:
+  :a = 1
+  :b = 2
+#+end_example
+
+*** Metadata
+
+Objects that have metadata attached to them are rendered with a =Meta
+Information= section that shows the metadata in tabular form.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print (with-meta [1 2] {:a 1}))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentVector
+
+--- Meta Information:
+  :a = 1
+
+--- Contents:
+  0. 1
+  1. 2
+#+end_example
+
+*** Namespace
+
+Clojure namespaces are rendered with their class name, their
+printed value, the total number of mappings, and sections for the
+=Refer from=, =Interns= and =Imports= mappings.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print (find-ns 'clojure.string))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Namespace
+Count: 786
+
+--- Refer from:
+  clojure.core = [ #'clojure.core/primitives-classnames #'clojure.core/+' #'clojure.core/decimal? #'clojure.core/restart-agent #'clojure.core/sort-by ... ]
+
+--- Imports:
+  { Enum java.lang.Enum, InternalError java.lang.InternalError, NullPointerException java.lang.NullPointerException, InheritableThreadLocal java.lang.InheritableThreadLocal, Class java.lang.Class, ... }
+
+--- Interns:
+  { ends-with? #'clojure.string/ends-with?, replace-first-char #'clojure.string/replace-first-char, capitalize #'clojure.string/capitalize, reverse #'clojure.string/reverse, join #'clojure.string/join, ... }
+
+--- Datafy:
+  :name = clojure.string
+  :publics = { blank? #'clojure.string/blank?, capitalize #'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }
+  :imports = { AbstractMethodError java.lang.AbstractMethodError, Appendable java.lang.Appendable, ArithmeticException java.lang.ArithmeticException, ArrayIndexOutOfBoundsException java.lang.ArrayIndexOutOfBoundsException, ArrayStoreException java.lang.ArrayStoreException, ... }
+  :interns = { blank? #'clojure.string/blank?, capitalize #'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }
+#+end_example
+
+*** Navigable
+
+Objects implementing the [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L194][Navigable]] protocol are rendered with an
+optional =Datafy= section. The ='clojure.core.protocols/nav= function
+of the object will be used for navigation, instead of the default
+implementation declared on object.
+
+Minimum requirement for this feature is a Clojure version >= 1.10.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (-> {:name "John Doe"}
+      (with-meta {'clojure.core.protocols/nav
+                  (fn [coll k v] [k (get coll k v)])})
+      (inspect/inspect-print))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentArrayMap
+
+--- Meta Information:
+  clojure.core.protocols/nav = user$eval11043$fn__11044@4c605d88
+
+--- Contents:
+  :name = "John Doe"
+
+--- Datafy:
+  :name = [ :name "John Doe" ]
+#+end_example
+
+Collections that contain elements that implement the [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L182][Datafiable]] and
+[[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L194][Navigable]] protocols will be rendered with an additional =Datafy=
+section that shows the datafy-ed version of the elements.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (->> (iterate inc 0)
+       (map #(hash-map :x %))
+       (map #(with-meta %
+               {'clojure.core.protocols/datafy (fn [x] (assoc x :class (.getSimpleName (class x))))
+                'clojure.core.protocols/nav (fn [coll k v] [k (get coll k v)])}))
+       (take 5)
+       (inspect/inspect-print))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.LazySeq
+
+--- Contents:
+  0. { :x 0 }
+  1. { :x 1 }
+  2. { :x 2 }
+  3. { :x 3 }
+  4. { :x 4 }
+
+--- Datafy:
+  0. { :class "PersistentHashMap", :x 0 }
+  1. { :class "PersistentHashMap", :x 1 }
+  2. { :class "PersistentHashMap", :x 2 }
+  3. { :class "PersistentHashMap", :x 3 }
+  4. { :class "PersistentHashMap", :x 4 }
+#+end_example
+
+*** Pagination
+
+Collections that have more than 32 elements are paginated. A paginated
+collection can be navigated with the =inspect/next-page= and
+=inspect/prev-page= functions. The size of each page can be adjusted
+with the =inspect/set-page-size= function.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print (iterate inc 0))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Iterate
+
+--- Contents:
+  0. 0
+  1. 1
+  2. 2
+  3. 3
+  4. 4
+  5. 5
+  6. 6
+  7. 7
+  8. 8
+  9. 9
+  10. 10
+  11. 11
+  12. 12
+  13. 13
+  14. 14
+  15. 15
+  16. 16
+  17. 17
+  18. 18
+  19. 19
+  20. 20
+  21. 21
+  22. 22
+  23. 23
+  24. 24
+  25. 25
+  26. 26
+  27. 27
+  28. 28
+  29. 29
+  30. 30
+  31. 31
+  ...
+
+--- Page Info:
+  Page size: 32, showing page: 1 of ?
+#+end_example
+
+*** Ref
+
+Clojure references are rendered with their class name, their
+containing object in the =Contains= section, and an optional =Datafy=
+section.
+
+The object rendered under the =Contains= section is indented by 2
+spaces to better distinguish it from enclosing reference object.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print (atom {:a 1}))
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Atom
+
+--- Contains:
+  Class: clojure.lang.PersistentArrayMap
+
+  --- Contents:
+    :a = 1
+
+--- Datafy:
+  0. { :a 1 }
+#+end_example
+
+*** String
+
+Strings are rendered with their class name, their value, and the
+printed version of the string in the =Printed Value= section.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print "Hello world")
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: java.lang.String
+Value: "Hello world"
+
+--- Print:
+  Hello world
+#+end_example
+
+*** Symbol
+
+Clojure symbols are rendered with their class name, their printed
+value, and their fields.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print 'abc/def)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Symbol
+Value: "abc/def"
+
+--- Fields:
+  "_hasheq" = 0
+  "_meta" =
+  "_str" = "abc/def"
+  "name" = "def"
+  "ns" = "abc"
+#+end_example
+
+*** Var
+
+Clojure vars are rendered with their class name, their value (if
+bound), metadata information and an optional =Datafy= section.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print #'*assert*)
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.Var
+Value: true
+
+--- Meta Information:
+  :ns = clojure.core
+  :name = *assert*
+
+--- Datafy:
+  0. true
+#+end_example
+*** Vector
+
+Vectors are rendered with their class name, the number of items and
+the paginated items in tabular form.
+
+#+begin_src clojure :exports both :results output :wrap example
+  (inspect/inspect-print [1 2 3])
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Class: clojure.lang.PersistentVector
+
+--- Contents:
+  0. 1
+  1. 2
+  2. 3
+#+end_example

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1,29 +1,131 @@
 (ns orchard.inspect-test
   (:require
-   [clojure.test :refer [deftest is are testing]]
-   [orchard.inspect :as inspect]))
+   [clojure.data :as data]
+   [clojure.walk :as walk]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [clojure.test :as t :refer [deftest is are testing]]
+   [orchard.inspect :as inspect]
+   [orchard.misc :refer [datafy? java-api-version]])
+  (:import java.io.File))
 
-(def nil-result ["(\"nil\" (:newline))"])
+(defn- demunge-str [s]
+  (str/replace s #"(?i)\$([a-z-]+)__([0-9]+)(@[a-f0-9]+)?" "\\$$1"))
 
-(def var-result ["(\"Class\" \": \" (:value \"clojure.lang.Var\" 0) (:newline) \"Meta Information: \" (:newline) \"  \" (:value \":ns\" 1) \" = \" (:value \"clojure.core\" 2) (:newline) \"  \" (:value \":name\" 3) \" = \" (:value \"*assert*\" 4) (:newline) \"Value: \" (:value \"true\" 5))"])
+(defn- demunge
+  ([rendered]
+   (demunge rendered demunge-str))
+  ([rendered demunge-fn]
+   (walk/prewalk (fn [form]
+                   (if (string? form)
+                     (demunge-fn form)
+                     form))
+                 rendered)))
+
+(defn- render-plain [x]
+  (cond (and (seq? x) (keyword? (first x)))
+        (let [[type value & args] x]
+          (case type
+            :newline "\n"
+            :value (format "%s <%s>" value (str/join "," args))))
+        (seq? x)
+        (str/join "" (map render-plain x))
+        :else (str x)))
+
+(defn- diff-text [expected actual]
+  (when (zero? (:exit (shell/sh "git" "--version")))
+    (let [actual-file (File/createTempFile "actual" ".txt")
+          expected-file (File/createTempFile "expected" ".txt")]
+      (spit actual-file (render-plain actual))
+      (spit expected-file (render-plain expected))
+      (try (let [{:keys [exit out err] :as result}
+                 (shell/sh "git" "diff"
+                           (if (= "dumb" (System/getenv "TERM")) "--no-color" "--color")
+                           "--minimal"
+                           "--no-index"
+                           (str actual-file) (str expected-file))]
+             (case exit
+               (0 1) out
+               (ex-info "Failed to call diff" result)))
+           (finally
+             (io/delete-file actual-file)
+             (io/delete-file expected-file))))))
+
+(defn- test-message [msg expected actual]
+  (let [expected-text (render-plain expected)
+        actual-text (render-plain actual)]
+    (with-out-str
+      (println (format "Inspect test failed" (when msg (str ": " msg))))
+      (let [diff (diff-text expected actual)]
+        (when-not (str/blank? diff)
+          (println)
+          (println "=== Text Diff ===\n")
+          (println diff)))
+      (let [[only-in-expected only-in-actual both] (data/diff expected actual)]
+        (when (seq only-in-expected)
+          (println)
+          (println "=== Expected data diff ===\n")
+          (pprint/pprint only-in-expected))
+        (when (seq only-in-actual)
+          (println)
+          (println "=== Actual data diff ===\n")
+          (pprint/pprint only-in-actual)))
+      (when-not (= expected-text actual-text)
+        (when expected
+          (println)
+          (println "=== Expected text ===\n")
+          (println expected-text))
+        (when actual
+          (println)
+          (println "=== Actual text ===\n")
+          (println actual-text)
+          (println))))))
+
+(defmethod t/assert-expr 'match? [msg form]
+  `(let [expected# ~(nth form 1)
+         actual# ~(nth form 2)
+         result# (= expected# actual#)]
+     (t/do-report
+      {:type (if result# :pass :fail)
+       :message (test-message ~msg expected# actual#)
+       :expected expected#
+       :actual actual#})
+     result#))
+
+(def nil-result
+  '("nil" (:newline)))
 
 (def code "(sorted-map :a {:b 1} :c \"a\" :d 'e :f [2 3])")
 
 (def eval-result (eval (read-string code)))
 
-(def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":a\" 1) \" = \" (:value \"{ :b 1 }\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"\\\"a\\\"\" 4) (:newline) \"  \" (:value \":d\" 5) \" = \" (:value \"e\" 6) (:newline) \"  \" (:value \":f\" 7) \" = \" (:value \"[ 2 3 ]\" 8) (:newline))"])
+(def inspect-result
+  '("Class"
+    ": "
+    (:value "clojure.lang.PersistentTreeMap" 0)
+    (:newline)
+    (:newline)
+    "--- Contents:"
+    (:newline)
+    "  " (:value ":a" 1) " = " (:value "{ :b 1 }" 2)
+    (:newline)
+    "  " (:value ":c" 3) " = " (:value "\"a\"" 4)
+    (:newline)
+    "  " (:value ":d" 5) " = " (:value "e" 6)
+    (:newline)
+    "  " (:value ":f" 7) " = " (:value "[ 2 3 ]" 8)
+    (:newline)))
 
-(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"1\" 2) (:newline) (:newline) \"  Path: :a\")"])
+(-> (inspect/fresh)
+    (inspect/start {:a {:b 1}}))
 
-(def inspect-result-with-nil ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"1\" 1) (:newline) \"  \" \"1\" \". \" (:value \"2\" 2) (:newline) \"  \" \"2\" \". \" (:value \"nil\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline))"])
-
-(def inspect-result-configure-length ["(\"Class\" \": \" (:value \"clojure.lang.PersistentVector\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"[ 1... 2222 333 ... ]\" 1) (:newline))"])
-
-(def eval-and-inspect-result ["(\"Class\" \": \" (:value \"java.lang.String\" 0) (:newline) \"Value: \" \"\\\"1001\\\"\")"])
-
-(def java-hashmap-inspect-result ["(\"Class\" \": \" (:value \"java.util.HashMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"2\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"3\" 4) (:newline) \"  \" (:value \":a\" 5) \" = \" (:value \"1\" 6) (:newline))"])
-
-(def tagged-literal-inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.TaggedLiteral\" 0) (:newline) \"Value\" \": \" (:value \"\\\"#foo ()\\\"\" 1) (:newline) \"---\" (:newline) \"Fields:\" (:newline) \"  \" (:value \"\\\"form\\\"\" 2) \" = \" (:value \"()\" 3) (:newline) \"  \" (:value \"\\\"tag\\\"\" 4) \" = \" (:value \"foo\" 5) (:newline) (:newline) \"Static fields:\" (:newline) \"  \" (:value \"\\\"FORM_KW\\\"\" 6) \" = \" (:value \":form\" 7) (:newline) \"  \" (:value \"\\\"TAG_KW\\\"\" 8) \" = \" (:value \":tag\" 9) (:newline) (:newline))"])
+(-> (inspect/fresh)
+    (inspect/start {:a {:b 1}})
+    (inspect/down 1)
+    (inspect/down 1))
 
 (def long-sequence (range 70))
 (def long-vector (vec (range 70)))
@@ -31,81 +133,136 @@
 (def long-nested-coll (vec (map #(range (* % 10) (+ (* % 10) 80)) (range 200))))
 (def truncated-string (str "\"" (apply str (repeat 146 "a")) "..."))
 
+(defn- section? [name rendered]
+  (when (string? rendered)
+    (re-matches (re-pattern (format "--- %s:" name)) rendered)))
+
+(defn- section [name rendered]
+  (->> rendered
+       (drop-while #(not (section? name %)))
+       (take-while #(or (section? name %)
+                        (not (section? ".*" %))))))
+
+(defn- datafy-section [rendered]
+  (section "Datafy" rendered))
+
+(defn- header [rendered]
+  (take-while #(not (and (string? %)
+                         (re-matches #".*---.*" %))) rendered))
+
+(defn- extend-datafy-class [m]
+  (vary-meta m assoc 'clojure.core.protocols/datafy (fn [x] (assoc x :class (.getSimpleName (class x))))))
+
+(defn- extend-nav-vector [m]
+  (vary-meta m assoc 'clojure.core.protocols/nav (fn [coll k v] [k (get coll k v)])))
+
 (defn inspect
   [value]
   (inspect/start (inspect/fresh) value))
 
 (defn render
   [inspector]
-  (vector (pr-str (:rendered inspector))))
+  (:rendered inspector))
 
 (deftest nil-test
   (testing "nil renders correctly"
-    (is (= nil-result
-           (-> nil
-               inspect
-               render)))))
+    (is (match? nil-result
+                (-> nil
+                    inspect
+                    render)))))
 
 (deftest pop-empty-test
   (testing "popping an empty inspector renders nil"
-    (is (= nil-result
-           (-> (inspect/fresh)
-               inspect/up
-               render)))))
+    (is (match? nil-result
+                (-> (inspect/fresh)
+                    inspect/up
+                    render)))))
 
 (deftest pop-empty-idempotent-test
   (testing "popping an empty inspector is idempotent"
-    (is (= nil-result
-           (-> (inspect/fresh)
-               inspect/up
-               inspect/up
-               render)))))
+    (is (match? nil-result
+                (-> (inspect/fresh)
+                    inspect/up
+                    inspect/up
+                    render)))))
 
 (deftest push-empty-test
   (testing "pushing an empty inspector index renders nil"
-    (is (= nil-result
-           (-> (inspect/fresh)
-               (inspect/down 1)
-               render)))))
+    (is (match? nil-result
+                (-> (inspect/fresh)
+                    (inspect/down 1)
+                    render)))))
 
 (deftest push-empty-idempotent-test
   (testing "pushing an empty inspector index is idempotent"
-    (is (= nil-result
-           (-> (inspect/fresh)
-               (inspect/down 1)
-               (inspect/down 1)
-               render)))))
+    (is (match? nil-result
+                (-> (inspect/fresh)
+                    (inspect/down 1)
+                    (inspect/down 1)
+                    render)))))
 
 (deftest inspect-var-test
-  (testing "rendering a var"
-    (is (= var-result
-           (-> #'*assert*
-               inspect
-               render)))))
+  (testing "inspecting a var"
+    (let [rendered (-> #'*assert* inspect render)]
+      (testing "renders the header"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.lang.Var" 0)
+                      (:newline)
+                      "Value: "
+                      (:value "true" 1)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (testing "renders the meta information section"
+        (is (match? (cond-> '("--- Meta Information:"
+                              (:newline)
+                              "  " (:value ":ns" 2) " = " (:value "clojure.core" 3)
+                              (:newline)
+                              "  " (:value ":name" 4) " = " (:value "*assert*" 5)
+                              (:newline))
+                      datafy? (concat ['(:newline)]))
+                    (section "Meta Information" rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " "0" ". " (:value "true" 6)
+                        (:newline))
+                      (datafy-section rendered))))))))
 
 (deftest inspect-expr-test
   (testing "rendering an expr"
-    (is (= inspect-result
-           (-> eval-result
-               inspect
-               render)))))
+    (is (match? inspect-result
+                (-> eval-result
+                    inspect
+                    render)))))
 
 (deftest push-test
   (testing "pushing a rendered expr inspector idx"
-    (is (= push-result
-           (-> eval-result
-               inspect
-               (inspect/down 2)
-               render)))))
+    (is (match? '("Class"
+                  ": " (:value "clojure.lang.PersistentArrayMap" 0)
+                  (:newline)
+                  (:newline)
+                  "--- Contents:"
+                  (:newline)
+                  "  " (:value ":b" 1) " = " (:value "1" 2)
+                  (:newline)
+                  (:newline)
+                  "--- Path:"
+                  (:newline)
+                  "  "
+                  ":a")
+                (-> eval-result inspect (inspect/down 2) render)))))
 
 (deftest pop-test
   (testing "popping a rendered expr inspector"
-    (is (= inspect-result
-           (-> eval-result
-               inspect
-               (inspect/down 2)
-               inspect/up
-               render)))))
+    (is (match? inspect-result
+                (-> eval-result
+                    inspect
+                    (inspect/down 2)
+                    inspect/up
+                    render)))))
 
 (deftest pagination-test
   (testing "big collections are paginated"
@@ -120,7 +277,7 @@
             inspect
             :rendered
             ^String (last)
-            (.startsWith "  Page size:"))))
+            (.startsWith "Page size:"))))
   (testing "small collections are not paginated"
     (is (= '(:newline)
            (-> (range 10)
@@ -138,7 +295,7 @@
                            :rendered
                            last))))
   (testing "uncounted collections have their size determined on the last page"
-    (is (= "  Page size: 32, showing page: 2 of 2"
+    (is (= "Page size: 32, showing page: 2 of 2"
            (-> (range 50)
                inspect
                inspect/next-page
@@ -186,13 +343,22 @@
 
 (deftest eval-and-inspect-test
   (testing "evaluate expr in the context of currently inspected value"
-    (is (= eval-and-inspect-result
-           (-> eval-result
-               inspect
-               (inspect/down 2)
-               (inspect/down 2)
-               (inspect/eval-and-inspect "(str (+ v 1000))")
-               render)))))
+    (is (match? '("Class"
+                  ": " (:value "java.lang.String" 0)
+                  (:newline)
+                  "Value: " "\"1001\""
+                  (:newline)
+                  (:newline)
+                  "--- Print:"
+                  (:newline)
+                  "  " "1001"
+                  (:newline))
+                (-> eval-result
+                    inspect
+                    (inspect/down 2)
+                    (inspect/down 2)
+                    (inspect/eval-and-inspect "(str (+ v 1000))")
+                    render)))))
 
 (deftest def-value-test
   (testing "define var with the currently inspected value"
@@ -205,13 +371,13 @@
 
 (deftest path-test
   (testing "inspector tracks the path in the data structure"
-    (is (-> long-map inspect (inspect/down 39) render ^String (first) (.endsWith "\"  Path: (find 50) key\")")))
-    (is (-> long-map inspect (inspect/down 40) render ^String (first) (.endsWith "\"  Path: (get 50)\")")))
-    (is (-> long-map inspect (inspect/down 40) (inspect/down 0) render ^String (first) (.endsWith "\"  Path: (get 50) class\")"))))
+    (is (= "(find 50) key" (-> long-map inspect (inspect/down 39) render last)))
+    (is (= "(get 50)" (-> long-map inspect (inspect/down 40) render last)))
+    (is (= "(get 50) class"  (-> long-map inspect (inspect/down 40) (inspect/down 0) render last))))
   (testing "doesn't show path if unknown navigation has happened"
-    (is (-> long-map inspect (inspect/down 40) (inspect/down 0) (inspect/down 1) render ^String (first) (.endsWith "(:newline))"))))
+    (is (= '(:newline)  (-> long-map inspect (inspect/down 40) (inspect/down 0) (inspect/down 1) render last))))
   (testing "doesn't show the path in the top level"
-    (is (-> [1 2 3] inspect render ^String (first) (.endsWith "(:newline))")))))
+    (is (= '(:newline) (-> [1 2 3] inspect render last)))))
 
 (defprotocol IMyTestType
   (^String get-name [this]))
@@ -225,7 +391,7 @@
 
 (deftest inspect-val-test
   (testing "inspect-value print types"
-    (are [result form] (= result (inspect/inspect-value form))
+    (are [result form] (match? result (inspect/inspect-value form))
       "1" 1
       "\"2\"" "2"
       truncated-string (apply str (repeat 300 \a))
@@ -251,7 +417,7 @@
   (testing "inspect-value adjust length and size"
     (binding [inspect/*max-atom-length* 6
               inspect/*max-coll-size* 2]
-      (are [result form] (= result (inspect/inspect-value form))
+      (are [result form] (match? result (inspect/inspect-value form))
         "1" 1
         "nil" nil
         "\"2\"" "2"
@@ -266,36 +432,146 @@
         "{ :a { ( 0 1 ... ) \"ab..., 2 3, ... } }" {:a {(range 10) "abcdefg", 2 3, 4 5, 6 7, 8 9, 10 11}}
         "java.lang.Long[] { 0, 1, ... }" (into-array Long (range 10))))
     (binding [inspect/*max-coll-size* 6]
-      (are [result form] (= result (inspect/inspect-value form))
+      (are [result form] (match? result (inspect/inspect-value form))
         "[ ( 1 1 1 1 1 1 ... ) ]" [(repeat 1)]
         "{ :a { ( 0 1 2 3 4 5 ... ) 1, 2 3, 4 5, 6 7, 8 9, 10 11 } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}))))
 
+(deftest inspect-class-fields-test
+  (testing "inspecting a class with fields renders correctly"
+    (is (match? (case java-api-version
+                  (8 11)
+                  '("--- Fields:"
+                    (:newline)
+                    "  " (:value "public static final java.lang.Boolean java.lang.Boolean.FALSE" 5)
+                    (:newline)
+                    "  " (:value "public static final java.lang.Boolean java.lang.Boolean.TRUE" 6)
+                    (:newline)
+                    "  " (:value "public static final java.lang.Class java.lang.Boolean.TYPE" 7)
+                    (:newline)
+                    (:newline))
+                  '("--- Fields:"
+                    (:newline)
+                    "  " (:value "public static final java.lang.Boolean java.lang.Boolean.FALSE" 6)
+                    (:newline)
+                    "  " (:value "public static final java.lang.Boolean java.lang.Boolean.TRUE" 7)
+                    (:newline)
+                    "  " (:value "public static final java.lang.Class java.lang.Boolean.TYPE" 8)
+                    (:newline)
+                    (:newline)))
+                (->> Boolean inspect render (section "Fields")))))
+  (testing "inspecting a class without fields renders correctly"
+    (is (-> Object inspect render (section "Fields") empty?))))
+
 (deftest inspect-coll-test
   (testing "inspect :coll prints contents of the coll"
-    (is (= inspect-result-with-nil
-           (render (inspect/start (inspect/fresh) [1 2 nil 3]))))))
+    (is (match? '("Class"
+                  ": " (:value "clojure.lang.PersistentVector" 0)
+                  (:newline)
+                  (:newline)
+                  "--- Contents:"
+                  (:newline)
+                  "  " "0" ". " (:value "1" 1)
+                  (:newline)
+                  "  " "1" ". " (:value "2" 2)
+                  (:newline)
+                  "  " "2" ". " (:value "nil" 3)
+                  (:newline)
+                  "  " "3" ". " (:value "3" 4)
+                  (:newline))
+                (render (inspect/start (inspect/fresh) [1 2 nil 3]))))))
+
+(deftest inspect-coll-nav-test
+  (testing "inspecting a collection extended with the Datafiable and Navigable protocols"
+    (let [rendered (-> (->> (iterate inc 0)
+                            (map #(hash-map :x %))
+                            (map extend-datafy-class)
+                            (map extend-nav-vector))
+                       inspect (inspect/set-page-size 2) render)]
+      (testing "renders the content section"
+        (is (match? '("--- Contents:"
+                      (:newline)
+                      "  " "0" ". " (:value "{ :x 0 }" 1)
+                      (:newline)
+                      "  " "1" ". " (:value "{ :x 1 }" 2)
+                      (:newline)
+                      "  " "..."
+                      (:newline)
+                      (:newline))
+                    (section "Contents" rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " "0" ". " (:value "{ :class \"PersistentHashMap\", :x 0 }" 3)
+                        (:newline)
+                        "  " "1" ". " (:value "{ :class \"PersistentHashMap\", :x 1 }" 4)
+                        (:newline)
+                        "  " "..."
+                        (:newline)
+                        (:newline))
+                      (datafy-section rendered)))))
+      (testing "renders the page info section"
+        (is (match? '("--- Page Info:"
+                      (:newline)
+                      "  " "Page size: 2, showing page: 1 of ?")
+                    (section "Page Info" rendered)))))))
 
 (deftest inspect-configure-length-test
   (testing "inspect respects :max-atom-length and :max-coll-size configuration"
-    (is (= inspect-result-configure-length
-           (render (-> (inspect/fresh)
-                       (assoc :max-atom-length 4
-                              :max-coll-size 3)
-                       (inspect/start [[111111 2222 333 44 5]])))))))
+    (is (match? '("Class"
+                  ": "
+                  (:value "clojure.lang.PersistentVector" 0)
+                  (:newline)
+                  (:newline)
+                  "--- Contents:"
+                  (:newline)
+                  "  " "0" ". " (:value "[ 1... 2222 333 ... ]" 1)
+                  (:newline))
+                (render (-> (inspect/fresh)
+                            (assoc :max-atom-length 4
+                                   :max-coll-size 3)
+                            (inspect/start [[111111 2222 333 44 5]])))))))
 
 (deftest inspect-java-hashmap-test
   (testing "inspecting java.util.Map descendendants prints a key-value coll"
     (let [^java.util.Map the-map  {:a 1, :b 2, :c 3}]
-      (is (= java-hashmap-inspect-result
-             (-> (inspect/fresh)
-                 (inspect/start (java.util.HashMap. the-map))
-                 render))))))
+      (is (match? '("Class"
+                    ": "
+                    (:value "java.util.HashMap" 0)
+                    (:newline)
+                    (:newline)
+                    "--- Contents:"
+                    (:newline)
+                    "  " (:value ":b" 1) " = " (:value "2" 2)
+                    (:newline)
+                    "  " (:value ":c" 3) " = " (:value "3" 4)
+                    (:newline)
+                    "  " (:value ":a" 5) " = " (:value "1" 6)
+                    (:newline))
+                  (-> (inspect/fresh)
+                      (inspect/start (java.util.HashMap. the-map))
+                      render))))))
 
 (deftest inspect-java-object-test
   (testing "inspecting any Java object prints its fields"
-    (is (= tagged-literal-inspect-result
-           (render (inspect/start (inspect/fresh)
-                                  (clojure.lang.TaggedLiteral/create 'foo ())))))))
+    (is (match? '("Class"
+                  ": "
+                  (:value "clojure.lang.TaggedLiteral" 0)
+                  (:newline)
+                  "Value" ": " (:value "\"#foo ()\"" 1)
+                  (:newline)
+                  (:newline)
+                  "--- Fields:"
+                  (:newline) "  " (:value "\"form\"" 2) " = " (:value "()" 3)
+                  (:newline) "  " (:value "\"tag\"" 4) " = " (:value "foo" 5)
+                  (:newline)
+                  (:newline)
+                  "--- Static fields:"
+                  (:newline) "  " (:value "\"FORM_KW\"" 6) " = " (:value ":form" 7)
+                  (:newline) "  " (:value "\"TAG_KW\"" 8) " = " (:value ":tag" 9)
+                  (:newline))
+                (render (inspect/start (inspect/fresh)
+                                       (clojure.lang.TaggedLiteral/create 'foo ())))))))
 
 (deftest inspect-path
   (testing "inspector keeps track of the path in the inspected structure"
@@ -319,3 +595,302 @@
              (:path (-> inspector (inspect/down 0)))))
       (is (= '[:a (nth 2) :b :c (nth 73) (find :foo) key class <unknown>]
              (:path (-> inspector (inspect/down 0) (inspect/down 1))))))))
+
+(deftest inspect-object-class-test
+  (testing "inspecting the java.lang.Object class"
+    (let [rendered (-> Object inspect render)]
+      (testing "renders the header section"
+        (is (match? '("Class" ": " (:value "java.lang.Class" 0) (:newline) (:newline))
+                    (header rendered))))
+      (testing "renders the constructors section"
+        (is (match? '("--- Constructors:"
+                      (:newline)
+                      "  " (:value "public java.lang.Object()" 1)
+                      (:newline)
+                      (:newline))
+                    (section "Constructors" rendered))))
+      (testing "renders the methods section"
+        (is (match? (cond-> '("--- Methods:"
+                              (:newline)
+                              "  " (:value "public boolean java.lang.Object.equals(java.lang.Object)" 2)
+                              (:newline)
+                              "  " (:value "public final native java.lang.Class java.lang.Object.getClass()" 3)
+                              (:newline)
+                              "  " (:value "public native int java.lang.Object.hashCode()" 4)
+                              (:newline)
+                              "  " (:value "public final native void java.lang.Object.notify()" 5)
+                              (:newline)
+                              "  " (:value "public final native void java.lang.Object.notifyAll()" 6)
+                              (:newline)
+                              "  " (:value "public java.lang.String java.lang.Object.toString()" 7)
+                              (:newline)
+                              "  " (:value "public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException" 8)
+                              (:newline)
+                              "  " (:value "public final void java.lang.Object.wait() throws java.lang.InterruptedException" 9)
+                              (:newline)
+                              "  " (:value "public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException" 10)
+                              (:newline))
+                      datafy? (concat ['(:newline)]))
+                    (section "Methods" rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? `("--- Datafy:"
+                        (:newline)
+                        "  " (:value ":flags" 11) " = " (:value "#{ :public }" 12)
+                        (:newline)
+                        "  " (:value ":members" 13) " = "
+                        (:value ~(str "{ clone [ { :name clone, :return-type java.lang.Object, :declaring-class java.lang.Object, "
+                                      ":parameter-types [], :exception-types [ java.lang.CloneNotSupportedException ], ... } ], equals "
+                                      "[ { :name equals, :return-type boolean, :declaring-class java.lang.Object, :parameter-types "
+                                      "[ java.lang.Object ], :exception-types [], ... } ], finalize [ { :name finalize, :return-type void, "
+                                      ":declaring-class java.lang.Object, :parameter-types [], :exception-types [ java.lang.Throwable ], "
+                                      "... } ], getClass [ { :name getClass, :return-type java.lang.Class, :declaring-class java.lang.Object, "
+                                      ":parameter-types [], :exception-types [], ... } ], hashCode [ { :name hashCode, :return-type int, "
+                                      ":declaring-class java.lang.Object, :parameter-types [], :exception-types [], ... } ], ... }") 14)
+                        (:newline)
+                        "  " (:value ":name" 15) " = " (:value "java.lang.Object" 16)
+                        (:newline))
+                      (datafy-section rendered))))))))
+
+(deftest inspect-atom-test
+  (testing "inspecting an atom"
+    (let [rendered (-> (atom {:a 1}) inspect render)]
+      (testing "renders the header section"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.lang.Atom" 0)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (testing "renders the contains section"
+        (is (match? (cond-> '("--- Contains:"
+                              (:newline)
+                              "  " "Class" ": " (:value "clojure.lang.PersistentArrayMap" 1)
+                              (:newline)
+                              (:newline)
+                              "  --- Contents:"
+                              (:newline)
+                              "    " (:value ":a" 2) " = " (:value "1" 3)
+                              (:newline))
+                      datafy? (concat ['(:newline)]))
+                    (section "Contains" rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " "0" ". " (:value "{ :a 1 }" 4)
+                        (:newline))
+                      (datafy-section rendered))))))))
+
+(deftest inspect-atom-infinite-seq-test
+  (testing "inspecting an atom holding an infinite seq"
+    (let [rendered (-> (atom (repeat 1)) inspect (inspect/set-page-size 3) render)]
+      (testing "renders the header section"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.lang.Atom" 0)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (testing "renders the contains section"
+        (is (match? (cond-> '("--- Contains:"
+                              (:newline)
+                              "  " "Class" ": " (:value "clojure.lang.Repeat" 1)
+                              (:newline)
+                              (:newline)
+                              "  --- Contents:"
+                              (:newline)
+                              "    " "0" ". " (:value "1" 2)
+                              (:newline)
+                              "    " "1" ". " (:value "1" 3)
+                              (:newline)
+                              "    " "2" ". " (:value "1" 4)
+                              (:newline)
+                              "    " "..."
+                              (:newline))
+                      datafy? (concat ['(:newline)]))
+                    (section "Contains" rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " "0" ". " (:value "( 1 1 1 1 1 ... )" 5)
+                        (:newline))
+                      (datafy-section rendered))))))))
+
+(deftest inspect-clojure-string-namespace-test
+  (testing "inspecting the clojure.string namespace"
+    (let [result (-> (find-ns 'clojure.string) inspect render)]
+      (testing "renders the header"
+        (is (match? `("Class"
+                      ": "
+                      (:value "clojure.lang.Namespace" 0)
+                      (:newline)
+                      "Count"
+                      ": "
+                      (:value ~(case (:minor *clojure-version*)
+                                 8 "748"
+                                 9 "778"
+                                 10 "786"
+                                 "799")
+                              1)
+                      (:newline)
+                      (:newline))
+                    (header result))))
+      (testing "renders the refer from section"
+        (is (match? `("--- Refer from:"
+                      (:newline)
+                      "  "
+                      (:value "clojure.core" 2)
+                      " = "
+                      (:value ~(str "[ #'clojure.core/primitives-classnames #'clojure.core/+' #'clojure.core/decimal? "
+                                    "#'clojure.core/restart-agent #'clojure.core/sort-by ... ]") 3)
+                      (:newline)
+                      (:newline))
+                    (section "Refer from" result))))
+      (testing "renders the imports section"
+        (is (match? `("--- Imports:"
+                      (:newline)
+                      "  " (:value ~(str "{ Enum java.lang.Enum, "
+                                         "InternalError java.lang.InternalError, "
+                                         "NullPointerException java.lang.NullPointerException, "
+                                         "InheritableThreadLocal java.lang.InheritableThreadLocal, "
+                                         "Class java.lang.Class, ... }") 4)
+                      (:newline)
+                      (:newline))
+                    (section "Imports" result))))
+      (testing "renders the interns section"
+        (is (match? (cond-> `("--- Interns:"
+                              (:newline)
+                              "  " (:value ~(str "{ ends-with? #'clojure.string/ends-with?, "
+                                                 "replace-first-char #'clojure.string/replace-first-char, "
+                                                 "capitalize #'clojure.string/capitalize, "
+                                                 "reverse #'clojure.string/reverse, join #'clojure.string/join, ... }") 5)
+                              (:newline))
+                      datafy? (concat ['(:newline)]))
+                    (section "Interns" result))))
+      (when datafy?
+        (testing "renders the datafy from section"
+          (is (match? `("--- Datafy:"
+                        (:newline)
+                        "  " (:value ":name" 6) " = " (:value "clojure.string" 7)
+                        (:newline)
+                        "  " (:value ":publics" 8) " = "
+                        (:value ~(str "{ blank? #'clojure.string/blank?, capitalize "
+                                      "#'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
+                                      "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 9)
+                        (:newline)
+                        "  " (:value ":imports" 10) " = "
+                        (:value ~(str "{ AbstractMethodError java.lang.AbstractMethodError, Appendable java.lang.Appendable, "
+                                      "ArithmeticException java.lang.ArithmeticException, ArrayIndexOutOfBoundsException "
+                                      "java.lang.ArrayIndexOutOfBoundsException, ArrayStoreException java.lang.ArrayStoreException, ... }") 11)
+                        (:newline)
+                        "  " (:value ":interns" 12) " = "
+                        (:value ~(str "{ blank? #'clojure.string/blank?, capitalize #'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
+                                      "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 13)
+                        (:newline))
+                      (datafy-section result))))))))
+
+(deftest inspect-datafiable-metadata-extension-test
+  (testing "inspecting a map extended with the Datafiable protocol"
+    (let [rendered (-> (extend-datafy-class {:name "John Doe"}) inspect render)]
+      (testing "renders the header"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.lang.PersistentArrayMap" 0)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (testing "renders the meta information section"
+        (is (match? '("--- Meta Information:"
+                      (:newline)
+                      "  "
+                      (:value "clojure.core.protocols/datafy" 1)
+                      " = "
+                      (:value "orchard.inspect_test$extend_datafy_class$fn" 2)
+                      (:newline)
+                      (:newline))
+                    (demunge (section "Meta Information" rendered)))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " (:value ":name" 5) " = " (:value "\"John Doe\"" 6)
+                        (:newline)
+                        "  " (:value ":class" 7) " = " (:value "\"PersistentArrayMap\"" 8)
+                        (:newline))
+                      (datafy-section rendered))))))))
+
+(deftest inspect-navigable-metadata-extension-test
+  (testing "inspecting a map extended with the Navigable protocol"
+    (let [rendered (-> (extend-nav-vector {:name "John Doe"}) inspect render)]
+      (testing "renders the header"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.lang.PersistentArrayMap" 0)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (testing "renders the meta information section"
+        (is (match? '("--- Meta Information:"
+                      (:newline)
+                      "  " (:value "clojure.core.protocols/nav" 1)
+                      " = " (:value "orchard.inspect_test$extend_nav_vector$fn" 2)
+                      (:newline)
+                      (:newline))
+                    (demunge (section "Meta Information" rendered)))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? '("--- Datafy:"
+                        (:newline)
+                        "  " (:value ":name" 5) " = " (:value "[ :name \"John Doe\" ]" 6)
+                        (:newline))
+                      (datafy-section rendered))))))))
+
+(deftest inspect-throwable-test
+  (testing "inspecting a throwable"
+    (let [rendered (-> (doto ^Throwable (ex-info "BOOM" {})
+                         (.setStackTrace (into-array StackTraceElement [])))
+                       inspect render)]
+      (testing "renders the header"
+        (is (match? `("Class"
+                      ": " (:value "clojure.lang.ExceptionInfo" 0)
+                      (:newline)
+                      "Value" ": "
+                      (:value
+                       ~(if (= 8 (:minor *clojure-version*))
+                          (str (str "\"#error {\\n :cause \\\"BOOM\\\"\\n :data {}\\n "
+                                    ":via\\n [{:type clojure.lang.ExceptionInfo\\n   "
+                                    ":message \\\"BOOM\\\"\\n   "
+                                    ":data {}\\n   :at nil}]\\n :trace\\n []}\""))
+                          (str "\"#error {\\n :cause \\\"BOOM\\\"\\n :data {}\\n :via\\n "
+                               "[{:type clojure.lang.ExceptionInfo\\n   "
+                               ":message \\\"BOOM\\\"\\n   :data {}}]\\n :trace\\n []}\"")) 1)
+                      (:newline)
+                      (:newline))
+                    (header rendered))))
+      (when datafy?
+        (testing "renders the datafy section"
+          (is (match? (case java-api-version
+                        (11 16 17)
+                        '("--- Datafy:"
+                          (:newline)
+                          "  " (:value ":via" 34) " = " (:value "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]" 35)
+                          (:newline)
+                          "  " (:value ":trace" 36) " = " (:value "[]" 37)
+                          (:newline)
+                          "  " (:value ":cause" 38) " = " (:value "\"BOOM\"" 39)
+                          (:newline)
+                          "  " (:value ":data" 40) " = " (:value "{}" 41)
+                          (:newline))
+                        '("--- Datafy:"
+                          (:newline)
+                          "  " (:value ":via" 30) " = " (:value "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]" 31)
+                          (:newline)
+                          "  " (:value ":trace" 32) " = " (:value "[]" 33)
+                          (:newline)
+                          "  " (:value ":cause" 34) " = " (:value "\"BOOM\"" 35)
+                          (:newline)
+                          "  " (:value ":data" 36) " = " (:value "{}" 37)
+                          (:newline)))
+                      (datafy-section rendered))))))))

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -64,3 +64,20 @@
 
 (deftest directory?
   (is (misc/directory? (.toURL (.toURI (java.io.File. ""))))))
+
+(deftest call-when-resolved
+  (let [f (misc/call-when-resolved 'clojure.core/identity)]
+    (is (= 1 (f 1))))
+  (let [f (misc/call-when-resolved 'com.example/unknown)]
+    (is (nil? (f 1)))))
+
+(deftest lazy-seq?
+  (is (misc/lazy-seq? (repeat 1)))
+  (is (not (misc/lazy-seq? nil)))
+  (is (not (misc/lazy-seq? [1 2 3])))
+  (is (not (misc/lazy-seq? :not-a-seq))))
+
+(deftest safe-count
+  (is (= 3 (misc/safe-count [1 2 3])))
+  (is (nil? (misc/safe-count (repeat 1))))
+  (is (nil? (misc/safe-count :not-a-seq))))


### PR DESCRIPTION
Hello,

this PR adds basic support for Datafy and Nav to Orchard's
Inspector. The PR adds a Datafy section to the inspection view.

A good introduction to Datafy and Nav can be found here:

<https://corfield.org/blog/2018/12/03/datafy-nav/>


- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

## User Interface

Here's an overview how the UI looks like at the moment. In a nutshell,
a Datafy section is added to an object if it's datafy representation
is different than the original object.

This is done because datafy is defined on Object. Otherwise we would
show the same data in the datafy section as has been shown in a
previous section.


<a id="org0fc9983"></a>

### Class

    (class (Object.))

    Class: java.lang.Class

    --- Interfaces:

    --- Constructors:
      public java.lang.Object()

    --- Fields:

    --- Methods:
      public final native void java.lang.Object.wait(long) throws java.lang.InterruptedException
      public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException
      public final void java.lang.Object.wait() throws java.lang.InterruptedException
      public boolean java.lang.Object.equals(java.lang.Object)
      public java.lang.String java.lang.Object.toString()
      public native int java.lang.Object.hashCode()
      public final native java.lang.Class java.lang.Object.getClass()
      public final native void java.lang.Object.notify()
      public final native void java.lang.Object.notifyAll()

    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :flags = #{ :public }
      :members = { clone [ { :name clone, :return-type java.lang.Object, :declaring-class java.lang.Object, :parameter-types [], :exception-types [ java.lang.CloneNotSupportedException ], ... } ], equals [ { :name equals, :return-type boolean, :declaring-class java.lang.Object, :parameter-types [ java.lang.Object ], :exception-types [], ... } ], finalize [ { :name finalize, :return-type void, :declaring-class java.lang.Object, :parameter-types [], :exception-types [ java.lang.Throwable ], ... } ], getClass [ { :name getClass, :return-type java.lang.Class, :declaring-class java.lang.Object, :parameter-types [], :exception-types [], ... } ], hashCode [ { :name hashCode, :return-type int, :declaring-class java.lang.Object, :parameter-types [], :exception-types [], ... } ], ... }
      :name = java.lang.Object


<a id="org2b0ae0a"></a>

### References

    (atom {:a 1})

    Class: clojure.lang.Atom
    Contains:

    Class: clojure.lang.PersistentArrayMap
    Contents:
      :a = 1
    ---
    Datafy:
    Class: clojure.lang.PersistentVector
    Contents:
      0. { :a 1 }


<a id="orgfd8acfc"></a>

### Namespace

    (create-ns 'orchard.inspect-test-ns)

    Class: clojure.lang.Namespace
    Count: 96
    ---
    Refer from:
    Imports: { Enum java.lang.Enum, InternalError java.lang.InternalError, NullPointerException java.lang.NullPointerException, InheritableThreadLocal java.lang.InheritableThreadLocal, Class java.lang.Class, ... }
    Interns: {}
    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :name = orchard.inspect-test-ns
      :publics = {}
      :imports = { AbstractMethodError java.lang.AbstractMethodError, Appendable java.lang.Appendable, ArithmeticException java.lang.ArithmeticException, ArrayIndexOutOfBoundsException java.lang.ArrayIndexOutOfBoundsException, ArrayStoreException java.lang.ArrayStoreException, ... }
      :interns = {}


<a id="org14b99cc"></a>

### Objects extended with metadata

    (with-meta {:name "John Doe"}
      {'clojure.core.protocols/datafy (fn [x] (assoc x :type 'Person))})

    Class: clojure.lang.PersistentArrayMap
    Meta Information:
      clojure.core.protocols/datafy = orchard.inspect_test$eval70975$fn__70976@24234c2b
    Contents:
      :name = "John Doe"
    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :name = "John Doe"
      :type = Person


<a id="org0dc7edf"></a>

### Nav support

    (with-meta {:name "John Doe"}
      {'clojure.core.protocols/datafy
       (fn [x] (assoc x :type 'Person))
       'clojure.core.protocols/nav
       (fn [coll k v]
         [k (get coll k v)])})

    Class: clojure.lang.PersistentArrayMap
    Meta Information:
      clojure.core.protocols/datafy = orchard.inspect_test$eval70979$fn__70980@11c9298e
      clojure.core.protocols/nav = orchard.inspect_test$eval70979$fn__70982@307bd0ce
    Contents:
      :name = "John Doe"
    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :name = [ :name "John Doe" ]
      :type = [ :type Person ]


<a id="orgb9bca26"></a>

### Throwable support

    (ex-info "BOOM" {})

    Class: clojure.lang.ExceptionInfo
    Value: "#error {\n :cause \"BOOM\"\n :data {}\n :via\n [{:type clojure.lang.ExceptionInfo\n   :message \"BOOM\"\n   :data {}\n   :at [orchard.inspect_test...
    ---
    Fields:
      "backtrace" = java.lang.Object[] { short[] { 5, 1, 3, 0, 38, ... }, int[] { 1048576, 393216, 917504, 0, 24510464, ... }, java.lang.Object[] { clojure.core$ex_info, clojure.core$ex_info, orchard.inspect_test$eval70985, orchard.inspect_test$eval70985, clojure.lang.Compiler, ... }, long[] { 34363890496, 34363727080, 34363890496, 34363727080, 140652066883904, ... }, nil }
      "cause" = nil
      "data" = {}
      "depth" = 30
      "detailMessage" = "BOOM"
      "stackTrace" = java.lang.StackTraceElement[] { orchard.inspect_test$eval70985.invokeStatic(form-init6026781234703563055.clj:396), orchard.inspect_test$eval70985.invoke(form-init6026781234703563055.clj:396), clojure.lang.Compiler.eval(Compiler.java:7181), clojure.lang.Compiler.eval(Compiler.java:7136), clojure.core$eval.invokeStatic(core.clj:3202), ... }
      "suppressedExceptions" = (  )

    Static fields:
      "$assertionsDisabled" = true
      "CAUSE_CAPTION" = "Caused by: "
      "EMPTY_THROWABLE_ARRAY" = java.lang.Throwable[] {  }
      "NULL_CAUSE_MESSAGE" = "Cannot suppress a null exception."
      "SELF_SUPPRESSION_MESSAGE" = "Self-suppression not permitted"
      "SUPPRESSED_CAPTION" = "Suppressed: "
      "SUPPRESSED_SENTINEL" = (  )
      "UNASSIGNED_STACK" = java.lang.StackTraceElement[] {  }
      "serialVersionUID" = -7034897190745766939

    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :via = [ { :type clojure.lang.ExceptionInfo, :message "BOOM", :data {}, :at [ orchard.inspect_test$eval70985 invokeStatic "form-init6026781234703563055.clj" 396 ] } ]
      :trace = [ [ orchard.inspect_test$eval70985 invokeStatic "form-init6026781234703563055.clj" 396 ] [ orchard.inspect_test$eval70985 invoke "form-init6026781234703563055.clj" 396 ] [ clojure.lang.Compiler eval "Compiler.java" 7181 ] [ clojure.lang.Compiler eval "Compiler.java" 7136 ] [ clojure.core$eval invokeStatic "core.clj" 3202 ] ... ]
      :cause = "BOOM"
      :data = {}


<a id="orgfc1cc26"></a>

### Datomic Entity Maps

With the following code Datomic entities can be inspected and navigated.

    (extend-protocol clojure.core.protocols/Datafiable
      datomic.query.EntityMap
      (datafy [o] (into {} o)))

    (extend-protocol clojure.core.protocols/Navigable
      datomic.query.EntityMap
      (nav [coll k v]
        (clojure.datafy/datafy v)))

A list of Datomic entities looks like this in the inspector.

```
Class: clojure.lang.LazySeq
Contents: 
  0. #:db{:id 17592186045426}
  1. #:db{:id 17592186045464}
```
    
Inspecting one of those entities looks like this:

    Class: datomic.query.EntityMap
    Value: "#:db{:id 17592186045484}"
    ---
    Fields:
      "cache" = { :db/id 17592186045484 }
      "db" = { :id "6301025a-b0f1-4b9f-a9c1-83d64c7933e0", :memidx { :eavt #{ datomic.db.Datum@3aad15de datomic.db.Datum@a576f1d9 datomic.db.Datum@b92dfaa0 datomic.db.Datum@ca34a035 datomic.db.Datum@acb1f819 ... }, :avet #{ datomic.db.Datum@e0b11c05 datomic.db.Datum@f56f0503 datomic.db.Datum@b75722b3 datomic.db.Datum@f00ed8f5 datomic.db.Datum@adf34881 ... }, :aevt #{ datomic.db.Datum@3aad15de datomic.db.Datum@e0b11c05 datomic.db.Datum@d83059bd datomic.db.Datum@b931c078 datomic.db.Datum@b2faa1fb ... }, :raet #{ datomic.db.Datum@a576f1d9 datomic.db.Datum@b92dfaa0 datomic.db.Datum@ca34a035 datomic.db.Datum@953d3c2a datomic.db.Datum@942a2156 ... }, :fulltext { 47 { "_0.tii" com.datomic.lucene.store.RAMFile@4047c27b, "_0.fnm" com.datomic.lucene.store.RAMFile@3975a5ac, "segments.gen" com.datomic.lucene.store.RAMFile@277722e4, "_0.nrm" com.datomic.lucene.store.RAMFile@491e487, "_0.frq" com.datomic.lucene.store.RAMFile@7abbba74, ... }, 62 { "_0.tii" com.datomic.lucene.store.RAMFile@31127fcb, "_1.nrm" com.datomic.lucene.store.RAMFile@73e6af21, "_0.fnm" com.datomic.lucene.store.RAMFile@6de97d30, "segments.gen" com.datomic.lucene.store.RAMFile@32f05563, "_0.nrm" com.datomic.lucene.store.RAMFile@103e88d1, ... }, 75 { "_0.tii" com.datomic.lucene.store.RAMFile@2418e2ba, "_3.fdt" com.datomic.lucene.store.RAMFile@6b6b0202, "_3.prx" com.datomic.lucene.store.RAMFile@59bab00e, "_1.nrm" com.datomic.lucene.store.RAMFile@6b09064e, "_3.frq" com.datomic.lucene.store.RAMFile@8e724a7, ... } } }, :indexing nil, :mid-index nil, :index nil, ... }
      "edits" = nil
      "eid" = 17592186045484

    Static fields:
      "const__0" = #'clojure.core/push-thread-bindings
      "const__1" = #'clojure.core/hash-map
      "const__11" = #'clojure.core/hash
      "const__13" = #'clojure.core/seq
      "const__14" = #'datomic.query/emap
      "const__15" = #'clojure.core/keys
      "const__18" = #'datomic.db/resolve-id
      "const__2" = #'clojure.core/*print-length*
      "const__20" = #'datomic.query/touch
      "const__22" = #'clojure.core/chunked-seq?
      "const__23" = #'clojure.core/chunk-first
      "const__24" = #'clojure.core/chunk-rest
      "const__26" = #'clojure.core/first
      "const__27" = #'clojure.core/next
      "const__28" = #'clojure.core/into
      "const__29" = #'clojure.core/map
      "const__3" = 20
      "const__30" = #'clojure.core/comp
      "const__31" = #'clojure.core/str
      "const__32" = #'datomic.query/get-lazy-entity
      "const__33" = #'clojure.core/concat
      "const__34" = #'clojure.core/remove
      "const__35" = #'clojure.core/not
      "const__37" = #'datomic.db/normalize-kw
      "const__39" = #'datomic.query/eav
      "const__4" = #'clojure.core/*print-level*
      "const__41" = #'clojure.core/assoc
      "const__5" = 3
      "const__6" = #'clojure.core/pr-str
      "const__7" = #'clojure.core/pop-thread-bindings

    ---
    Datafy:
    Class: clojure.lang.PersistentArrayMap
    Contents:
      :kodo.file/sha = "19229ecff0189702c94d12005e6af143f4d6ee5a"
      :kodo.file/commit = { :kodo.commit/message "zdAELbqMzakfiRsnZusHMHXdXyiUJ", :kodo.commit/sha "f8afc26bc0d09b66c80f3596872302d9d993ccff", :kodo.commit/parents #{ #:db{:id 17592186045426} }, :kodo.commit/files #{ #:db{:id 17592186045484} #:db{:id 17592186045467} }, :kodo.commit/committed-at Sat Aug 20 15:48:42 UTC 2022, ... }
      :kodo.file/forms = #{ #:db{:id 17592186045490} #:db{:id 17592186045492} #:db{:id 17592186045488} }
      :kodo.file/path = "src/ydvwghyccsgrkowkjjlbpehwshnvy/ijiavgsniankwmkrp/tgglucwfamui/jbzawpmsgi.clj"
      :kodo.file/path+sha = [ "src/ydvwghyccsgrkowkjjlbpehwshnvy/ijiavgsniankwmkrp/tgglucwfamui/jbzawpmsgi.clj" "19229ecff0189702c94d12005e6af143f4d6ee5a" ]

I haven't opened a PR on cider-nrepl yet, because I was constantly
tweaking the rendering a bit. Once we aggree on a UI I can do that
works as well (if there needs to be done anything).

WDYT?

