### PR TITLE
Infer var metadata for 'proxy' vars

### DIFF
--- a/.circleci/deploy/deploy_release.clj
+++ b/.circleci/deploy/deploy_release.clj
@@ -1,12 +1,12 @@
 (ns deploy-release
   (:require
    [clojure.java.shell :refer [sh]]
-   [clojure.string :as str]))
+   [clojure.string :as string]))
 
 (def release-marker "v")
 
 (defn make-version [tag]
-  (str/replace-first tag release-marker ""))
+  (string/replace-first tag release-marker ""))
 
 (defn log-result [m]
   (println m)

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,6 +2,7 @@
           :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj"]}
  :linters {:unused-private-var {:level :warning
                                 :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
+           :consistent-alias {:aliases {clojure.string string}}
            ;; Enable this opt-in linter:
            :unsorted-required-namespaces
            {:level :warning}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## master (unreleased)
 
+- [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'proxy' vars.
 - [#170](https://github.com/clojure-emacs/orchard/pull/170): Fix exception thrown when inspecting short Eduction.
 
 ## 0.13.0 (2023-07-21)
+
 - [cider-nrepl #777](https://github.com/clojure-emacs/cider-nrepl/issues/777): Introduce `orchard.indent` ns / functionality.
 
 ## 0.12.0 (2023-06-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'proxy' vars.
+- [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'indirect' vars.
 - [#170](https://github.com/clojure-emacs/orchard/pull/170): Fix exception thrown when inspecting short Eduction.
 
 ## 0.13.0 (2023-07-21)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/ex
 test: clean spec-2 .EXPORT_ALL_VARIABLES
 	lein with-profile -user,-dev,+$(VERSION),$(TEST_PROFILES) test
 
+quick-test: test
+
 eastwood:
 	lein with-profile -user,-dev,+$(VERSION),+eastwood,+deploy,$(TEST_PROFILES) eastwood
 
@@ -30,11 +32,6 @@ deploy: check-env clean
 # Usage: PROJECT_VERSION=0.13.0 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
-
-check-install-env:
-ifndef PROJECT_VERSION
-	$(error Please set PROJECT_VERSION as an env var beforehand.)
-endif
 
 clean:
 	lein with-profile -user,-dev clean

--- a/src-jdk8/orchard/java/legacy_parser.clj
+++ b/src-jdk8/orchard/java/legacy_parser.clj
@@ -5,7 +5,7 @@
    :no-doc true}
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str])
+   [clojure.string :as string])
   (:import
    (com.sun.javadoc ClassDoc ConstructorDoc Doc FieldDoc MethodDoc
                     Parameter RootDoc Tag Type)
@@ -181,8 +181,8 @@
 
     (.parse parser sr handler false)
     (-> (str sb)
-        (str/replace #"\n{3,}" "\n\n") ; normalize whitespace
-        (str/replace #" +```" "```"))))
+        (string/replace #"\n{3,}" "\n\n") ; normalize whitespace
+        (string/replace #" +```" "```"))))
 
 ;; Note that @link and @linkplain are also of 'kind' @see.
 (defn docstring
@@ -210,7 +210,7 @@
   (symbol
    (str (when-let [c (.asClassDoc t)] ; when not a primitive
           (str (-> c .containingPackage .name) "."))
-        (-> t .typeName (str/replace "." "$"))
+        (-> t .typeName (string/replace "." "$"))
         (.dimension t))))
 
 (defprotocol Parsed
@@ -257,9 +257,9 @@
   "Return the relative `.java` source path for the top-level class."
   [klass]
   (-> (str klass)
-      (str/replace #"^class " "")
-      (str/replace #"\$.*" "")
-      (str/replace "." "/")
+      (string/replace #"^class " "")
+      (string/replace #"\$.*" "")
+      (string/replace "." "/")
       (str ".java")))
 
 (defn source-info

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -4,7 +4,7 @@
   (:refer-clojure :exclude [resolve])
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str])
+   [clojure.string :as string])
   (:import
    (java.io StringReader StringWriter)
    (javax.lang.model.element Element ElementKind ExecutableElement TypeElement VariableElement)
@@ -183,8 +183,8 @@
 
     (.parse parser sr handler false)
     (-> (str sb)
-        (str/replace #"\n{3,}" "\n\n") ; normalize whitespace
-        (str/replace #" +```" "```"))))
+        (string/replace #"\n{3,}" "\n\n") ; normalize whitespace
+        (string/replace #" +```" "```"))))
 
 (defn docstring
   "Get parsed docstring text of `Element` e using source information in env"
@@ -205,12 +205,12 @@
   "Using parse tree info, return the type's name equivalently to the `typesym`
   function in `orchard.java`."
   ([n ^DocletEnvironment env]
-   (let [t (str/replace (str n) #"<.*>" "") ; drop generics
+   (let [t (string/replace (str n) #"<.*>" "") ; drop generics
          util (.getElementUtils env)]
      (if-let [c (.getTypeElement util t)]
        (let [pkg (str (.getPackageOf util c) ".")
-             cls (-> (str/replace-first t pkg "")
-                     (str/replace "." "$"))]
+             cls (-> (string/replace-first t pkg "")
+                     (string/replace "." "$"))]
          (symbol (str pkg cls))) ; classes
        (symbol t)))))            ; primitives
 
@@ -283,8 +283,8 @@
   [klass]
   (when-let [^Class cls (resolve klass)]
     (let [path (-> (.getName cls)
-                   (str/replace #"\$.*" "")
-                   (str/replace "." "/")
+                   (string/replace #"\$.*" "")
+                   (string/replace "." "/")
                    (str ".java"))]
       (if-let [module (-> cls .getModule .getName)]
         (str module "/" path)

--- a/src/orchard/cljs/meta.cljc
+++ b/src/orchard/cljs/meta.cljc
@@ -3,8 +3,10 @@
   {:author "Gary Trakhman"
    :added "0.5"}
   (:require
-   [orchard.cljs.analysis :as a #?@(:cljs [:include-macros true])]
-   [orchard.misc :as misc #?@(:cljs [:include-macros true])]
+   #?(:clj  [orchard.cljs.analysis :as a]
+      :cljs [orchard.cljs.analysis :as a :include-macros true])
+   #?(:clj  [orchard.misc :as misc]
+      :cljs [orchard.misc :as misc :include-macros true])
    [orchard.namespace :as ns]))
 
 (defn normalize-ns-file

--- a/src/orchard/clojuredocs.clj
+++ b/src/orchard/clojuredocs.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.util.os :as os])
   (:import
    (java.io IOException)
@@ -16,10 +16,10 @@
 (def default-edn-file-url
   "https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn")
 (def cache-file-name
-  (str/join os/file-separator [(os/cache-dir)
-                               "orchard"
-                               "clojuredocs"
-                               "export.edn"]))
+  (string/join os/file-separator [(os/cache-dir)
+                                  "orchard"
+                                  "clojuredocs"
+                                  "export.edn"]))
 
 (def connect-timeout
   "Timeout value for checking connection. Unit is millisecond."

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -98,13 +98,16 @@
      ;; a special symbol - always use :unqualified-sym
      (some-> (cljs-ana/special-meta env unqualified-sym)
              (cljs-meta/normalize-var-meta))
-     ;; an NS
+
+     ;; a NS
      (some->> (cljs-ana/find-ns env sym)
               (cljs-meta/normalize-ns-meta))
+
      ;; ns alias
      (some->> (cljs-ana/ns-alias env sym context-ns)
               (cljs-ana/find-ns env)
               (cljs-meta/normalize-ns-meta))
+
      ;; macro ns
      (some->> (find-ns unqualified-sym)
               (cljs-meta/normalize-macro-ns env))
@@ -112,23 +115,30 @@
      ;; macro ns alias
      (some->> (cljs-meta/aliased-macro-var env sym context-ns)
               (cljs-meta/normalize-macro-ns env))
+
      ;; referred var
      (some->> (get (cljs-ana/referred-vars env context-ns) sym)
               (cljs-ana/find-symbol-meta env)
               (cljs-meta/normalize-var-meta))
+
      ;; referred macro
      (some->> (cljs-meta/referred-macro-meta env sym context-ns)
               (cljs-meta/normalize-macro-meta))
+
      ;; scoped var
      (some->> (cljs-meta/scoped-var-meta env sym context-ns)
+              (m/merge-meta-from-proxied-var-cljs env)
               (cljs-meta/normalize-var-meta))
+
      ;; scoped macro
      (some->> (cljs-meta/scoped-macro-meta env sym context-ns)
               (cljs-meta/normalize-macro-meta))
+
      ;; var in cljs.core
      (some->> (get (cljs-ana/core-vars env context-ns) sym)
               (cljs-ana/var-meta)
               (cljs-meta/normalize-var-meta))
+
      ;; macro in cljs.core
      (some->> (cljs-meta/scoped-macro-meta env sym 'cljs.core)
               (cljs-meta/normalize-macro-meta)))))

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -119,6 +119,7 @@
      ;; referred var
      (some->> (get (cljs-ana/referred-vars env context-ns) sym)
               (cljs-ana/find-symbol-meta env)
+              (m/merge-meta-for-indirect-var-cljs env)
               (cljs-meta/normalize-var-meta))
 
      ;; referred macro

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -99,7 +99,7 @@
      (some-> (cljs-ana/special-meta env unqualified-sym)
              (cljs-meta/normalize-var-meta))
 
-     ;; a NS
+     ;; a namespace
      (some->> (cljs-ana/find-ns env sym)
               (cljs-meta/normalize-ns-meta))
 

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -127,7 +127,7 @@
 
      ;; scoped var
      (some->> (cljs-meta/scoped-var-meta env sym context-ns)
-              (m/merge-meta-from-proxied-var-cljs env)
+              (m/merge-meta-for-indirect-var-cljs env)
               (cljs-meta/normalize-var-meta))
 
      ;; scoped macro

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -9,10 +9,10 @@
 
   Pretty wild, right?"
   (:require
-   [clojure.string :as s]
+   [clojure.string :as string]
    [orchard.misc :as misc])
   (:import
-   clojure.lang.Seqable
+   (clojure.lang Seqable)
    (java.lang.reflect Constructor Field Method Modifier)
    (java.util List Map)))
 
@@ -194,7 +194,7 @@
    (safe-pr-seq value " " fmt))
   ([value sep fmt]
    (->> (map inspect-value value)
-        (s/join sep)
+        (string/join sep)
         (format fmt))))
 
 (def ^:private ^:dynamic *max-atom-length* 150)
@@ -548,7 +548,7 @@
 (defn- render-indent-str-lines [inspector s]
   (reduce #(-> (render-indent %1 (str %2))
                (render-ln))
-          inspector (s/split-lines s)))
+          inspector (string/split-lines s)))
 
 (defmethod inspect :string [inspector ^java.lang.String obj]
   (-> (render-class-name inspector obj)
@@ -696,7 +696,7 @@
     (if (and (seq path) (not-any? #(= % '<unknown>) path))
       (-> (render-section-header inspector "Path")
           (indent)
-          (render-indent (s/join " " (:path inspector)))
+          (render-indent (string/join " " (:path inspector)))
           (unindent))
       inspector)))
 

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -5,7 +5,7 @@
    [clojure.java.io :as io]
    [clojure.java.javadoc :as javadoc]
    [clojure.reflect :as r]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.java.resource :as resource]
    [orchard.misc :as misc]
    [orchard.util.io :as util.io])
@@ -74,15 +74,15 @@
    (let [maybe-module (when (>= misc/java-api-version 11)
                         (some-> (module-name class) (str "/")))]
      (str maybe-module
-          (-> (str/replace (str class) "." "/")
-              (str/replace "$" "."))
+          (-> (string/replace (str class) "." "/")
+              (string/replace "$" "."))
           ".html")))
   ([class member argtypes]
    (str (javadoc-url class) "#" member
         (when argtypes
           (if (<= misc/java-api-version 9) ; argtypes were munged before Java 10
-            (str "-" (str/join "-" (map #(str/replace % #"\[\]" ":A") argtypes)) "-")
-            (str "(" (str/join "," argtypes) ")"))))))
+            (str "-" (string/join "-" (map #(string/replace % #"\[\]" ":A") argtypes)) "-")
+            (str "(" (string/join "," argtypes) ")"))))))
 
 ;;; ## Source Analysis
 ;;
@@ -316,7 +316,7 @@
 
 (defn trim-one-dot
   [s]
-  (str/replace s #"^\.|\.$" ""))
+  (string/replace s #"^\.|\.$" ""))
 
 (defn resolve-symbol
   "Return the info map for a Java member symbol.
@@ -330,7 +330,7 @@
   {:pre [(every? symbol? [ns sym])]}
   (let [sym (-> sym str trim-one-dot)
         sym* (symbol sym)
-        [class static-member] (->> (str/split sym #"/" 2)
+        [class static-member] (->> (string/split sym #"/" 2)
                                    (map #(when % (symbol %))))]
     (if-let [c (resolve-class ns class)]
       (when static-member
@@ -344,7 +344,7 @@
   "Return type info, for a Java class, interface or record."
   [ns sym]
   (let [sym (-> sym str trim-one-dot)
-        sym-split (->> (str/split sym #"/" 2)
+        sym-split (->> (string/split sym #"/" 2)
                        (map #(when % (symbol %))))]
     (some->> (first sym-split)
              (resolve-class ns)

--- a/src/orchard/java/classpath.clj
+++ b/src/orchard/java/classpath.clj
@@ -6,7 +6,7 @@
   classpath manipulation magic, performed by the Boot build tool."
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.misc :as misc])
   (:import
    (java.io File)
@@ -102,7 +102,7 @@
   []
   (let [class-path (System/getProperty "fake.class.path")
         dir-separator (System/getProperty "file.separator")
-        paths (str/split class-path (re-pattern (System/getProperty "path.separator")))
+        paths (string/split class-path (re-pattern (System/getProperty "path.separator")))
         urls (map
               (fn [path]
                 (let [url (if (re-find #".jar$" path)

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.walk :as walk]
    [orchard.cljs.analysis :as cljs-ana]
    [orchard.clojuredocs :as cljdocs]
@@ -21,13 +21,13 @@
   (if (seq? description)
     (str "(" (->> description
                   (map #(with-out-str (pprint/pprint %)))
-                  str/join
-                  str/trim-newline)
+                  string/join
+                  string/trim-newline)
          ")")
     (->>  description
           pprint/pprint
           with-out-str
-          str/trim-newline)))
+          string/trim-newline)))
 
 (defn format-spec
   "Return sequence of [role spec-description] pairs."
@@ -52,7 +52,7 @@
   entry pointing to https://clojure.org/..."
   [info]
   (if-let [url (cond
-                 (not (str/blank? (:url info)))
+                 (not (string/blank? (:url info)))
                  (str "https://clojure.org/" (:url info))
 
                  (:special-form info)
@@ -272,10 +272,10 @@
        "(not documented)"))
   ([n v]
    (->> (-> (var-doc v)
-            (str/replace #"\s+" " ") ; normalize whitespace
-            (str/split #"(?<=\.) ")) ; split sentences
+            (string/replace #"\s+" " ") ; normalize whitespace
+            (string/split #"(?<=\.) ")) ; split sentences
         (take n)
-        (str/join " "))))
+        (string/join " "))))
 
 (defn var-code
   "Find the source of the var `v`.

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [update-keys update-vals])
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.util.io :as util.io]))
 
 (require 'clojure.core.protocols)
@@ -113,8 +113,8 @@
   (try
     ;; the no-opt split is because a java version string can end with
     ;; an optional string consisting of a hyphen followed by other characters
-    (let [[no-opt _] (str/split java-ver #"-")
-          [major minor _] (str/split no-opt #"\.")
+    (let [[no-opt _] (string/split java-ver #"-")
+          [major minor _] (string/split no-opt #"\.")
           major (Integer/parseInt major)]
       (if (> major 1)
         major
@@ -138,7 +138,7 @@
   [sym]
   (some-> sym
           str
-          (str/replace #"\$macros" "")
+          (string/replace #"\$macros" "")
           symbol))
 
 (defn ns-obj?

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -67,7 +67,7 @@
                   (symbol x))))
 
 (defn namespace-sym
-  "Return the namespace of a fully qualified symbol if possible.
+  "Return the namespace of a fully qualified symbol if possible, as a symbol.
 
   It leaves the symbol untouched if not."
   [sym]
@@ -76,7 +76,7 @@
     sym))
 
 (defn name-sym
-  "Return the name of a fully qualified symbol if possible.
+  "Return the name of a fully qualified symbol if possible, as a symbol.
 
   It leaves the symbol untouched if not."
   [sym]

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -7,7 +7,7 @@
    :added "0.5"}
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.java.classpath :as cp]
    [orchard.misc :as misc])
   (:import
@@ -41,8 +41,8 @@
   according to the canonical naming convention, if present on the classpath."
   ^URL [ns]
   (let [path (-> (str ns)
-                 (str/replace "-" "_")
-                 (str/replace "." "/"))]
+                 (string/replace "-" "_")
+                 (string/replace "." "/"))]
     (or (io/resource (str path ".clj"))
         (io/resource (str path ".cljc"))
         (io/resource (str path ".cljs")))))
@@ -69,7 +69,7 @@
 (defn in-project?
   "Whether the URL is in the current project's directory."
   [url]
-  (let [path (if (misc/os-windows?) (comp str/lower-case str) str)]
+  (let [path (if (misc/os-windows?) (comp string/lower-case str) str)]
     (.startsWith ^String (path url) (path project-root))))
 
 (defn inlined-dependency?

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -1,7 +1,7 @@
 (ns orchard.spec
   (:require
    [clojure.pprint :as pp]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.walk :as walk]
    [orchard.misc :as misc]))
 
@@ -199,7 +199,7 @@
   "Given a string like \"clojure.core/let\" or \":user/email\" returns
   the associated spec in the registry, if there is one."
   [s]
-  (let [[spec-ns spec-kw] (str/split s #"/")]
+  (let [[spec-ns spec-kw] (string/split s #"/")]
     (if (.startsWith ^String spec-ns ":")
       (get-spec (keyword (subs spec-ns 1) spec-kw))
       (get-spec (symbol s)))))

--- a/src/orchard/util/os.clj
+++ b/src/orchard/util/os.clj
@@ -5,14 +5,14 @@
   {:author "Masashi Iizuka"
    :added "0.5"}
   (:require [clojure.java.io :as io]
-            [clojure.string :as str])
+            [clojure.string :as string])
   (:import (java.io BufferedReader)))
 
 (def os-name
-  (str/lower-case (System/getProperty "os.name")))
+  (string/lower-case (System/getProperty "os.name")))
 
 (def os-type
-  (condp #(str/includes? %2 %1) os-name
+  (condp #(string/includes? %2 %1) os-name
     "linux" ::linux
     "mac" ::mac
     "windows" ::windows
@@ -53,7 +53,7 @@
                           "\\\"@"]
                          (map #(str "[Dir]::GetKnownFolderPath(\\\"" %  "\\\")") guids)
                          ["}"])]
-    (run-commands (count guids) ["powershell.exe" "-Command" (str/join "\n" commands)])))
+    (run-commands (count guids) ["powershell.exe" "-Command" (string/join "\n" commands)])))
 
 (defn cache-dir
   "Returns the path to the user's cache directory.
@@ -65,9 +65,9 @@
   []
   (case os-type
     ::mac
-    (str/join file-separator [(System/getProperty "user.home")
-                              "Library"
-                              "Caches"])
+    (string/join file-separator [(System/getProperty "user.home")
+                                 "Library"
+                                 "Caches"])
 
     ::windows
     (-> ["F1B32785-6FBA-4FCF-9D55-7B8E7F157091"]
@@ -75,6 +75,6 @@
         first)
 
     (let [cache-home (System/getenv "XDG_CACHE_HOME")]
-      (if (str/blank? cache-home)
+      (if (string/blank? cache-home)
         (str (System/getProperty "user.home") file-separator ".cache")
         cache-home))))

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.repl :as repl]
    [clojure.set :as set]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [orchard.query :as q]))
 
 (defn- to-fn

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,8 +1,9 @@
 (ns ^{:doc "A test namespace"} orchard.test-ns
-  (:refer-clojure :exclude [unchecked-byte while replace])
-  (:require [clojure.string :refer [replace]]
-            [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]]
-            [orchard.test-no-defs :as no-defs])
+  (:refer-clojure :exclude [replace unchecked-byte while])
+  (:require
+   [clojure.string :as string :refer [replace]]
+   [orchard.test-no-defs :as no-defs]
+   [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]])
   #?(:cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]])
      :clj  (:require [orchard.test-macros :as test-macros :refer [my-add]]))
   #?(:cljs (:import [goog.ui IdGenerator])))
@@ -23,3 +24,20 @@
 (defn- test-private-fn
   []
   (inc (test-public-fn)))
+
+(defn proxied
+  "Docstring"
+  ([])
+  ([a b c]))
+
+(def proxy1
+  proxied)
+
+(def proxy2
+  replace)
+
+(def proxy3
+  string/capitalize)
+
+(def proxy4
+  clojure.string/includes?)

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -3,9 +3,9 @@
   (:require
    [clojure.string :as string :refer [replace]]
    [orchard.test-no-defs :as no-defs]
-   [orchard.test-ns-dep :as test-dep :refer [foo-in-dep]])
-  #?(:cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]])
-     :clj  (:require [orchard.test-macros :as test-macros :refer [my-add]]))
+   [orchard.test-ns-dep :as test-dep :refer [foo-in-dep referred]])
+  #?(:clj  (:require [orchard.test-macros :as test-macros :refer [my-add]])
+     :cljs (:require-macros [orchard.test-macros :as test-macros :refer [my-add]]))
   #?(:cljs (:import [goog.ui IdGenerator])))
 
 (defrecord TestRecord [a b c])

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -25,19 +25,19 @@
   []
   (inc (test-public-fn)))
 
-(defn proxied
+(defn source
   "Docstring"
   ([])
   ([a b c]))
 
-(def proxy1
-  proxied)
+(def indirect1
+  source)
 
-(def proxy2
+(def indirect2
   replace)
 
-(def proxy3
+(def indirect3
   string/capitalize)
 
-(def proxy4
+(def indirect4
   clojure.string/includes?)

--- a/test-resources/orchard/test_ns_dep.cljc
+++ b/test-resources/orchard/test_ns_dep.cljc
@@ -1,5 +1,9 @@
-(ns ^{:doc "Dependency of test-ns namespace"} orchard.test-ns-dep)
+(ns ^{:doc "Dependency of test-ns namespace"} orchard.test-ns-dep
+  (:require
+   [clojure.string :as string]))
 
 (defn foo-in-dep [foo] :bar)
 
 (def x ::dep-namespaced-keyword)
+
+(def referred string/trim)

--- a/test/orchard/apropos_test.clj
+++ b/test/orchard/apropos_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.apropos-test
   (:require
    [clojure.repl :as repl]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.test :refer [are deftest is testing]]
    [orchard.apropos :as sut :refer [find-symbols]]
    [orchard.meta :refer [var-name var-doc]]))
@@ -58,8 +58,7 @@
    (apropos-first v nil))
   ([v search-ns]
    (->> (find-symbols
-         (cond->
-          {:var-query {:search (re-pattern (str/escape v {\* "\\*"}))}}
+         (cond-> {:var-query {:search (re-pattern (string/escape v {\* "\\*"}))}}
            search-ns
            (assoc-in [:var-query :ns-query :exactly] [search-ns])))
         (filter #(= (:name %) (if search-ns (format "%s/%s" search-ns v) v)))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -691,7 +691,7 @@
                  (info/info*)
                  (select-keys [:ns :name :file])))))))
 
-(deftest indirect-cljs
+(deftest indirect-vars-cljs
   (when cljs-available?
     (testing "Uses logic from `merge-meta-for-indirect-var-cljs`"
       (are [input expected] (testing input
@@ -702,11 +702,13 @@
                                          info/info*
                                          (select-keys [:arglists :doc])
                                          (update :doc (fn [s]
-                                                        (-> s string/split-lines first))))))
+                                                        (some-> s string/split-lines first))))))
                               true)
         'indirect1 '{:arglists ([] [a b c]), :doc "Docstring"}
         'indirect2 '{:arglists ([s match replacement]),
-                     :doc "Replaces all instance of match with replacement in s."}
+                     :doc      "Replaces all instance of match with replacement in s."}
         'indirect3 '{:arglists ([s]),
-                     :doc "Converts first character of the string to upper-case, all other"}
-        'indirect4 '{:arglists ([s substr]), :doc "True if s includes substr."}))))
+                     :doc      "Converts first character of the string to upper-case, all other"}
+        'indirect4 '{:arglists ([s substr]), :doc "True if s includes substr."}
+        'referred  '{:arglists ([s])
+                     :doc      "Removes whitespace from both ends of string."}))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -691,9 +691,9 @@
                  (info/info*)
                  (select-keys [:ns :name :file])))))))
 
-(deftest proxy-cljs
+(deftest indirect-cljs
   (when cljs-available?
-    (testing "Uses logic from `merge-meta-from-proxied-var-cljs`"
+    (testing "Uses logic from `merge-meta-for-indirect-var-cljs`"
       (are [input expected] (testing input
                               (is (= expected
                                      (-> @*cljs-params*
@@ -704,9 +704,9 @@
                                          (update :doc (fn [s]
                                                         (-> s string/split-lines first))))))
                               true)
-        'proxy1 '{:arglists ([] [a b c]), :doc "Docstring"}
-        'proxy2 '{:arglists ([s match replacement]),
-                  :doc "Replaces all instance of match with replacement in s."}
-        'proxy3 '{:arglists ([s]),
-                  :doc "Converts first character of the string to upper-case, all other"}
-        'proxy4 '{:arglists ([s substr]), :doc "True if s includes substr."}))))
+        'indirect1 '{:arglists ([] [a b c]), :doc "Docstring"}
+        'indirect2 '{:arglists ([s match replacement]),
+                     :doc "Replaces all instance of match with replacement in s."}
+        'indirect3 '{:arglists ([s]),
+                     :doc "Converts first character of the string to upper-case, all other"}
+        'indirect4 '{:arglists ([s substr]), :doc "True if s includes substr."}))))

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.info-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str :refer [replace-first]]
+   [clojure.string :as string :refer [replace-first]]
    [clojure.test :refer [are deftest is testing use-fixtures]]
    [orchard.info :as info]
    [orchard.java :as java]
@@ -13,7 +13,7 @@
 
 (def cljs-available?
   (let [sym 'orchard.cljs.test-env
-        fname (-> sym str (str/replace "." "/") (str/replace "-" "_") (str ".cljc"))]
+        fname (-> sym str (string/replace "." "/") (string/replace "-" "_") (str ".cljc"))]
     (assert (some-> fname io/resource io/as-file .exists)
             (format "The %s file can be required to begin with" fname))
     (try
@@ -24,11 +24,10 @@
 
 (def ^:dynamic *cljs-params* nil)
 
-(defn wrap-info-params
-  [f]
+(defn wrap-info-params [f]
   (with-bindings (cond-> {}
-                   cljs-available? (assoc #'*cljs-params* {:dialect :cljs
-                                                           :env (@(resolve 'orchard.cljs.test-env/create-test-env))}))
+                   cljs-available? (assoc #'*cljs-params* (delay {:dialect :cljs
+                                                                  :env (@(resolve 'orchard.cljs.test-env/create-test-env))})))
     (f)))
 
 (use-fixtures :once wrap-info-params)
@@ -44,7 +43,7 @@
   (testing "deftype"
     (when cljs-available?
       (testing "- :cljs"
-        (let [i (info/info 'orchard.test-ns 'TestType *cljs-params*)]
+        (let [i (info/info 'orchard.test-ns 'TestType @*cljs-params*)]
           (is (= '{:ns orchard.test-ns
                    :name TestType
                    :type true
@@ -52,7 +51,7 @@
                    :tag function
                    :arglists nil}
                  (select-keys i [:ns :name :record :type :tag :arglists])))
-          (is (str/includes? (:file i) "test_ns"))))))
+          (is (string/includes? (:file i) "test_ns"))))))
 
   (testing "- :clj"
     (let [i (info/info 'orchard.test-ns 'TestType)]
@@ -68,7 +67,7 @@
   (testing "defrecord"
     (when cljs-available?
       (testing "- :cljs"
-        (let [i (info/info 'orchard.test-ns 'TestRecord *cljs-params*)]
+        (let [i (info/info 'orchard.test-ns 'TestRecord @*cljs-params*)]
           (is (= '{:ns orchard.test-ns
                    :name TestRecord
                    :type true
@@ -76,7 +75,7 @@
                    :tag function
                    :arglists nil}
                  (select-keys i [:ns :name :record :type :tag :arglists])))
-          (is (str/includes? (:file i) "test_ns")))))
+          (is (string/includes? (:file i) "test_ns")))))
 
     (testing "- :clj"
       (let [i (info/info 'orchard.test-ns 'TestRecord)]
@@ -110,7 +109,7 @@
           (let [special-doc-map (misc/require-and-resolve 'cljs.repl/special-doc-map)
                 special-syms (into '#{in-ns load load-file} (keys special-doc-map))]
             (is (= special-syms (->> (into special-syms ns-syms)
-                                     (map #(merge *cljs-params* {:ns target-ns :sym %}))
+                                     (map #(merge @*cljs-params* {:ns target-ns :sym %}))
                                      (info-specials)))))))
       (testing "- :clj"
         (let [special-doc-map (misc/require-and-resolve 'clojure.repl/special-doc-map)
@@ -128,13 +127,13 @@
                      :arglists ([foo])}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info* (merge *cljs-params* params))]
+          (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:ns :name :arglists])))
-            (is (str/includes? (:file i) "test_ns_dep")))))
+            (is (string/includes? (:file i) "test_ns_dep")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :arglists])))
-          (is (str/includes? (:file i) "test_ns_dep")))))))
+          (is (string/includes? (:file i) "test_ns_dep")))))))
 
 (deftest info-resolve-var-before-alias-test
   (testing "resolve a fully qualified var before an alias - test for bug #53"
@@ -143,7 +142,7 @@
                      :arglists ([s match replacement])}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info 'orchard.test-ns 'clojure.string/replace *cljs-params*)]
+          (let [i (info/info 'orchard.test-ns 'clojure.string/replace @*cljs-params*)]
             (is (= expected (select-keys i [:ns :name :arglists]))))))
 
       (testing "- :clj"
@@ -156,7 +155,7 @@
                      :arglists ([s match replacement])}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info 'orchard.test-ns 'replace *cljs-params*)]
+          (let [i (info/info 'orchard.test-ns 'replace @*cljs-params*)]
             (is (= expected (select-keys i [:ns :name :arglists]))))))
 
       (testing "- :clj"
@@ -173,7 +172,7 @@
                      :doc "Removes whitespace from both ends of string."}]
       (when cljs-available?
         (testing "- :cljs"
-          (is (= expected (-> (info/info* (merge *cljs-params* params))
+          (is (= expected (-> (info/info* (merge @*cljs-params* params))
                               (select-keys [:ns :name :arglists :doc]))))))
       (testing "- :clj"
         (is (= expected (-> (info/info* params)
@@ -184,7 +183,7 @@
   (testing "Resolution from current namespace"
     (when cljs-available?
       (testing "- :cljs"
-        (let [i (info/info* (merge *cljs-params* '{:ns cljs.core :sym +}))]
+        (let [i (info/info* (merge @*cljs-params* '{:ns cljs.core :sym +}))]
           (is (= '+ (:name i)))
           (is (= 'cljs.core (:ns i))))))
     (testing "- :clj"
@@ -195,7 +194,7 @@
   (testing "Resolution from other namespaces"
     (when cljs-available?
       (testing "- :cljs"
-        (let [i (info/info* (merge *cljs-params* '{:ns cljs.user :sym +}))]
+        (let [i (info/info* (merge @*cljs-params* '{:ns cljs.user :sym +}))]
           (is (= (-> #'+ meta :name) (:name i)))
           (is (= 'cljs.core (:ns i))))))
     (testing "- :clj"
@@ -206,14 +205,14 @@
 (when cljs-available?
   (deftest info-cljs-tooling-issue-28-test
     (testing "Resolution from current namespace - issue #28 from cljs-tooling"
-      (let [i (info/info* (merge *cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
+      (let [i (info/info* (merge @*cljs-params* '{:ns orchard.test-ns :sym issue-28}))]
         (is (= '{:arglists ([])
-                 :line 15
+                 :line 16
                  :column 1
                  :ns orchard.test-ns
                  :name issue-28}
                (select-keys i [:arglists :line :column :ns :name])))
-        (is (str/includes? (:file i) "orchard/test_ns"))))))
+        (is (string/includes? (:file i) "orchard/test_ns"))))))
 
 (deftest info-ns-as-sym-test
   (testing "Only namespace as qualified symbol"
@@ -224,25 +223,25 @@
                      :line 1}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info* (merge *cljs-params* params))]
+          (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:line :doc :name :ns])))
-            (is (str/includes? (:file i) "orchard/test_ns")))))
+            (is (string/includes? (:file i) "orchard/test_ns")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
-          (is (str/includes? (:file i) "orchard/test_ns"))))
+          (is (string/includes? (:file i) "orchard/test_ns"))))
 
       (when cljs-available?
         ;; is how the info middleware sends it
         (testing "- :cljs with context"
           (let [params '{:context-ns orchard.test-ns
                          :sym orchard.test-ns}
-                i (info/info* (merge *cljs-params* params))]
+                i (info/info* (merge @*cljs-params* params))]
             (is (= '{:ns orchard.test-ns
                      :name orchard.test-ns
                      :line 1}
                    (select-keys i [:line :name :ns])))
-            (is (str/includes? (:file i) "orchard/test_ns"))))))))
+            (is (string/includes? (:file i) "orchard/test_ns"))))))))
 
 (deftest info-ns-dependency-as-sym-test
   (testing "Namespace dependency"
@@ -253,32 +252,32 @@
                      :line 1}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info* (merge *cljs-params* params))]
+          (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:line :doc :name :ns])))
-            (is (str/includes? (:file i) "orchard/test_ns_dep")))))
+            (is (string/includes? (:file i) "orchard/test_ns_dep")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
-          (is (str/includes? (:file i) "orchard/test_ns_dep"))))
+          (is (string/includes? (:file i) "orchard/test_ns_dep"))))
 
       ;; is how the info middleware sends it
       (when cljs-available?
         (testing "- :cljs with context"
           (let [params '{:sym orchard.test-ns-dep
                          :context-ns orchard.test-ns}
-                i (info/info* (merge *cljs-params* params))]
+                i (info/info* (merge @*cljs-params* params))]
             (is (= '{:ns orchard.test-ns-dep
                      :name orchard.test-ns-dep
                      :doc "Dependency of test-ns namespace"
                      :line 1}
                    (select-keys i [:line :name :doc :ns])))
-            (is (str/includes? (:file i) "orchard/test_ns_dep"))))))))
+            (is (string/includes? (:file i) "orchard/test_ns_dep"))))))))
 
 (deftest info-cljs-core-namespace-test
   (testing "Namespace itself but cljs.core"
     (when cljs-available?
       (testing "- :cljs"
-        (is (= 'cljs.core (:ns (info/info* (merge *cljs-params* '{:sym cljs.core})))))))
+        (is (= 'cljs.core (:ns (info/info* (merge @*cljs-params* '{:sym cljs.core})))))))
     (testing "- :clj"
       (is (= 'clojure.core (:ns (info/info* '{:sym clojure.core})))))))
 
@@ -292,14 +291,14 @@
                      :line 1}]
       (when cljs-available?
         (testing "- :cljs"
-          (let [i (info/info* (merge *cljs-params* params))]
+          (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
-            (is (str/includes? (:file i) "orchard/test_ns_dep")))))
+            (is (string/includes? (:file i) "orchard/test_ns_dep")))))
 
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
-          (is (str/includes? (:file i) "orchard/test_ns_dep")))))))
+          (is (string/includes? (:file i) "orchard/test_ns_dep")))))))
 
 (deftest info-namespace-macro-test
   (testing "Macro namespace"
@@ -317,7 +316,7 @@
                          :name orchard.test-macros
                          :line 1}]
           (is (= (take 4 (repeat expected))
-                 (map #(info/info* (merge *cljs-params* %)) params))))))))
+                 (map #(info/info* (merge @*cljs-params* %)) params))))))))
 
 (deftest info-namespace-cljs-core-macro-test
   (when cljs-available?
@@ -335,7 +334,7 @@
                          :arglists ([bindings & body])}]
           (is (= (take 6 (repeat expected))
                  (->> params
-                      (map #(info/info* (merge *cljs-params* %)))
+                      (map #(info/info* (merge @*cljs-params* %)))
                       (map #(select-keys % [:ns :name :doc :arglists]))))))))))
 
 (deftest info-namespace-macro-alias-test
@@ -349,7 +348,7 @@
                          :file "orchard/test_macros.clj"
                          :line 1}]
           (is (= (take 2 (repeat expected))
-                 (map #(info/info* (merge *cljs-params* %)) params))))))))
+                 (map #(info/info* (merge @*cljs-params* %)) params))))))))
 
 (deftest info-macros-var-test
   (testing "Macro"
@@ -365,7 +364,7 @@
                          :file "orchard/test_macros.clj"}]
           (is (= (take 2 (repeat expected))
                  (->> params
-                      (map #(info/info* (merge *cljs-params* %)))
+                      (map #(info/info* (merge @*cljs-params* %)))
                       (map #(select-keys % [:ns :name :arglists :macro :file]))))))))
 
     (testing "- :clj"
@@ -401,7 +400,7 @@
         (testing "- :cljs"
           (is (= (take 3 (repeat expected))
                  (->> params
-                      (map #(info/info* (merge *cljs-params* %)))
+                      (map #(info/info* (merge @*cljs-params* %)))
                       (map #(select-keys % [:ns :name :arglists :macro :file])))))))
 
       (testing "- :clj"
@@ -424,7 +423,7 @@
         (testing "- :cljs"
           (is (= (take 1 (repeat expected))
                  (->> params
-                      (map #(info/info* (merge *cljs-params* %)))
+                      (map #(info/info* (merge @*cljs-params* %)))
                       (map #(select-keys % [:ns :name :arglists :macro :file])))))))
 
       (testing "- :clj"
@@ -459,7 +458,7 @@
           f "orchard/test_no_defs.cljc"]
       (when cljs-available?
         (testing "- :cljs"
-          (let [cljs-merged-params (merge *cljs-params* params)]
+          (let [cljs-merged-params (merge @*cljs-params* params)]
             (is (-> cljs-merged-params info/info* ^String (:file) (.endsWith f))))))
 
       (testing "- :clj"
@@ -557,46 +556,47 @@
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity()")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity()"]
-        (is (str/includes? url exp-suffix))))
+        (is (string/includes? url exp-suffix))))
 
     (testing "Javadoc 1.8 format"
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity--")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity--"]
-        (is (str/includes? url exp-suffix)))))
+        (is (string/includes? url exp-suffix)))))
 
   (testing "Get general URL for a clojure javadoc"
     (let [reply    (info/javadoc-info "clojure/java/io.clj")
           url      (:javadoc reply)
-          url-type (class url)
-          exp-type java.net.URL]
-      (is (= url-type exp-type))))
+          url-type (class url)]
+      (is (= java.net.URL url-type))))
 
   (testing "Get URL for commonly used Java libraries via the *remote-javadocs* mechanism"
     (let [reply    (info/javadoc-info "com/amazonaws/services/lambda/AWSLambdaClient.html#listFunctions()")
           url      (:javadoc reply)]
-      (is (= url "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/lambda/AWSLambdaClient.html#listFunctions()"))))
+      (is (= "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/lambda/AWSLambdaClient.html#listFunctions()"
+             url))))
 
   (testing "Get fall through URL type for other Javadocs (external libs?)"
     (let [reply (info/javadoc-info "http://some/other/url")
           url (:javadoc reply)]
-      (is (= url "http://some/other/url")))))
+      (is (= "http://some/other/url"
+             url)))))
 
 ;; TODO: Assess the value of this test
 (deftest javadoc-url-test
-  (when (= misc/java-api-version 7)
+  (when (= 7 misc/java-api-version)
     (testing "java 1.7"
       (is (= "java/lang/StringBuilder.html#charAt(int)"
              (-> (info/info-java 'java.lang.StringBuilder 'charAt)
                  (get :javadoc))))))
 
-  (when (= misc/java-api-version 8)
+  (when (= 8 misc/java-api-version)
     (testing "java 1.8"
       (is (= "java/lang/StringBuilder.html#charAt-int-"
              (-> (info/info-java 'java.lang.StringBuilder 'charAt)
                  (get :javadoc))))))
 
-  (when (= misc/java-api-version 9)
+  (when (= 9 misc/java-api-version)
     (testing "java 9"
       (is (= "java/lang/StringBuilder.html#charAt-int-"
              (-> (info/info-java 'java.lang.StringBuilder 'charAt)
@@ -612,14 +612,14 @@
   (:resource (info/file-info x)))
 
 (deftest resource-path-test
-  (is (= (class (file (subs (str (io/resource "clojure/core.clj")) 4)))
-         java.net.URL))
-  (is (= (class (file "clojure/core.clj"))
-         java.net.URL))
-  (is (= (class (file "clojure-1.7.0.jar:clojure/core.clj"))
-         java.net.URL))
-  (is (= (class (file "orchard/test_ns.cljc"))
-         java.net.URL))
+  (is (= java.net.URL
+         (class (file (subs (str (io/resource "clojure/core.clj")) 4)))))
+  (is (= java.net.URL
+         (class (file "clojure/core.clj"))))
+  (is (= java.net.URL
+         (class (file "clojure-1.7.0.jar:clojure/core.clj"))))
+  (is (= java.net.URL
+         (class (file "orchard/test_ns.cljc"))))
   (is (relative "clojure/core.clj"))
   (is (nil? (relative "notclojure/core.clj"))))
 
@@ -687,6 +687,26 @@
       (is (= '{:ns orchard.test-ns
                :name x
                :file "orchard/test_ns.cljc"}
-             (-> (merge *cljs-params* '{:ns orchard.test-ns :sym x})
+             (-> (merge @*cljs-params* '{:ns orchard.test-ns :sym x})
                  (info/info*)
                  (select-keys [:ns :name :file])))))))
+
+(deftest proxy-cljs
+  (when cljs-available?
+    (testing "Uses logic from `merge-meta-from-proxied-var-cljs`"
+      (are [input expected] (testing input
+                              (is (= expected
+                                     (-> @*cljs-params*
+                                         (merge {:ns 'orchard.test-ns
+                                                 :sym input})
+                                         info/info*
+                                         (select-keys [:arglists :doc])
+                                         (update :doc (fn [s]
+                                                        (-> s string/split-lines first))))))
+                              true)
+        'proxy1 '{:arglists ([] [a b c]), :doc "Docstring"}
+        'proxy2 '{:arglists ([s match replacement]),
+                  :doc "Replaces all instance of match with replacement in s."}
+        'proxy3 '{:arglists ([s]),
+                  :doc "Converts first character of the string to upper-case, all other"}
+        'proxy4 '{:arglists ([s substr]), :doc "True if s includes substr."}))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -6,7 +6,7 @@
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.pprint :as pprint]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.test :as t :refer [deftest is are testing]]
    [orchard.inspect :as inspect]
    [orchard.misc :refer [datafy? tap? java-api-version]]
@@ -14,7 +14,7 @@
   (:import java.io.File))
 
 (defn- demunge-str [s]
-  (str/replace s #"(?i)\$([a-z-]+)__([0-9]+)(@[a-f0-9]+)?" "\\$$1"))
+  (string/replace s #"(?i)\$([a-z-]+)__([0-9]+)(@[a-f0-9]+)?" "\\$$1"))
 
 (defn- demunge
   ([rendered]
@@ -31,9 +31,9 @@
         (let [[type value & args] x]
           (case type
             :newline "\n"
-            :value (format "%s <%s>" value (str/join "," args))))
+            :value (format "%s <%s>" value (string/join "," args))))
         (seq? x)
-        (str/join "" (map render-plain x))
+        (string/join "" (map render-plain x))
         :else (str x)))
 
 (defn- diff-text [expected actual]
@@ -61,7 +61,7 @@
     (with-out-str
       (println (format "Inspect test failed" (when msg (str ": " msg))))
       (let [diff (diff-text expected actual)]
-        (when-not (str/blank? diff)
+        (when-not (string/blank? diff)
           (println)
           (println "=== Text Diff ===\n")
           (println diff)))

--- a/test/orchard/java/classpath_test.clj
+++ b/test/orchard/java/classpath_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [orchard.java]
    [orchard.java.classpath :as cp]
@@ -17,7 +17,7 @@
   (let [s (if (instance? URL x)
             (.getPath ^URL x)
             x)]
-    (str/replace s #"/$" "")))
+    (string/replace s #"/$" "")))
 
 (deftest classpath-test
   (testing "Classpath"

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -77,15 +77,15 @@
       (is (empty? (:see-also (sut/special-sym-meta 'if)))))))
 
 #_{:clj-kondo/ignore [:unused-binding]}
-(defn proxied
+(defn source
   "Docstring"
   {:style/indent 1}
   ([])
   ([a b c]))
 
-(def proxy-by-var-quote #'proxied)
+(def indirect-by-var-quote #'source)
 
-(def proxy-by-var-symbol proxied)
+(def indirect-by-var-symbol source)
 
 (deftest var-meta-test
   ;; Test files can't be found on the class path.
@@ -103,32 +103,32 @@
                             (eval '(do (in-ns 'clojure.string)
                                        (def pok 10))))))))
 
-  (testing "Uses logic from `merge-meta-from-proxied-var-clj`"
+  (testing "Uses logic from `merge-meta-for-indirect-var-clj`"
     (is (= {:doc "Docstring"
             :arglists '([] [a b c])
             :style/indent 1}
-           (select-keys (sut/var-meta #'proxy-by-var-quote)
+           (select-keys (sut/var-meta #'indirect-by-var-quote)
                         [:doc :arglists :style/indent])))
     (is (= {:doc "Docstring"
             :arglists '([] [a b c])
             :style/indent 1}
-           (select-keys (sut/var-meta #'proxy-by-var-symbol)
+           (select-keys (sut/var-meta #'indirect-by-var-symbol)
                         [:doc :arglists :style/indent])))))
 
-(deftest merge-meta-from-proxied-var-clj-test
-  (testing "Copies `:doc`, `:style/indent` and `:arglist` metadata from the proxied var to the proxy var"
+(deftest merge-meta-for-indirect-var-clj-test
+  (testing "Copies `:doc`, `:style/indent` and `:arglist` metadata from the source var to the indirect var"
     (testing "For a var which value is var"
       (is (= {:doc "Docstring"
               :arglists '([] [a b c])
               :style/indent 1}
-             (select-keys (#'sut/merge-meta-from-proxied-var-clj (meta #'proxy-by-var-quote) #'proxy-by-var-quote)
+             (select-keys (#'sut/merge-meta-for-indirect-var-clj (meta #'indirect-by-var-quote) #'indirect-by-var-quote)
                           [:doc :arglists :style/indent]))))
 
     (testing "For a var which value is an object, which at read-time is expressed as a single symbol"
       (is (= {:doc "Docstring"
               :style/indent 1
               :arglists '([] [a b c])}
-             (select-keys (#'sut/merge-meta-from-proxied-var-clj (meta #'proxy-by-var-symbol) #'proxy-by-var-symbol)
+             (select-keys (#'sut/merge-meta-for-indirect-var-clj (meta #'indirect-by-var-symbol) #'indirect-by-var-symbol)
                           [:doc :arglists :style/indent]))))))
 
 (deftest var-meta-without-see-also-test

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -1,20 +1,20 @@
 (ns orchard.meta-test
   (:require
-   [clojure.test :refer [deftest are is testing]]
+   [clojure.test :refer [are deftest is testing]]
    [orchard.clojuredocs :as docs]
-   [orchard.meta :as m]))
+   [orchard.meta :as sut]))
 
 (deftest merge-meta-test
   (testing "Always safe and preserves object"
     (are [form] (let [x form]
-                  (= x (m/merge-meta x {:random 'meta})))
+                  (= x (sut/merge-meta x {:random 'meta})))
       0 1 1.0 (float 1) (double 1) 1M 1N 1/2
       'symbol :keyword
       (atom 10) (delay 10)
       [1 2 3] '(1 2 3)
       {1 2} #{1 2 3}))
   (testing "Applies meta"
-    (are [form] (-> (m/merge-meta form {:random 'meta})
+    (are [form] (-> (sut/merge-meta form {:random 'meta})
                     meta :random (= 'meta))
       ;; Keywords and numbers have no metadata.
       ;; Atoms and delays are mutable.
@@ -25,7 +25,7 @@
 (deftest strip-meta-test
   (testing "Always safe and preserves object"
     (are [form] (let [x form]
-                  (= x (m/strip-meta (m/merge-meta x {:random 'meta}))))
+                  (= x (sut/strip-meta (sut/merge-meta x {:random 'meta}))))
       0 1 1.0 (float 1) (double 1) 1M 1N 1/2
       'symbol :keyword
       (atom 10) (delay 10)
@@ -33,7 +33,7 @@
       {1 2} #{1 2 3}))
   (testing "Removes meta"
     (are [form] (-> (with-meta form {:random 'meta})
-                    m/strip-meta meta :random not)
+                    sut/strip-meta meta :random not)
       ;; Keywords and numbers have no metadata.
       ;; Atoms and delays are mutable.
       'symbol
@@ -44,7 +44,7 @@
   `(do ~@x))
 
 (deftest macroexpand-all-test
-  (is (->> (m/macroexpand-all '(test-macro ^{:random meta} (hi)))
+  (is (->> (sut/macroexpand-all '(test-macro ^{:random meta} (hi)))
            second
            meta
            :random
@@ -52,69 +52,109 @@
 
 (deftest special-sym-meta-test
   (testing "Names are correct for `&`, `catch`, `finally`"
-    (is (= '& (:name (m/special-sym-meta '&))))
-    (is (= 'catch (:name (m/special-sym-meta 'catch))))
-    (is (= 'finally (:name (m/special-sym-meta 'finally)))))
+    (is (= '& (:name (sut/special-sym-meta '&))))
+    (is (= 'catch (:name (sut/special-sym-meta 'catch))))
+    (is (= 'finally (:name (sut/special-sym-meta 'finally)))))
 
   (testing ":see-also metadata is attached"
-    (is (not-empty (:see-also (m/special-sym-meta 'if)))))
+    (is (not-empty (:see-also (sut/special-sym-meta 'if)))))
 
   (testing "Name is correct for `clojure.core/import*`"
     ;; Only compiler special to be namespaced
-    (is (= 'clojure.core/import* (:name (m/special-sym-meta 'clojure.core/import*)))))
+    (is (= 'clojure.core/import* (:name (sut/special-sym-meta 'clojure.core/import*)))))
 
   (testing "No ns for &, which uses fn's info"
-    (is (nil? (:ns (m/special-sym-meta '&)))))
+    (is (nil? (:ns (sut/special-sym-meta '&)))))
 
   (testing "Returns nil for unknown symbol"
-    (is (nil? (m/special-sym-meta 'unknown)))))
+    (is (nil? (sut/special-sym-meta 'unknown)))))
 
 (deftest special-sym-meta-without-see-also-test
   (with-redefs [;; do not load documents
                 docs/load-docs-if-not-loaded! (constantly nil)]
     (docs/clean-cache!)
     (testing "Attaching see-also is skipped"
-      (is (empty? (:see-also (m/special-sym-meta 'if)))))))
+      (is (empty? (:see-also (sut/special-sym-meta 'if)))))))
+
+#_{:clj-kondo/ignore [:unused-binding]}
+(defn proxied
+  "Docstring"
+  {:style/indent 1}
+  ([])
+  ([a b c]))
+
+(def proxy-by-var-quote #'proxied)
+
+(def proxy-by-var-symbol proxied)
 
 (deftest var-meta-test
   ;; Test files can't be found on the class path.
-  (is (:file (m/var-meta #'m/var-meta)))
+  (is (:file (sut/var-meta #'sut/var-meta)))
   (testing "Includes spec information"
-    (is (or (contains? (m/var-meta (resolve 'let)) :spec)
+    (is (or (contains? (sut/var-meta (resolve 'let)) :spec)
             (nil? (resolve 'clojure.spec.alpha/spec)))))
   (testing "Includes see-also information from clojure docs"
-    (is (contains? (m/var-meta (resolve 'clojure.set/union)) :see-also)))
+    (is (contains? (sut/var-meta (resolve 'clojure.set/union)) :see-also)))
   (is (re-find #"string\.clj"
-               (:file (#'m/maybe-add-file
+               (:file (#'sut/maybe-add-file
                        {:ns (find-ns 'clojure.string)}))))
   (is (not (re-find #"/form-init[^/]*$"
-                    (:file (m/var-meta
+                    (:file (sut/var-meta
                             (eval '(do (in-ns 'clojure.string)
-                                       (def pok 10)))))))))
+                                       (def pok 10))))))))
+
+  (testing "Uses logic from `merge-meta-from-proxied-var-clj`"
+    (is (= {:doc "Docstring"
+            :arglists '([] [a b c])
+            :style/indent 1}
+           (select-keys (sut/var-meta #'proxy-by-var-quote)
+                        [:doc :arglists :style/indent])))
+    (is (= {:doc "Docstring"
+            :arglists '([] [a b c])
+            :style/indent 1}
+           (select-keys (sut/var-meta #'proxy-by-var-symbol)
+                        [:doc :arglists :style/indent])))))
+
+(deftest merge-meta-from-proxied-var-clj-test
+  (testing "Copies `:doc`, `:style/indent` and `:arglist` metadata from the proxied var to the proxy var"
+    (testing "For a var which value is var"
+      (is (= {:doc "Docstring"
+              :arglists '([] [a b c])
+              :style/indent 1}
+             (select-keys (#'sut/merge-meta-from-proxied-var-clj (meta #'proxy-by-var-quote) #'proxy-by-var-quote)
+                          [:doc :arglists :style/indent]))))
+
+    (testing "For a var which value is an object, which at read-time is expressed as a single symbol"
+      (is (= {:doc "Docstring"
+              :style/indent 1
+              :arglists '([] [a b c])}
+             (select-keys (#'sut/merge-meta-from-proxied-var-clj (meta #'proxy-by-var-symbol) #'proxy-by-var-symbol)
+                          [:doc :arglists :style/indent]))))))
 
 (deftest var-meta-without-see-also-test
   (with-redefs [;; do not load documents
                 docs/load-docs-if-not-loaded! (constantly nil)]
     (docs/clean-cache!)
     (testing "Including see-also is skipped"
-      (is (not (contains? (m/var-meta (resolve 'clojure.set/union)) :see-also))))))
+      (is (not (contains? (sut/var-meta (resolve 'clojure.set/union)) :see-also))))))
 
 (deftest ns-file-test
   (testing "Resolves the file path"
     (let [nss '[orchard.test-ns-dep orchard.test-no-defs]
           endings ["test_ns_dep.cljc" "test_no_defs.cljc"]]
-      (is (every? true? (map #(.endsWith (m/ns-file %1) %2) nss endings))))))
+      (is (every? true? (map #(.endsWith (sut/ns-file %1) %2) nss endings))))))
 
 (deftest ns-meta-test
   (let [ns 'orchard.test-ns-dep
-        ns-meta (m/ns-meta ns)]
+        ns-meta (sut/ns-meta ns)]
     (testing "Includes correct `:ns`"
       (is (= ns (:ns ns-meta))))
     (testing "Includes correct `:name`"
       (is (= ns (:name ns-meta))))
     (testing "Includes correct `:file`"
-      (is (= (m/ns-file ns) (:file ns-meta))))
+      (is (= (sut/ns-file ns) (:file ns-meta))))
     (testing "Includes `:line 1`"
       (is (= 1 (:line ns-meta))))
     (testing "Does not include anything else"
-      (is (= 4 (count (keys ns-meta)))))))
+      (is (= 4 (count (keys ns-meta)))
+          (pr-str ns-meta)))))

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.namespace-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.test :refer [are deftest is testing]]
    [orchard.misc :as misc]
    [orchard.namespace :as sut]))
@@ -22,8 +22,8 @@
   tests that follows"
   [url]
   (let [string (str url)
-        upper (str/upper-case string)
-        lower (str/lower-case string)]
+        upper (string/upper-case string)
+        lower (string/lower-case string)]
     (io/as-url
      (if (= string lower) upper lower))))
 

--- a/test/orchard/util/os_test.clj
+++ b/test/orchard/util/os_test.clj
@@ -1,21 +1,21 @@
 (ns orchard.util.os-test
   (:require
-   [clojure.string :as str]
+   [clojure.string :as string]
    [clojure.test :as test :refer [deftest is testing]]
    [orchard.util.os :as os]))
 
 (deftest cache-dir-test
   (testing "BSD"
     (with-redefs [os/os-type ::os/bsd]
-      (is (str/ends-with? (os/cache-dir) "/.cache"))))
+      (is (string/ends-with? (os/cache-dir) "/.cache"))))
 
   (testing "Linux"
     (with-redefs [os/os-type ::os/linux]
-      (is (str/ends-with? (os/cache-dir) "/.cache"))))
+      (is (string/ends-with? (os/cache-dir) "/.cache"))))
 
   (testing "Mac"
     (with-redefs [os/os-type ::os/mac]
-      (is (str/ends-with? (os/cache-dir) "/Library/Caches")))))
+      (is (string/ends-with? (os/cache-dir) "/Library/Caches")))))
 
 ;; NOTE: This test case targets AppVeyor mainly
 (deftest cache-dir-windows-test


### PR DESCRIPTION
Part of https://github.com/clojure-emacs/cider-nrepl/issues/788

Use case explained over there.

...I had attempted this before: https://github.com/clojure-emacs/cider-nrepl/pull/790 but it was targeting the wrong middleware. This impl is simpler / more predictable, needing no `pmap`-like parallelism.

I've tried this one locally, and it works as intended.

Works on CLJ and CLJS, tests added for both.

Cheers - V