### PR TITLE
Filter special form symbols from eldoc args list

### DIFF
--- a/src/orchard/eldoc.clj
+++ b/src/orchard/eldoc.clj
@@ -37,7 +37,11 @@
 (defn- extract-eldoc
   [info]
   (if-let [arglists (seq (-> info extract-arglists format-arglists))]
-    {:eldoc arglists :type "function"}
+    {:eldoc arglists
+     :type (cond
+             (:special-form info) "special-form"
+             (:macro info) "macro"
+             :else "function")}
     {:type "variable"}))
 
 (defn eldoc

--- a/test/orchard/eldoc_test.clj
+++ b/test/orchard/eldoc_test.clj
@@ -43,6 +43,18 @@
       (is (:eldoc result))
       (is (:docstring result))))
 
+  (testing "Clojure special form"
+    (let [result (eldoc/eldoc (info/info 'clojure.core 'if))]
+      (is (= (:type result) "special-form"))))
+
+  (testing "Clojure macro"
+    (let [result (eldoc/eldoc (info/info 'clojure.core 'when))]
+      (is (= (:type result) "macro"))))
+
+  (testing "Clojure function"
+    (let [result (eldoc/eldoc (info/info 'clojure.core 'inc))]
+      (is (= (:type result) "function"))))
+
   (testing "Java result structure"
     (let [result (eldoc/eldoc (info/info-java 'java.lang.String 'toLowerCase))]
       (is (:class result))


### PR DESCRIPTION
Fixes #165.

Currently, the eldoc args list for special forms includes the special form itself, which throws off the highlighting in Emacs' CIDER. This patch removes the special forms themselves from the args list. It specifically omits the Java interop special forms, because these, for some reason, do not include themselves in the :forms vector.