### PR TITLE
Add support for spec-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+- [#163](https://github.com/clojure-emacs/orchard/pull/163) Support Clojure Spec 2 in the Spec browser
+
 ## 0.10.0 (2022-09-04)
 
 ### Bugs fixed

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ VERSION ?= 1.10
 
 TEST_PROFILES ?= +test
 
+SPEC2_SOURCE_DIR = src-spec-alpha-2
+
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
 # .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
-test: clean .EXPORT_ALL_VARIABLES
+test: clean spec-2 .EXPORT_ALL_VARIABLES
 	lein with-profile -user,-dev,+$(VERSION),$(TEST_PROFILES) test
 
 eastwood:
@@ -30,6 +32,10 @@ install: clean
 
 clean:
 	lein with-profile -user,-dev clean
+	rm -rf $(SPEC2_SOURCE_DIR)
+
+spec-2:
+	@if [ ! -d "$(SPEC2_SOURCE_DIR)" ]; then git clone https://github.com/clojure/spec-alpha2.git $(SPEC2_SOURCE_DIR); fi
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,8 @@
              :eastwood  {:plugins  [[jonase/eastwood "1.2.2"]]
                          :eastwood {:exclude-namespaces ~(cond-> '[clojure.alpha.spec
                                                                    clojure.alpha.spec.gen
-                                                                   clojure.alpha.spec.impl]
+                                                                   clojure.alpha.spec.impl
+                                                                   clojure.alpha.spec.test]
                                                            jdk8?
                                                            (conj 'orchard.java.parser)
 

--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,8 @@
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
                     :jvm-opts ["-Dorchard.initialize-cache.silent=false"
                                "-Dorchard.internal.test-suite-running=true"
-                               "-Dorchard.internal.has-enriched-classpath=false"]}
+                               "-Dorchard.internal.has-enriched-classpath=false"]
+                    :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
              :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.9.0"]]
                                 :middleware [cider.enrich-classpath/middleware]
@@ -63,7 +64,7 @@
 
              ;; Development tools
              :dev {:dependencies [[org.clojure/tools.namespace "1.1.0"]]
-                   :source-paths ["dev"]
+                   :source-paths ["dev" "src-spec-alpha-2/src/main/clojure"]
                    :resource-paths ["test-resources"]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.8.0"]]

--- a/project.clj
+++ b/project.clj
@@ -77,7 +77,9 @@
                          {:dependencies [[clj-kondo "2021.12.19"]]}]
 
              :eastwood  {:plugins  [[jonase/eastwood "1.2.2"]]
-                         :eastwood {:exclude-namespaces ~(cond-> []
+                         :eastwood {:exclude-namespaces ~(cond-> '[clojure.alpha.spec
+                                                                   clojure.alpha.spec.gen
+                                                                   clojure.alpha.spec.impl]
                                                            jdk8?
                                                            (conj 'orchard.java.parser)
 

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -166,10 +166,13 @@
   (some? (resolve 'clojure.core.protocols/datafy)))
 
 (defn call-when-resolved
-  "Return a fn that calls the fn resolved through `var-sym` with it's
-  own arguments. `var-sym` will be resolved once. If `var-sym` can't
-  be resolved the function always returns nil."
+  "Return a fn that calls the fn resolved through `var-sym` with the
+  arguments passed to it. `var-sym` will be required and resolved
+  once. If requiring failed or the `var-sym` can't be resolved the
+  function always returns nil."
   [var-sym]
+  (try (require (symbol (namespace var-sym)))
+       (catch Exception _))
   (let [resolved-var (resolve var-sym)]
     (fn [& args]
       (when resolved-var

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -8,11 +8,13 @@
   (when-let [f (resolve sym)]
     (try (apply f args) (catch Exception _))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; This are all wrappers of clojure.spec.[alpha] functions.         ;;
-;; We can't simply require the ns because it's existence depends on ;;
-;; clojure version                                                  ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; These are all wrappers for Clojure Spec functions.                                   ;;
+;; - clojure.spec (released between Clojure 1.8 and 1.9, but never included in Clojure) ;;
+;; - clojure.spec.alpha (renamed from clojure.spec and included in Clojure 1.9)         ;;
+;; - clojure.alpha.spec (spec-2, the new experimental version)                          ;;
+;; We can't simply require the ns because it's existence depends on the Clojure version ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn get-spec [v]
   (or (spec 'clojure.alpha.spec/get-spec v)

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -2,11 +2,8 @@
   (:require
    [clojure.pprint :as pp]
    [clojure.string :as str]
-   [clojure.walk :as walk]))
-
-(defn- spec [sym & args]
-  (when-let [f (resolve sym)]
-    (try (apply f args) (catch Exception _))))
+   [clojure.walk :as walk]
+   [orchard.misc :as misc]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; These are all wrappers for Clojure Spec functions.                                   ;;
@@ -16,37 +13,92 @@
 ;; We can't simply require the ns because it's existence depends on the Clojure version ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn get-spec [v]
-  (or (spec 'clojure.alpha.spec/get-spec v)
-      (spec 'clojure.spec.alpha/get-spec v)
-      (spec 'clojure.spec/get-spec v)))
+;; clojure.spec
+
+(def ^:private clojure-spec-get-spec
+  (misc/call-when-resolved 'clojure.spec/get-spec))
+
+(def ^:private clojure-spec-describe
+  (misc/call-when-resolved 'clojure.spec/describe))
+
+(def ^:private clojure-spec-form
+  (misc/call-when-resolved 'clojure.spec/form))
+
+(def ^:private clojure-spec-gen
+  (misc/call-when-resolved 'clojure.spec/gen))
+
+(def ^:private clojure-spec-registry
+  (misc/call-when-resolved 'clojure.spec/registry))
+
+;; clojure.spec.alpha
+
+(def ^:private clojure-spec-alpha-get-spec
+  (misc/call-when-resolved 'clojure.spec.alpha/get-spec))
+
+(def ^:private clojure-spec-alpha-describe
+  (misc/call-when-resolved 'clojure.spec.alpha/describe))
+
+(def ^:private clojure-spec-alpha-form
+  (misc/call-when-resolved 'clojure.spec.alpha/form))
+
+(def ^:private clojure-spec-alpha-gen
+  (misc/call-when-resolved 'clojure.spec.alpha/gen))
+
+(def ^:private clojure-spec-alpha-registry
+  (misc/call-when-resolved 'clojure.spec.alpha/registry))
+
+;; clojure.alpha.spec
+
+(def ^:private clojure-alpha-spec-get-spec
+  (misc/call-when-resolved 'clojure.alpha.spec/get-spec))
+
+(def ^:private clojure-alpha-spec-describe
+  (misc/call-when-resolved 'clojure.alpha.spec/describe))
+
+(def ^:private clojure-alpha-spec-form
+  (misc/call-when-resolved 'clojure.alpha.spec/form))
+
+(def ^:private clojure-alpha-spec-gen
+  (misc/call-when-resolved 'clojure.alpha.spec/gen))
+
+(def ^:private clojure-alpha-spec-registry
+  (misc/call-when-resolved 'clojure.alpha.spec/registry))
+
+(defn get-spec [k]
+  (or (clojure-alpha-spec-get-spec k)
+      (clojure-spec-alpha-get-spec k)
+      (clojure-spec-get-spec k)))
 
 (defn describe [s]
-  (or (spec 'clojure.alpha.spec/describe s)
-      (spec 'clojure.spec.alpha/describe s)
-      (spec 'clojure.spec/describe s)))
+  (or (clojure-alpha-spec-describe s)
+      (clojure-spec-alpha-describe s)
+      (clojure-spec-describe s)))
 
 (defn registry []
   (apply merge
-         (spec 'clojure.spec/registry)
-         (spec 'clojure.spec.alpha/registry)
-         (spec 'clojure.alpha.spec/registry)))
+         (clojure-spec-registry)
+         (clojure-spec-alpha-registry)
+         (clojure-alpha-spec-registry)))
 
 (defn form [s]
-  (or (spec 'clojure.alpha.spec/form s)
-      (spec 'clojure.spec.alpha/form s)
-      (spec 'clojure.spec/form s)))
+  (or (clojure-alpha-spec-form s)
+      (clojure-spec-alpha-form s)
+      (clojure-spec-form s)))
 
 (defn gen [s]
-  (or (spec 'clojure.alpha.spec/gen s)
-      (spec 'clojure.spec.alpha/gen s)
-      (spec 'clojure.spec/gen s)))
+  (or (clojure-alpha-spec-gen s)
+      (clojure-spec-alpha-gen s)
+      (clojure-spec-gen s)))
+
+(def ^:private generate*
+  "All Clojure Spec versions use test.check under the hood. So let's
+  directly use its `generate` function instead of going through the
+  various Spec versions again."
+  (misc/call-when-resolved 'clojure.test.check.generators/generate))
 
 (defn generate [s]
-  (let [gen (gen s)]
-    (or (spec 'clojure.alpha.spec.gen/generate gen)
-        (spec 'clojure.spec.gen.alpha/generate gen)
-        (spec 'clojure.spec.gen/generate gen))))
+  (when-let [gen (gen s)]
+    (generate* gen)))
 
 ;;; Utility functions
 

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -4,15 +4,9 @@
    [clojure.string :as str]
    [clojure.walk :as walk]))
 
-(defmacro spec [fname & args]
-  `(when-let [f# (or (resolve (symbol "clojure.spec.alpha" ~fname))
-                     (resolve (symbol "clojure.spec" ~fname)))]
-     (f# ~@args)))
-
-(defmacro spec-gen [fname & args]
-  `(when-let [f# (or (resolve (symbol "clojure.spec.gen.alpha" ~fname))
-                     (resolve (symbol "clojure.spec.gen" ~fname)))]
-     (f# ~@args)))
+(defn- spec [sym & args]
+  (when-let [f (resolve sym)]
+    (try (apply f args) (catch Exception _))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; This are all wrappers of clojure.spec.[alpha] functions.         ;;
@@ -20,15 +14,37 @@
 ;; clojure version                                                  ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn get-spec [v] (spec "get-spec" v))
+(defn get-spec [v]
+  (or (spec 'clojure.alpha.spec/get-spec v)
+      (spec 'clojure.spec.alpha/get-spec v)
+      (spec 'clojure.spec/get-spec v)))
 
-(defn describe [s] (spec "describe" s))
+(defn describe [s]
+  (or (spec 'clojure.alpha.spec/describe s)
+      (spec 'clojure.spec.alpha/describe s)
+      (spec 'clojure.spec/describe s)))
 
-(defn registry [] (spec "registry"))
+(defn registry []
+  (apply merge
+         (spec 'clojure.spec/registry)
+         (spec 'clojure.spec.alpha/registry)
+         (spec 'clojure.alpha.spec/registry)))
 
-(defn form [s] (spec "form" s))
+(defn form [s]
+  (or (spec 'clojure.alpha.spec/form s)
+      (spec 'clojure.spec.alpha/form s)
+      (spec 'clojure.spec/form s)))
 
-(defn generate [s] (spec-gen "generate" (spec "gen" s)))
+(defn gen [s]
+  (or (spec 'clojure.alpha.spec/gen s)
+      (spec 'clojure.spec.alpha/gen s)
+      (spec 'clojure.spec/gen s)))
+
+(defn generate [s]
+  (let [gen (gen s)]
+    (or (spec 'clojure.alpha.spec.gen/generate gen)
+        (spec 'clojure.spec.gen.alpha/generate gen)
+        (spec 'clojure.spec.gen/generate gen))))
 
 ;;; Utility functions
 

--- a/test/orchard/spec_test.clj
+++ b/test/orchard/spec_test.clj
@@ -21,10 +21,7 @@
              :ret (clojure.core/fn [%] (clojure.core/> (:start %) (:end %)))
              :fn nil)))))
 
-(def spec-available? (or (resolve (symbol "clojure.spec.alpha" "get-spec"))
-                         (resolve (symbol "clojure.spec" "get-spec"))))
-
-(when spec-available?
+(when spec/spec?
   (deftest spec-is-found-by-ns-alias
     (testing "current ns keyword"
       (testing "spec-list finds current ns keyword"
@@ -52,3 +49,11 @@
         (let [spec1 (spec/spec-form "::spec/test-dummy" "orchard.spec-test")
               spec2 (spec/spec-form ":orchard.spec/test-dummy" "orchard.spec-test")]
           (is (= "clojure.core/boolean?" spec1 spec2) "Both return the same correct spec"))))))
+
+(when (and spec/clojure-spec-alpha? spec/clojure-alpha-spec?)
+  (deftest spec-registry-precedence-test
+    (testing "a spec registered in multiple registries"
+      (eval '(clojure.spec.alpha/def ::bar string?))
+      (eval '(clojure.alpha.spec/def ::bar boolean?))
+      (is (= "clojure.core/boolean?" (spec/spec-form "::bar" "orchard.spec-test"))
+          "should be resolved from the spec-2 registry"))))


### PR DESCRIPTION
Hello,

this PR adds support for [spec-2](https://github.com/clojure/spec-alpha2) to orchard. spec-2 is supposed to be the successor of `clojure.spec.alpha`, but is still in an experimental state. The main advantage of spec-2 is that it adds `s/schema` and `s/select` which should improve some short comings of `s/keys` from the original spec. `s/schema` and `s/select` are supposed to help with re-using spec declarations. You would use `s/schema` to define the general shape of a data structure and then use `s/select` to make concrete sub selections of specs that have been defined with `s/schema`. It is not recommended to use spec-2 in production, but some people might do.

When Clojure Spec was initially released it lived under the namespace `clojure.spec`. Some time after the release it was renamed to `clojure.spec.alpha`. I believe because of this transition phase Orchard supports both namespaces and checks at run time which version of Clojure Spec is available and resolves specs accordingly. This PR adds a third option to the mix.

The PR changes Orchard to support `spec-list`, `spec-form` and `spec-example` NREPL ops in the following way:

For the `spec-form` and `spec-example` NREPL ops the Clojure specs are resolved and generated in the following order:

- spec-alpha-2 (aka `clojure.alpha.spec`)

- spec-alpha (aka `clojure.spec.alpha`, which is shipped with Clojure these days)

- spec (aka `clojure.spec`, which is shipped in old Clojure versions?)

There is however a chance of a conflict if a spec is declared in more than one of the registries, and multiple variants of Clojure Spec are loaded at the same time. The most likely scenario is that people who use spec-2 have loaded both spec-alpha-2 (aka `clojure.alpha.spec`) and spec-alpha (aka `clojure.spec.alpha`). So spec-2 specs would shadow specs defined in a "previous" spec variant.

For the `spec-list` NREPL op the available spec registries are merged with spec-2 (`clojure.alpha.spec`) taking precedence over spec-alpha (aka `clojure.spec.alpha`) over spec (aka `clojure.spec`).

This order has been chosen because I believe people using spec-2 would prefer to see those specs instead of specs form older versions, in the unlikely case of a spec defined in multiple registries.

To be honest, I'm not super confident of the "unlikely" case and what happens in the future. This was the most pragmatic approach I could think of to get spec-2 working in Cider. It seems to work in my project and it should not affect people not using spec-2.

An alternative approach could be:

We could index the results of the NREPL operations by their spec variants. So, the `spec-list` op could return:

{:spec-alpha-2 ["some/spec", "another/spec"]
 :spec-alpha ["some/spec"]
 :spec ["some/spec"]}

And something similar for the other ops. The Cider frontend could then display all available Specs at the same time. If we want to go this direction we should probably introduces a new middleware with new ops for this, or add additional keys to the result of the existing ops. This might be the more "clean" approach, to support multiple flavors of Clojure Spec. But I'm not sure if it's worth the effort and I believe it would complicate the frontends a bit. Also I don't know how important it is to still support `clojure.spec`.

Any other ideas how to best integrate this?

Another open question is:

If we want to add tests for spec-2 we somehow need to bring the dependency in. spec-2 is only available via deps.edn. We could try to add it to orchard via lein-tools-deps or use some script to fetch it and leverage Leinigen's checkout feature to somehow add it to the classpath.

WDYT?

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

