### PR TITLE
added function `tap-current-value` to inspector 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master (unreleased)
-- added new inspector functin `tap-current-value`
+- Added new inspector function `tap-current-value`
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master (unreleased)
+- added new inspector functin `tap-current-value`
 
 ### New features
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -16,7 +16,7 @@
    (java.lang.reflect Constructor Field Method Modifier)
    (java.util List Map)))
 
-;; Datafy and Nav are only available since Clojure 1.10
+;; Datafy Nav and tap> are only available since Clojure 1.10
 (require 'clojure.core.protocols)
 
 (def ^:private datafy
@@ -25,6 +25,8 @@
 (def ^:private nav
   (misc/call-when-resolved 'clojure.core.protocols/nav))
 
+(def ^:private maybe-tap>
+  (misc/call-when-resolved 'clojure.core/tap>))
 ;;
 ;; Navigating Inspector State
 ;;
@@ -174,7 +176,7 @@
 (defn tap-current-value
   "Tap the currently inspected value."
   [inspector]
-  (tap> (:value inspector))
+  (maybe-tap> (:value inspector))
   (inspect-render inspector))
 
 (declare inspector-value-string)

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -171,6 +171,12 @@
   (intern namespace (symbol var-name) (:value inspector))
   (inspect-render inspector))
 
+(defn tap-current-value
+  "Tap the currently inspected value."
+  [inspector]
+  (tap> (:value inspector))
+  (inspect-render inspector))
+
 (declare inspector-value-string)
 
 ;;

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -165,6 +165,11 @@
   otherwise false."
   (some? (resolve 'clojure.core.protocols/datafy)))
 
+(def tap?
+  "True if tap> (added in Clojure 1.10) is supported,
+  otherwise false."
+  (some? (resolve 'clojure.core/tap>)))
+
 (defn call-when-resolved
   "Return a fn that calls the fn resolved through `var-sym` with the
   arguments passed to it. `var-sym` will be required and resolved

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -895,21 +895,20 @@
                           (:newline)))
                       (datafy-section rendered))))))))
 
-
 (deftest tap-current-value
   (testing "tap> current value")
   (let [proof (atom [])
         test-tap-handler (fn [x]
                            (swap! proof conj x))]
-   (add-tap test-tap-handler)
-   (-> (inspect/fresh)
-       (inspect/start {:a {:b 1}})
-       (inspect/tap-current-value)
-       (inspect/down 2)
-       (inspect/tap-current-value)
-       (inspect/down 1)
-       (inspect/tap-current-value))
-   (remove-tap test-tap-handler)
-   (is (= [{:a {:b 1}}
-           {:b 1}
-           1]) @proof)))
+    (add-tap test-tap-handler)
+    (-> (inspect/fresh)
+        (inspect/start {:a {:b 1}})
+        (inspect/tap-current-value)
+        (inspect/down 2)
+        (inspect/tap-current-value)
+        (inspect/down 1)
+        (inspect/tap-current-value))
+    (remove-tap test-tap-handler)
+    (is (= [{:a {:b 1}}
+            {:b 1}
+            :b] @proof))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -9,7 +9,7 @@
    [clojure.string :as str]
    [clojure.test :as t :refer [deftest is are testing]]
    [orchard.inspect :as inspect]
-   [orchard.misc :refer [datafy? java-api-version]])
+   [orchard.misc :refer [datafy? tap? java-api-version]])
   (:import java.io.File))
 
 (defn- demunge-str [s]
@@ -897,18 +897,19 @@
 
 (deftest tap-current-value
   (testing "tap> current value")
-  (let [proof (atom [])
-        test-tap-handler (fn [x]
-                           (swap! proof conj x))]
-    (add-tap test-tap-handler)
-    (-> (inspect/fresh)
-        (inspect/start {:a {:b 1}})
-        (inspect/tap-current-value)
-        (inspect/down 2)
-        (inspect/tap-current-value)
-        (inspect/down 1)
-        (inspect/tap-current-value))
-    (remove-tap test-tap-handler)
-    (is (= [{:a {:b 1}}
-            {:b 1}
-            :b] @proof))))
+  (when tap?
+    (let [proof (atom [])
+          test-tap-handler (fn [x]
+                             (swap! proof conj x))]
+      (add-tap test-tap-handler)
+      (-> (inspect/fresh)
+          (inspect/start {:a {:b 1}})
+          (inspect/tap-current-value)
+          (inspect/down 2)
+          (inspect/tap-current-value)
+          (inspect/down 1)
+          (inspect/tap-current-value))
+      (remove-tap test-tap-handler)
+      (is (= [{:a {:b 1}}
+              {:b 1}
+              :b] @proof)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -894,3 +894,16 @@
                           "  " (:value ":data" 36) " = " (:value "{}" 37)
                           (:newline)))
                       (datafy-section rendered))))))))
+
+
+(deftest tap-current-value []
+  (testing "tap> current value"
+    (let [_ (atom nil)
+          test-tap-handler (fn [x] (reset! _ x))]
+
+      (add-tap test-tap-handler)
+      (-> (inspect/fresh)
+          (inspect/start 123)
+          (inspect/tap-current-value))
+      (remove-tap test-tap-handler)
+      (is (= 123 @_)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -910,4 +910,6 @@
        (inspect/down 1)
        (inspect/tap-current-value))
    (remove-tap test-tap-handler)
-   (is (= [{:a {:b 1}} {:b 1} 1 ]) @proof)))
+   (is (= [{:a {:b 1}}
+           {:b 1}
+           1]) @proof)))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -897,13 +897,17 @@
 
 
 (deftest tap-current-value
-  (testing "tap> current value"
-    (let [proof (atom nil)
-          test-tap-handler (fn [x] (reset! proof x))]
-
-      (add-tap test-tap-handler)
-      (-> (inspect/fresh)
-          (inspect/start 123)
-          (inspect/tap-current-value))
-      (remove-tap test-tap-handler)
-      (is (= 123 @proof)))))
+  (testing "tap> current value")
+  (let [proof (atom [])
+        test-tap-handler (fn [x]
+                           (swap! proof conj x))]
+   (add-tap test-tap-handler)
+   (-> (inspect/fresh)
+       (inspect/start {:a {:b 1}})
+       (inspect/tap-current-value)
+       (inspect/down 2)
+       (inspect/tap-current-value)
+       (inspect/down 1)
+       (inspect/tap-current-value))
+   (remove-tap test-tap-handler)
+   (is (= [{:a {:b 1}} {:b 1} 1 ]) @proof)))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -896,14 +896,14 @@
                       (datafy-section rendered))))))))
 
 
-(deftest tap-current-value []
+(deftest tap-current-value
   (testing "tap> current value"
-    (let [_ (atom nil)
-          test-tap-handler (fn [x] (reset! _ x))]
+    (let [proof (atom nil)
+          test-tap-handler (fn [x] (reset! proof x))]
 
       (add-tap test-tap-handler)
       (-> (inspect/fresh)
           (inspect/start 123)
           (inspect/tap-current-value))
       (remove-tap test-tap-handler)
-      (is (= 123 @_)))))
+      (is (= 123 @proof)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -9,7 +9,8 @@
    [clojure.string :as str]
    [clojure.test :as t :refer [deftest is are testing]]
    [orchard.inspect :as inspect]
-   [orchard.misc :refer [datafy? tap? java-api-version]])
+   [orchard.misc :refer [datafy? tap? java-api-version]]
+   [orchard.misc :as misc])
   (:import java.io.File))
 
 (defn- demunge-str [s]
@@ -901,7 +902,7 @@
     (let [proof (atom [])
           test-tap-handler (fn [x]
                              (swap! proof conj x))]
-      (add-tap test-tap-handler)
+      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
       (-> (inspect/fresh)
           (inspect/start {:a {:b 1}})
           (inspect/tap-current-value)
@@ -909,7 +910,7 @@
           (inspect/tap-current-value)
           (inspect/down 1)
           (inspect/tap-current-value))
-      (remove-tap test-tap-handler)
+      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)
       (is (= [{:a {:b 1}}
               {:b 1}
               :b] @proof)))))


### PR DESCRIPTION
This PR is a pre-requisite to work on https://github.com/clojure-emacs/cider/issues/3311
It adds a new function to the inspector to tap> the current value.

This function would needed to be called in a new operation in the cider-nrepl middleware.

- [x]  The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

