### PR TITLE
[inspector] Fix exception thrown when inspecting short Eduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#170](https://github.com/clojure-emacs/orchard/pull/170): Fix exception thrown when inspecting short Eduction.
+
 ## 0.13.0 (2023-07-21)
 - [cider-nrepl #777](https://github.com/clojure-emacs/cider-nrepl/issues/777): Introduce `orchard.indent` ns / functionality.
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -372,14 +372,12 @@
        ins))))
 
 (defn- last-page [{:keys [current-page page-size]} obj]
-  (if (or (instance? clojure.lang.Counted obj)
-          ;; if there are no more items after the current page,
-          ;; we must have reached the end of the collection, so
-          ;; it's not infinite.
-          (empty? (drop (* (inc current-page) page-size) obj)))
-    (quot (dec (count obj)) page-size)
-    ;; possibly infinite
-    Integer/MAX_VALUE))
+  (cond (instance? clojure.lang.Counted obj) (quot (dec (count obj)) page-size)
+        ;; if there are no more items after the current page, we must have
+        ;; reached the end of the collection, so it's not infinite.
+        (empty? (drop (* (inc current-page) page-size) obj)) current-page
+        ;; possibly infinite
+        :else Integer/MAX_VALUE))
 
 (defn- render-page-info [{:keys [current-page page-size] :as inspector} obj]
   (if-not (sequential? obj)

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -379,8 +379,10 @@
         ;; possibly infinite
         :else Integer/MAX_VALUE))
 
+(declare known-types)
+
 (defn- render-page-info [{:keys [current-page page-size] :as inspector} obj]
-  (if-not (sequential? obj)
+  (if-not (#{:coll :array} (known-types inspector obj))
     inspector
     (let [last-page (last-page inspector obj)
           paginate? (not= last-page 0)]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -897,6 +897,21 @@
                           (:newline)))
                       (datafy-section rendered))))))))
 
+(deftest inspect-eduction-test
+  (testing "inspecting eduction shows its object fields"
+    (let [rendered (-> (eduction (range 10)) inspect render)]
+      (testing "renders the header section"
+        (is (match? '("Class"
+                      ": "
+                      (:value "clojure.core.Eduction" 0)
+                      (:newline)
+                      "Value"
+                      ": "
+                      (:value "\"(0 1 2 3 4 5 6 7 8 9)\"" 1)
+                      (:newline)
+                      (:newline))
+                    (header rendered)))))))
+
 (deftest tap-current-value
   (testing "tap> current value")
   (when tap?

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -910,7 +910,12 @@
                       (:value "\"(0 1 2 3 4 5 6 7 8 9)\"" 1)
                       (:newline)
                       (:newline))
-                    (header rendered)))))))
+                    (header rendered)))))
+
+    (let [rendered (-> (eduction (range 100)) inspect render)]
+      (testing "doesn't render page info section"
+        (is (match? '()
+                    (section "Page Info" rendered)))))))
 
 (deftest tap-current-value
   (testing "tap> current value")


### PR DESCRIPTION
Because `Eduction` type implements `clojure.lang.Sequential` but not `clojure.lang.Counted`, the inspector threw an exception when trying to inspect it. A minor but annoying bug. Besides, there could be other similar classes out there, so it's worth fixing.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

Thanks!
