### PR TITLE
0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.14.2 (2023-08-09)
+
 ### Changes
 
 - [#176](https://github.com/clojure-emacs/orchard/issues/176): `orchard.xref`: include info for test vars.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ kondo:
 deploy: check-env clean
 	lein with-profile -user,-dev,+$(VERSION),-provided deploy clojars
 
-# Usage: PROJECT_VERSION=0.14.1 make install
+# Usage: PROJECT_VERSION=0.14.2 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.14.1"]
+[cider/orchard "0.14.2"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
@@ -147,7 +147,7 @@ clients can make of use of the general functionality contained in
 You can install Orchard locally like this:
 
 ```
-PROJECT_VERSION=0.14.1 make install
+PROJECT_VERSION=0.14.2 make install
 ```
 
 ...note that projects such as cider-nrepl or refactor-nrepl use copies of Orchard that are inlined with [mranderson](https://github.com/benedekfazekas/mranderson),


### PR DESCRIPTION
### Changes

- [#176](https://github.com/clojure-emacs/orchard/issues/176): `orchard.xref`: include info for test vars.
- `orchard.xref`: avoid duplicate vars that might appear following REPL re-evaluation.