### PR TITLE
0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.14.0 (2023-08-03)
+
 - [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'indirect' vars.
 - [#170](https://github.com/clojure-emacs/orchard/pull/170): Fix exception thrown when inspecting short Eduction.
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ kondo:
 deploy: check-env clean
 	lein with-profile -user,-dev,+$(VERSION),-provided deploy clojars
 
-# Usage: PROJECT_VERSION=0.13.0 make install
+# Usage: PROJECT_VERSION=0.14.0 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.13.0"]
+[cider/orchard "0.14.0"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
@@ -147,7 +147,7 @@ clients can make of use of the general functionality contained in
 You can install Orchard locally like this:
 
 ```
-PROJECT_VERSION=0.13.0 make install
+PROJECT_VERSION=0.14.0 make install
 ```
 
 ...note that projects such as cider-nrepl or refactor-nrepl use copies of Orchard that are inlined with [mranderson](https://github.com/benedekfazekas/mranderson),


### PR DESCRIPTION
- [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'indirect' vars.
- [#170](https://github.com/clojure-emacs/orchard/pull/170): Fix exception thrown when inspecting short Eduction.