### PR TITLE
Parallelize `orchard.xref/fn-refs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- [#173](https://github.com/clojure-emacs/orchard/issues/173): Parallelize `orchard.xref/fn-refs` 
+
 ## 0.14.0 (2023-08-03)
 
 - [cider-nrepl #788](https://github.com/clojure-emacs/cider-nrepl/issues/788): Infer var metadata for 'indirect' vars.

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -116,7 +116,11 @@
   (let [var (as-var v)
         all-vars (q/vars {:ns-query {:project? true} :private? true})
         deps-map (zipmap all-vars (pmap fn-deps all-vars))]
-    (map first (filter (fn [[_k v]] (contains? v var)) deps-map))))
+    (into []
+          (comp (filter (fn [[_k v]]
+                          (contains? v var)))
+                (map first))
+          deps-map)))
 
 (comment
   ;; this can be used to blow up memory, which will clear the class cache of old references

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -65,9 +65,12 @@
     (let [f-class-name (-> v .getClass .getName)
           ;; this uses the implementation detail that the clojure compiler always
           ;; prefixes names of lambdas with the name of its surrounding function class
-          deps (into #{} (comp (filter (fn [[k _v]] (clojure.string/includes? k f-class-name)))
-                               (map (fn [[_k value]] (.get ^java.lang.ref.Reference value)))
-                               (mapcat fn-deps-class))
+          deps (into #{}
+                     (comp (filter (fn [[k _v]]
+                                     (clojure.string/includes? k f-class-name)))
+                           (map (fn [[_k value]]
+                                  (.get ^java.lang.ref.Reference value)))
+                           (mapcat fn-deps-class))
                      class-cache)]
       ;; if there's no deps the class is most likely AoT compiled,
       ;; try to access it directly


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/orchard/issues/173

#### Before

```clj
(time
  (do
    (doall (xref/fn-refs #'orchard.misc/as-sym))
    1))
"Elapsed time: 3570.653465 msecs"
```

#### After

```clj
(time
  (do
    (doall (xref/fn-refs #'orchard.misc/as-sym))
    1))
"Elapsed time: 528.020007 msecs"
```

`pmap` isn't exactly the best. I had a nice Claypoole integration in a discarded PR recently. Can be a global improvement after discussion later.

Cheers - V