### PR TITLE
Setup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /checkouts
 /src-spec-alpha-2
 /classes
+.javac
+.enrich-classpath-lein-repl
 /gh-pages
 /unzipped-jdk-source
 /target

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl .EXPORT_ALL_VARIABLES
-.DEFAULT_GOAL := lein-repl
+.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl .EXPORT_ALL_VARIABLES
+.DEFAULT_GOAL := install
 
 HOME=$(shell echo $$HOME)
 VERSION ?= 1.11
@@ -54,9 +54,13 @@ clean:
 $(SPEC2_SOURCE_DIR):
 	@if [ ! -d "$(SPEC2_SOURCE_DIR)" ]; then git clone https://github.com/clojure/spec-alpha2.git $(SPEC2_SOURCE_DIR) --depth=1; fi
 
+.javac: $(wildcard test-java/orchard/*.clj)
+	lein with-profile +test javac
+	touch $@
+
 # Create and cache a `java` command. project.clj is mandatory; the others are optional but are taken into account for cache recomputation.
 # It's important not to silence with step with @ syntax, so that Enrich progress can be seen as it resolves dependencies.
-.enrich-classpath-lein-repl: $(SPEC2_SOURCE_DIR) Makefile project.clj $(wildcard checkouts/*/project.clj) $(wildcard deps.edn) $(wildcard $(HOME)/.clojure/deps.edn) $(wildcard profiles.clj) $(wildcard $(HOME)/.lein/profiles.clj) $(wildcard $(HOME)/.lein/profiles.d) $(wildcard /etc/leiningen/profiles.clj)
+.enrich-classpath-lein-repl: .javac $(SPEC2_SOURCE_DIR) Makefile project.clj $(wildcard checkouts/*/project.clj) $(wildcard deps.edn) $(wildcard $(HOME)/.clojure/deps.edn) $(wildcard profiles.clj) $(wildcard $(HOME)/.lein/profiles.clj) $(wildcard $(HOME)/.lein/profiles.d) $(wildcard /etc/leiningen/profiles.clj)
 	bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(LEIN_PROFILES) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > $@
 
 # Launches a repl, falling back to vanilla lein repl if something went wrong during classpath calculation.
@@ -67,6 +71,8 @@ lein-repl: .enrich-classpath-lein-repl
 		echo "Falling back to lein repl... (you can avoid further falling back by removing .enrich-classpath-lein-repl)"; \
 		lein with-profiles $(LEIN_PROFILES) repl; \
 	fi
+
+repl: lein-repl
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
 # .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
-test: clean spec-2 .EXPORT_ALL_VARIABLES
+test: clean $(SPEC2_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	lein with-profile -user,-dev,+$(VERSION),$(TEST_PROFILES) test
 
 quick-test: test
@@ -41,8 +41,8 @@ clean:
 	lein with-profile -user,-dev clean
 	rm -rf $(SPEC2_SOURCE_DIR)
 
-spec-2:
-	@if [ ! -d "$(SPEC2_SOURCE_DIR)" ]; then git clone https://github.com/clojure/spec-alpha2.git $(SPEC2_SOURCE_DIR); fi
+$(SPEC2_SOURCE_DIR):
+	@if [ ! -d "$(SPEC2_SOURCE_DIR)" ]; then git clone https://github.com/clojure/spec-alpha2.git $(SPEC2_SOURCE_DIR) --depth=1; fi
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
-.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean .EXPORT_ALL_VARIABLES
+.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl .EXPORT_ALL_VARIABLES
+.DEFAULT_GOAL := lein-repl
 
+HOME=$(shell echo $$HOME)
 VERSION ?= 1.11
-
 TEST_PROFILES ?= +test
-
 SPEC2_SOURCE_DIR = src-spec-alpha-2
+
+# The Lein profiles that will be selected for `lein-repl`.
+# Feel free to upgrade this, or to override it with an env var named LEIN_PROFILES.
+# Expected format: "+dev,+test"
+# Don't use spaces here.
+LEIN_PROFILES ?= "+dev,+test,+1.11"
+
+# The enrich-classpath version to be injected.
+# Feel free to upgrade this.
+ENRICH_CLASSPATH_VERSION="1.16.0"
 
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
@@ -43,6 +53,20 @@ clean:
 
 $(SPEC2_SOURCE_DIR):
 	@if [ ! -d "$(SPEC2_SOURCE_DIR)" ]; then git clone https://github.com/clojure/spec-alpha2.git $(SPEC2_SOURCE_DIR) --depth=1; fi
+
+# Create and cache a `java` command. project.clj is mandatory; the others are optional but are taken into account for cache recomputation.
+# It's important not to silence with step with @ syntax, so that Enrich progress can be seen as it resolves dependencies.
+.enrich-classpath-lein-repl: $(SPEC2_SOURCE_DIR) Makefile project.clj $(wildcard checkouts/*/project.clj) $(wildcard deps.edn) $(wildcard $(HOME)/.clojure/deps.edn) $(wildcard profiles.clj) $(wildcard $(HOME)/.lein/profiles.clj) $(wildcard $(HOME)/.lein/profiles.d) $(wildcard /etc/leiningen/profiles.clj)
+	bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(LEIN_PROFILES) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > $@
+
+# Launches a repl, falling back to vanilla lein repl if something went wrong during classpath calculation.
+lein-repl: .enrich-classpath-lein-repl
+	@if grep --silent " -cp " .enrich-classpath-lein-repl; then \
+		eval "$$(cat .enrich-classpath-lein-repl) --interactive"; \
+	else \
+		echo "Falling back to lein repl... (you can avoid further falling back by removing .enrich-classpath-lein-repl)"; \
+		lein with-profiles $(LEIN_PROFILES) repl; \
+	fi
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ clients can make of use of the general functionality contained in
 
 ### Development
 
+enrich-classpath is important for development of Java-related features in Orchard.
+
+You can fire up a repl (and nrepl server) that uses cider-nrepl and enrich-classpath like so:
+
+```bash
+# or `make lein-repl`
+make
+```
+
 You can install Orchard locally like this:
 
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You can fire up a repl (and nrepl server) that uses cider-nrepl and enrich-class
 
 ```bash
 # or `make lein-repl`
-make
+make repl
 ```
 
 You can install Orchard locally like this:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ clients can make of use of the general functionality contained in
 
 ### Development
 
-enrich-classpath is important for development of Java-related features in Orchard.
+enrich-classpath is important for development of Java-related features in Orchard, since it makes the Java sources available. Certain features parse those Java sources as a source of information.
 
 You can fire up a repl (and nrepl server) that uses cider-nrepl and enrich-classpath like so:
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,4 +1,6 @@
 (ns user
+  {:clj-kondo/config '{:linters {:unused-namespace {:level :off}
+                                 :unused-referred-var {:level :off}}}}
   (:require
    [clojure.java.javadoc :refer [javadoc]]
    [clojure.pprint :refer [pprint]]

--- a/project.clj
+++ b/project.clj
@@ -60,12 +60,16 @@
                                "-Dorchard.internal.has-enriched-classpath=false"]
                     :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
-             :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.9.0"]]
+             :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.16.0"]]
                                 :middleware [cider.enrich-classpath/middleware]
-                                :jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]}
+                                :jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]
+                                :enrich-classpath {:shorten true}}
 
              ;; Development tools
-             :dev {:dependencies [[org.clojure/tools.namespace "1.4.4"]]
+             :dev {:plugins [[cider/cider-nrepl "0.37.0"]
+                             [refactor-nrepl "3.9.0"]]
+                   :dependencies [[nrepl/nrepl "1.0.0"]
+                                  [org.clojure/tools.namespace "1.4.4"]]
                    :source-paths ["dev" "src-spec-alpha-2/src/main/clojure"]
                    :resource-paths ["test-resources"]}
 

--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,7 @@
                                 :enrich-classpath {:shorten true}}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.37.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.37.1"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/project.clj
+++ b/project.clj
@@ -75,8 +75,7 @@
                                          merge-meta [[:inner 0]]
                                          letfn [[:block 1] [:inner 2]]}}}
 
-             :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2023.07.13"]]}]
+             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.07.13"]]}
 
              :eastwood  {:plugins  [[jonase/eastwood "1.4.0"]]
                          :eastwood {:exclude-namespaces ~(cond-> '[clojure.alpha.spec


### PR DESCRIPTION
* Improve clj-kondo setup
  * Prefer the official lein-clj-kondo plugin
  * Use and cache the clj-kondo analysis
* Makefile: cache `spec2` directory
* Add a repl helper with enrich-classpath
  * Follows https://github.com/clojure-emacs/enrich-classpath#any-lein-or-toolsdeps-project
  * Paricularly needed for Orchard development.

Cheers - V