### PR TITLE
Rework java `:doc`

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,8 +1,10 @@
-{:output {:progress true
-          :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj"]}
- :linters {:unused-private-var {:level :warning
-                                :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
-           :consistent-alias {:aliases {clojure.string string}}
-           ;; Enable this opt-in linter:
-           :unsorted-required-namespaces
-           {:level :warning}}}
+{:output            {:progress      true
+                     :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj"]}
+ :config-in-comment {:linters {:unused-value         {:level :off}
+                               :unresolved-namespace {:level :off}}}
+ :linters           {:unused-private-var {:level   :warning
+                                          :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
+                     :consistent-alias   {:aliases {clojure.string string}}
+                     ;; Enable this opt-in linter:
+                     :unsorted-required-namespaces
+                     {:level :warning}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#189](https://github.com/clojure-emacs/orchard/issues/179): `info` for Java: return extra `:doc`-related attributes, as reflected in the new `orchard.java.parser-next` namespace, allowing clients to render HTML and non-HTML fragments with precision.
+  * This namespace needs the `--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED` JVM flag to be present, otherwise a fallback will be used.
+  * ([enrich-classpath](https://github.com/clojure-emacs/enrich-classpath) adds that flag when suitable)
+
 ### Bugs fixed
 
 * [#182](https://github.com/clojure-emacs/orchard/issues/182): `info` on ClojureScript: don't mistakenly prioritize special form names over var names.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl .EXPORT_ALL_VARIABLES
+.PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl lint .EXPORT_ALL_VARIABLES
 .DEFAULT_GOAL := install
 
 HOME=$(shell echo $$HOME)
@@ -37,6 +37,8 @@ cljfmt:
 
 kondo: .make_kondo_prep clean
 	lein with-profile -dev,+test,+clj-kondo,+deploy clj-kondo
+
+lint: kondo cljfmt eastwood
 
 # Deployment is performed via CI by creating a git tag prefixed with "v".
 # Please do not deploy locally as it skips various measures.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LEIN_PROFILES ?= "+dev,+test,+1.11"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.
-ENRICH_CLASSPATH_VERSION="1.16.0"
+ENRICH_CLASSPATH_VERSION="1.17.0"
 
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPEC2_SOURCE_DIR = src-spec-alpha-2
 # Feel free to upgrade this, or to override it with an env var named LEIN_PROFILES.
 # Expected format: "+dev,+test"
 # Don't use spaces here.
-LEIN_PROFILES ?= "+dev,+test,+1.11,+mark-enriched-classpath"
+LEIN_PROFILES ?= "+dev,+test,+1.11"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ cljfmt:
 .make_kondo_prep: project.clj .clj-kondo/config.edn
 	lein with-profile -dev,+test,+clj-kondo,+deploy clj-kondo --copy-configs --dependencies --parallel --lint '$$classpath' > $@
 
-kondo: .make_kondo_prep
+kondo: .make_kondo_prep clean
 	lein with-profile -dev,+test,+clj-kondo,+deploy clj-kondo
 
 # Deployment is performed via CI by creating a git tag prefixed with "v".

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPEC2_SOURCE_DIR = src-spec-alpha-2
 # Feel free to upgrade this, or to override it with an env var named LEIN_PROFILES.
 # Expected format: "+dev,+test"
 # Don't use spaces here.
-LEIN_PROFILES ?= "+dev,+test,+1.11"
+LEIN_PROFILES ?= "+dev,+test,+1.11,+mark-enriched-classpath"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,9 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :jvm-opts ["-Dclojure.main.report=stderr"]
+  :jvm-opts ["-Dclojure.main.report=stderr"
+             "--add-opens"
+             "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"]
 
   :source-paths ["src" "src-jdk8" "src-newer-jdks"]
   :test-paths ~(cond-> ["test"]

--- a/project.clj
+++ b/project.clj
@@ -60,6 +60,8 @@
                                "-Dorchard.internal.has-enriched-classpath=false"]
                     :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
+             :mark-enriched-classpath {:jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]}
+
              :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.17.0"]]
                                 :middleware [cider.enrich-classpath/middleware]
                                 :jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]

--- a/project.clj
+++ b/project.clj
@@ -55,9 +55,12 @@
                                      "does-not-exist.jar"]
                     :java-source-paths ["test-java"]
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
-                    :jvm-opts ["-Dorchard.initialize-cache.silent=false"
-                               "-Dorchard.internal.test-suite-running=true"
-                               "-Dorchard.internal.has-enriched-classpath=false"]
+                    :jvm-opts
+                    ~(cond-> ["-Dorchard.initialize-cache.silent=false"
+                              "-Dorchard.internal.test-suite-running=true"
+                              "-Dorchard.internal.has-enriched-classpath=false"]
+                       (not jdk8?) (conj "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"))
+
                     :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
              :mark-enriched-classpath {:jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]}

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,7 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :jvm-opts ~(cond-> ["-Dclojure.main.report=stderr"]
-               (not jdk8?) (conj "--add-opens"
-                                 "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"))
+  :jvm-opts ["-Dclojure.main.report=stderr"]
 
   :source-paths ["src" "src-jdk8" "src-newer-jdks"]
   :test-paths ~(cond-> ["test"]
@@ -62,7 +60,7 @@
                                "-Dorchard.internal.has-enriched-classpath=false"]
                     :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
-             :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.16.0"]]
+             :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.17.0"]]
                                 :middleware [cider.enrich-classpath/middleware]
                                 :jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]
                                 :enrich-classpath {:shorten true}}

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,9 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :jvm-opts ["-Dclojure.main.report=stderr"
-             "--add-opens"
-             "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"]
+  :jvm-opts ~(cond-> ["-Dclojure.main.report=stderr"]
+               (not jdk8?) (conj "--add-opens"
+                                 "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"))
 
   :source-paths ["src" "src-jdk8" "src-newer-jdks"]
   :test-paths ~(cond-> ["test"]
@@ -84,12 +84,18 @@
              :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.07.13"]]}
 
              :eastwood  {:plugins  [[jonase/eastwood "1.4.0"]]
-                         :eastwood {:exclude-namespaces ~(cond-> '[clojure.alpha.spec
+                         :eastwood {:ignored-faults {:unused-ret-vals-in-try {orchard.java {:line 84}
+                                                                              orchard.java.parser-next-test true}}
+                                    :exclude-namespaces ~(cond-> '[clojure.alpha.spec
                                                                    clojure.alpha.spec.gen
                                                                    clojure.alpha.spec.impl
                                                                    clojure.alpha.spec.test]
                                                            jdk8?
-                                                           (conj 'orchard.java.parser)
+                                                           (conj 'orchard.java.parser
+                                                                 'orchard.java.parser-test
+                                                                 'orchard.java.parser-utils
+                                                                 'orchard.java.parser-next
+                                                                 'orchard.java.parser-next-test)
 
                                                            (or (not jdk8?)
                                                                (not (-> "TEST_PROFILES"

--- a/project.clj
+++ b/project.clj
@@ -57,17 +57,13 @@
                     ;; Initialize the cache verbosely, as usual, so that possible issues can be more easily diagnosed:
                     :jvm-opts
                     ~(cond-> ["-Dorchard.initialize-cache.silent=false"
-                              "-Dorchard.internal.test-suite-running=true"
-                              "-Dorchard.internal.has-enriched-classpath=false"]
+                              "-Dorchard.internal.test-suite-running=true"]
                        (not jdk8?) (conj "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"))
 
                     :source-paths ["test" "src-spec-alpha-2/src/main/clojure"]}
 
-             :mark-enriched-classpath {:jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]}
-
              :enrich-classpath {:plugins [[mx.cider/enrich-classpath "1.17.0"]]
                                 :middleware [cider.enrich-classpath/middleware]
-                                :jvm-opts ["-Dorchard.internal.has-enriched-classpath=true"]
                                 :enrich-classpath {:shorten true}}
 
              ;; Development tools

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -1,5 +1,9 @@
 (ns orchard.java.parser
-  "Source and docstring info for Java classes and members"
+  "Source and docstring info for Java classes and members.
+
+  Parses `:doc`s using Markdown.
+
+  This ns is automatically discarded if `orchard.java.parser-next` can be loaded."
   {:author "Jeff Valk"}
   (:require
    [clojure.java.io :as io]

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -1,17 +1,16 @@
 (ns orchard.java.parser
   "Source and docstring info for Java classes and members"
   {:author "Jeff Valk"}
-  (:refer-clojure :exclude [resolve])
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string])
+   [clojure.string :as string]
+   [orchard.java.parser-utils :refer [Parsed module-name parse-info* parse-java position source-path typesym]])
   (:import
-   (java.io StringReader StringWriter)
-   (javax.lang.model.element Element ElementKind ExecutableElement TypeElement VariableElement)
+   (java.io StringReader)
+   (javax.lang.model.element Element ElementKind TypeElement)
    (javax.swing.text.html HTML$Tag HTMLEditorKit$ParserCallback)
    (javax.swing.text.html.parser ParserDelegator)
-   (javax.tools ToolProvider)
-   (jdk.javadoc.doclet Doclet DocletEnvironment)))
+   (jdk.javadoc.doclet DocletEnvironment)))
 
 ;;; ## JDK Compatibility
 ;;
@@ -55,40 +54,6 @@
 ;;    "--patch-module" option. To accommodate this, the jar file entry is
 ;;    written to a temp file and passed to the compiler from disk. Design-wise,
 ;;    this is admittedly imperfect, but the performance cost is low and it works.
-
-(def result (atom nil))
-
-(defn parse-java
-  "Load and parse the resource path, returning a `DocletEnvironment` object."
-  [path module]
-  (when-let [res (io/resource path)]
-    (let [tmpdir   (System/getProperty "java.io.tmpdir")
-          tmpfile  (io/file tmpdir (.getName (io/file path)))
-          compiler (ToolProvider/getSystemDocumentationTool)
-          sources  (-> (.getStandardFileManager compiler nil nil nil)
-                       (.getJavaFileObjectsFromFiles [tmpfile]))
-          doclet   (class (reify Doclet
-                            (init [_this _ _]
-                              (reset! result nil))
-
-                            (run [_this root]
-                              (reset! result root)
-                              true)
-
-                            (getSupportedOptions [_this]
-                              #{})))
-          out      (StringWriter.) ; discard compiler messages
-          opts     (apply conj ["--show-members" "private"
-                                "--show-types" "private"
-                                "--show-packages" "all"
-                                "--show-module-contents" "all"
-                                "-quiet"]
-                          (when module
-                            ["--patch-module" (str module "=" tmpdir)]))]
-      (spit tmpfile (slurp res))
-      (.call (.getTask compiler out nil nil doclet opts sources))
-      (.delete tmpfile)
-      @result)))
 
 ;;; ## Docstring Parsing
 ;;
@@ -201,34 +166,6 @@
 ;; as produced by `orchard.java/reflect-info`: class members
 ;; are indexed first by name, then argument types.
 
-(defn typesym
-  "Using parse tree info, return the type's name equivalently to the `typesym`
-  function in `orchard.java`."
-  ([n ^DocletEnvironment env]
-   (let [t (string/replace (str n) #"<.*>" "") ; drop generics
-         util (.getElementUtils env)]
-     (if-let [c (.getTypeElement util t)]
-       (let [pkg (str (.getPackageOf util c) ".")
-             cls (-> (string/replace-first t pkg "")
-                     (string/replace "." "$"))]
-         (symbol (str pkg cls))) ; classes
-       (symbol t)))))            ; primitives
-
-(defn position
-  "Get line and column of `Element` e using parsed source information in env"
-  [e ^DocletEnvironment env]
-  (let [trees (.getDocTrees env)]
-    (when-let [path (.getPath trees e)]
-      (let [file (.getCompilationUnit path)
-            lines (.getLineMap file)
-            pos (.getStartPosition (.getSourcePositions trees)
-                                   file (.getLeaf path))]
-        {:line (.getLineNumber lines pos)
-         :column (.getColumnNumber lines pos)}))))
-
-(defprotocol Parsed
-  (parse-info* [o env]))
-
 (defn parse-info
   [o env]
   (merge (parse-info* o env)
@@ -236,20 +173,6 @@
          (position o env)))
 
 (extend-protocol Parsed
-  ExecutableElement ; => method, constructor
-  (parse-info* [m env]
-    {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
-             (-> m .getEnclosingElement (typesym env)) ; class name
-             (-> m .getSimpleName str symbol))         ; method name
-     :type (-> m .getReturnType (typesym env))
-     :argtypes (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))
-     :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))})
-
-  VariableElement ; => field, enum constant
-  (parse-info* [f env]
-    {:name (-> f .getSimpleName str symbol)
-     :type (-> f .asType (typesym env))})
-
   TypeElement ; => class, interface, enum
   (parse-info* [c env]
     {:class   (typesym c env)
@@ -265,30 +188,6 @@
                    (reduce (fn [ret [n ms]]
                              (assoc ret n (zipmap (map :argtypes ms) ms)))
                            {}))}))
-
-(defn- resolve
-  "Workaround for CLJ-1403, fixed in Clojure 1.10. Once 1.9 support is
-  discontinued, this function may simply be removed."
-  [sym]
-  (try (clojure.core/resolve sym)
-       (catch Exception _)))
-
-(defn module-name
-  "Return the module name, or nil if modular"
-  [klass]
-  (some-> klass ^Class resolve .getModule .getName))
-
-(defn source-path
-  "Return the relative `.java` source path for the top-level class."
-  [klass]
-  (when-let [^Class cls (resolve klass)]
-    (let [path (-> (.getName cls)
-                   (string/replace #"\$.*" "")
-                   (string/replace "." "/")
-                   (str ".java"))]
-      (if-let [module (-> cls .getModule .getName)]
-        (str module "/" path)
-        path))))
 
 (def lock (Object.))
 

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -266,18 +266,3 @@
       (catch Throwable e
         (when (= "true" (System/getProperty "orchard.internal.test-suite-running"))
           (throw e))))))
-
-(comment
-  (do
-    (source-info `String)
-    Thread/sleep
-    (-> (source-info `Thread)
-        (get-in [:members 'sleep ['long] :doc-fragments])
-        (clojure.pprint/pprint))
-
-    ;; XXX
-    Thread/sleep ;; has params, not rendered
-    Thread/onSpinWait ;; has @code inside <pre>, should be unwrapped
-    nil))
-
-;; a good unit test: every present doc for string and thread has doc-fragments counterpart

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -1,5 +1,12 @@
 (ns orchard.java.parser-next
-  "Source and docstring info for Java classes and members"
+  "Source and docstring info for Java classes and members.
+
+  Leaves `:doc` untouched.
+
+  Adds `:doc-fragments` and `:doc-first-sentence-fragments` attributes.
+  Both represent sequences of 'fragments', which can be of text or html type.
+  Clients are expected them to render the html fragments using a client-specific method,
+  and then join the client-processed by a newline."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string]

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -18,13 +18,13 @@
 
 (defn dispatch [node _stack _found-closing-tags-types]
   (cond
-    (-> node class (= com.sun.tools.javac.tree.DCTree$DCParam))
+    (instance? com.sun.tools.javac.tree.DCTree$DCParam node)
     ::param
 
-    (-> node class (= com.sun.tools.javac.tree.DCTree$DCThrows))
+    (instance? com.sun.tools.javac.tree.DCTree$DCThrows node)
     ::throws
 
-    (-> node class (= com.sun.tools.javac.tree.DCTree$DCReturn))
+    (instance? com.sun.tools.javac.tree.DCTree$DCReturn node)
     ::return
 
     (->> node class ancestors (some #{com.sun.tools.javac.tree.DCTree$DCBlockTag}))

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -137,18 +137,30 @@
     [(cond-> stack
        (not self-closing?)
        (conj v))
-     (if (and (= v "p")
-              self-closing?)
+     (cond
+       (and (= v "p")
+            self-closing?)
        [{:type "text"
          :content "\n"}]
+
+       (= v "a") ;; turn links into code
+       [{:type "html"
+         :content "<pre>"}]
+
+       :else
        [{:type "html"
          :content (str node)}])]))
 
-(defmethod process-node com.sun.tools.javac.tree.DCTree$DCEndElement [node stack _]
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCEndElement [^com.sun.tools.javac.tree.DCTree$DCEndElement node
+                                                                      stack
+                                                                      _]
   [(cond-> stack
      (seq stack) pop)
-   [{:type "html"
-     :content (str node)}]])
+   [(if (= (-> node .getName str (.equals "a")))
+      {:type "html"
+       :content "</a>"}
+      {:type "html"
+       :content (str node)})]])
 
 (defmethod process-node com.sun.tools.javac.tree.DCTree$DCText [node stack _]
   [stack (if (empty? stack)

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -20,7 +20,7 @@
     (-> node class (= com.sun.tools.javac.tree.DCTree$DCReturn))
     ::return
 
-    (->> node class ancestors (= com.sun.tools.javac.tree.DCTree$DCBlockTag))
+    (->> node class ancestors (some #{com.sun.tools.javac.tree.DCTree$DCBlockTag}))
     ::block-tag
 
     :else (class node)))
@@ -142,8 +142,7 @@
            [{:type "text"
              :content (str node)}]
            [{:type "html"
-             :content (str node)
-             :stack-here stack}])])
+             :content (str node)}])])
 
 (defmethod process-node com.sun.tools.javac.tree.DCTree$DCLink [^com.sun.tools.javac.tree.DCTree$DCLink node stack]
   [stack

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -110,17 +110,15 @@
              :content content}]
            [])]))))
 
-;; com.sun.tools.javac.tree.DCTree$DCUnknownInlineTag
-"{@jls 3.10.5}"
-
 (defmethod process-node com.sun.tools.javac.tree.DCTree$DCLiteral [^com.sun.tools.javac.tree.DCTree$DCLiteral node stack]
-  [stack
-   ;; if code:
-   [{:type "html"
-     :content (format "<pre>%s</pre> " (-> node .getBody .getBody))}]
-   ;; XXX
-   ;; else, tag as <b>, content as text
-   ])
+  (let [^String tag-name (-> node .getKind .tagName)
+        body (-> node .getBody .getBody)]
+    [stack
+     (if (-> tag-name (.equals "code"))
+       [{:type "html"
+         :content (format "<pre>%s</pre> " body)}]
+       [{:type "text"
+         :content body}])]))
 
 (defmethod process-node com.sun.tools.javac.tree.DCTree$DCStartElement [^com.sun.tools.javac.tree.DCTree$DCStartElement node
                                                                         stack]

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -156,7 +156,7 @@
                                                                       _]
   [(cond-> stack
      (seq stack) pop)
-   [(if (= (-> node .getName str (.equals "a")))
+   [(if (-> node .getName str (.equals "a"))
       {:type "html"
        :content "</a>"}
       {:type "html"

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -98,7 +98,9 @@
 
 (defmethod process-node ::block-tag [^com.sun.tools.javac.tree.DCTree$DCBlockTag node stack _]
   (let [tag-name (.getTagName node)]
-    (if (.equals tag-name "author")
+    (if (or (.equals tag-name "author")
+            (.equals tag-name "since")
+            (.equals tag-name "see"))
       ;; omit the tag - it makes the docstring larger on docstring UIs:
       [stack []]
       (let [tag-name (.getTagName node)

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -1,0 +1,432 @@
+(ns orchard.java.parser-next
+  "Source and docstring info for Java classes and members"
+  (:refer-clojure :exclude [resolve])
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string])
+  (:import
+   (java.io StringReader StringWriter)
+   (javax.lang.model.element Element ElementKind ExecutableElement TypeElement VariableElement)
+   (javax.swing.text.html HTML$Tag HTMLEditorKit$ParserCallback)
+   (javax.swing.text.html.parser ParserDelegator)
+   (javax.tools ToolProvider)
+   (jdk.javadoc.doclet Doclet DocletEnvironment)
+   com.sun.source.doctree.DocCommentTree))
+
+;; XXX extract utils
+;; XXX remove third+ newlines/ws
+
+;; XXX global
+(def result (atom nil))
+
+(defn parse-java
+  "Load and parse the resource path, returning a `DocletEnvironment` object."
+  [path module]
+  (when-let [res (io/resource path)]
+    (let [tmpdir   (System/getProperty "java.io.tmpdir")
+          tmpfile  (io/file tmpdir (.getName (io/file path)))
+          compiler (ToolProvider/getSystemDocumentationTool)
+          sources  (-> (.getStandardFileManager compiler nil nil nil)
+                       (.getJavaFileObjectsFromFiles [tmpfile]))
+          doclet   (class (reify Doclet
+                            (init [_this _ _]
+                              (reset! result nil))
+
+                            (run [_this root]
+                              (reset! result root)
+                              true)
+
+                            (getSupportedOptions [_this]
+                              #{})))
+          out      (StringWriter.) ; discard compiler messages
+          opts     (apply conj ["--show-members" "private"
+                                "--show-types" "private"
+                                "--show-packages" "all"
+                                "--show-module-contents" "all"
+                                "-quiet"]
+                          (when module
+                            ["--patch-module" (str module "=" tmpdir)]))]
+      (spit tmpfile (slurp res))
+      (.call (.getTask compiler out nil nil doclet opts sources))
+      (.delete tmpfile)
+      @result)))
+
+;;; ## Docstring Parsing
+;;
+
+(def the-block-class ;; XXX try/catch
+  com.sun.tools.javac.tree.DCTree$DCBlockTag)
+
+;; The HTML parser and DTD classes are in the `javax.swing` package, and have
+;; internal references to the `sun.awt.AppContext` class. On Mac OS X, any use
+;; of this class causes a stray GUI window to pop up. Setting the system
+;; property below prevents this. We only set the property if it
+;; hasn't already been explicitly set.
+(when (nil? (System/getProperty "apple.awt.UIElement"))
+  (System/setProperty "apple.awt.UIElement" "true"))
+
+(defn dispatch [node stack]
+  (cond
+    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCParam"))
+    ::param
+
+    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCThrows"))
+    ::throws
+
+    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCReturn"))
+    ::return
+
+    (->> node class ancestors (filter class?) (map (fn [c]
+                                                     (.getName c)))
+         (some #{"com.sun.tools.javac.tree.DCTree$DCBlockTag"}))
+    ::block-tag
+    :else (class node)))
+
+(defmulti process-node #'dispatch
+  :default ::default)
+
+(defn node-reducer [{:keys [stack result]} node]
+  (let [[new-stack m] (process-node node stack)]
+    {:stack new-stack
+     :result (into result m)}))
+
+(def node-reducer-init {:stack []
+                        :result []})
+
+(def zz (atom []))
+
+(defmethod process-node ::default [node stack]
+  (swap! zz conj node)
+  [stack
+   [{:type "html"
+     :content (str node)}]])
+
+(comment
+  (-> @params first .getDescription))
+
+(def KO (atom nil))
+
+(def newline-fragment
+  "A newline intended to separate html fragments.
+  We choose text, because inserting <p> elements could unbalance the tags,
+  given that javadocs don't necessarily consistently choose self-closing tags."
+  {:type "text"
+   :content "\n"})
+
+(def nbsp "&nbsp;")
+
+(defmethod process-node ::param [^com.sun.tools.javac.tree.DCTree$DCParam node stack]
+  ;; (swap! paramsR conj)
+  (let [{:keys [stack result] :as x} (reduce node-reducer
+                                             {:stack stack
+                                              :result []}
+                                             (.getDescription node))]
+    (when (seq result)
+      (reset! KO x))
+    [stack
+     (reduce into [[newline-fragment
+                    {:type "html"
+                     :content (format "<i>Param</i>%s<>%s</pre>:%s" nbsp (.getName node) nbsp)}]
+                   result])]))
+
+(def params (atom []))
+
+(defmethod process-node ::return [^com.sun.tools.javac.tree.DCTree$DCReturn node stack]
+  (swap! params conj node)
+  (let [{:keys [stack result] :as x} (reduce node-reducer
+                                             {:stack stack
+                                              :result []}
+                                             (.getDescription node))]
+    (when (seq result)
+      (reset! KO x))
+    [stack
+     (reduce into [[newline-fragment
+                    {:type "html"
+                     :content (format "<i>Returns</i>:%s" nbsp)}]
+                   result])]))
+
+(def throws (atom []))
+
+(def throwsR (atom []))
+
+(defmethod process-node ::throws [ ;; ^com.sun.tools.javac.tree.DCTree$DCBlockTag
+                                  node stack]
+  (swap! throws conj node)
+  (let [{:keys [stack result]} (reduce node-reducer
+                                       {:stack stack
+                                        :result []}
+                                       (.getDescription node))]
+    [stack
+     (reduce into [[newline-fragment
+                    {:type "html"
+                     :content (format "<i>Throws</i>:%s<pre>%s</pre>:%s" nbsp (.getExceptionName node) nbsp)}]
+                   result])]))
+
+(def blocks (atom []))
+(defmethod process-node ::block-tag [ ;; ^com.sun.tools.javac.tree.DCTree$DCBlockTag
+                                     node stack]
+  (swap! blocks conj node)
+  (let [tag-name (.getTagName node)]
+    (if (.equals tag-name "author")
+      ;; omit the tag - it makes the docstring larger on docstring UIs:
+      [stack []]
+      (let [tag-name (.getTagName node)
+            s (string/replace (str node) #"^@" "")
+            [_ b] (string/split s (re-pattern tag-name))
+            content (when b
+                      (let [bt (string/trim b)]
+                        (case tag-name
+                          ("implNote" "jls") (format "<i>%s</i>: %s" tag-name bt)
+                          (format "<i>%s</i>: <pre>%s</pre>" tag-name bt))))]
+        [stack
+         (if content
+           [newline-fragment
+            {:type "html"
+             :content content}]
+           [])]))))
+
+;; com.sun.tools.javac.tree.DCTree$DCUnknownInlineTag
+"{@jls 3.10.5}"
+
+(def aa (atom []))
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCLiteral [node stack]
+  (swap! aa conj node)
+  [stack
+   ;; if code:
+   [{:type "html"
+     :content (format "<pre>%s</pre> "(-> node .getBody .getBody))}]
+   ;; XXX
+   ;; else, tag as <b>, content as text
+   ])
+
+(def bb (atom []))
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCStartElement [node stack]
+  (swap! bb conj node)
+  (let [v (-> node .getName str)
+        self-closing? (or (.isSelfClosing node)
+                          ;; XXX only do this if no neighbor closing tag shares the same (-> node .getName str):
+                          (#{"p" "hr" "li"} v))]
+    [(cond-> stack
+       (not self-closing?)
+       (conj v))
+     (if (and (= v "p")
+              self-closing?)
+       [{:type "text"
+         :content "\n"}]
+       [{:type "html"
+         :content (str node)}])]))
+
+(def cc (atom []))
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCEndElement [node stack]
+  (swap! cc conj node)
+  [(cond-> stack
+     (seq stack) pop)
+   [{:type "html"
+     :content (str node)}]])
+
+(def dd (atom []))
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCText [node stack]
+  (swap! dd conj node)
+  [stack (if (empty? stack)
+           [{:type "text"
+             :content (str node)}]
+           [{:type "html"
+             :content (str node)
+             :stack-here stack}])])
+
+(def ee (atom []))
+(defmethod process-node com.sun.tools.javac.tree.DCTree$DCLink [node stack]
+  (swap! ee conj node)
+  [stack
+   [{:type "html"
+     :content (format "<pre>%s</pre> "(-> node .getReference .getSignature))}]])
+
+(def C (atom nil))
+
+(defn coalesce [xs]
+  (reduce (fn [acc {next-type :type next-content :content :as next-item}]
+            (let [{prev-type :type prev-content :content} (peek acc)]
+              (if (= prev-type next-type)
+                (update-in acc [(dec (count acc)) :content] str " " next-content)
+                (conj acc next-item))))
+          []
+          (into []
+                (remove (comp empty? :content))
+                xs)))
+
+
+(def mkmk (atom []))
+
+(comment
+  (->> @mkmk
+       (filter (every-pred (comp seq :full-body) (comp seq :block-tags)))
+       last
+       vals
+       (apply into)
+       (coalesce)))
+
+(defn docstring
+  "Get parsed docstring text of `e` using source information in env"
+  [^Element e ^DocletEnvironment env]
+  (let [^DocCommentTree comment-tree (some-> env
+                                             .getDocTrees
+                                             (.getDocCommentTree e))
+        full-body (some->> comment-tree
+                           .getFullBody
+                           (reduce node-reducer node-reducer-init)
+                           :result)
+        block-tags (some->> comment-tree
+                            .getBlockTags
+                            (reduce node-reducer node-reducer-init)
+                            :result)
+        first-sentence (some->> comment-tree
+                                .getFirstSentence
+                                (reduce node-reducer node-reducer-init)
+                                :result)]
+    (swap! mkmk conj {:full-body full-body :block-tags block-tags})
+    {:doc (some-> env .getElementUtils (.getDocComment e))
+     :doc-first-sentence-fragments (coalesce first-sentence)
+     :doc-fragments (coalesce (into full-body block-tags))}))
+
+;;; ## Java Parse Tree Traversal
+;;
+;; From the parse tree returned by the compiler, create a nested map structure
+;; as produced by `orchard.java/reflect-info`: class members
+;; are indexed first by name, then argument types.
+
+(defn typesym
+  "Using parse tree info, return the type's name equivalently to the `typesym`
+  function in `orchard.java`."
+  ([n ^DocletEnvironment env]
+   (let [t (string/replace (str n) #"<.*>" "") ; drop generics
+         util (.getElementUtils env)]
+     (if-let [c (.getTypeElement util t)]
+       (let [pkg (str (.getPackageOf util c) ".")
+             cls (-> (string/replace-first t pkg "")
+                     (string/replace "." "$"))]
+         (symbol (str pkg cls))) ; classes
+       (symbol t)))))            ; primitives
+
+(defn position
+  "Get line and column of `Element` e using parsed source information in env"
+  [e ^DocletEnvironment env]
+  (let [trees (.getDocTrees env)]
+    (when-let [path (.getPath trees e)]
+      (let [file (.getCompilationUnit path)
+            lines (.getLineMap file)
+            pos (.getStartPosition (.getSourcePositions trees)
+                                   file (.getLeaf path))]
+        {:line (.getLineNumber lines pos)
+         :column (.getColumnNumber lines pos)}))))
+
+(defprotocol Parsed
+  (parse-info* [o env]))
+
+(defn parse-info
+  [o env]
+  (merge (parse-info* o env)
+         (docstring o env)
+         (position o env)))
+
+(extend-protocol Parsed
+  ExecutableElement ; => method, constructor
+  (parse-info* [m env]
+    {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
+             (-> m .getEnclosingElement (typesym env)) ; class name
+             (-> m .getSimpleName str symbol))         ; method name
+     :type (-> m .getReturnType (typesym env))
+     :argtypes (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))
+     :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))})
+
+  VariableElement ; => field, enum constant
+  (parse-info* [f env]
+    {:name (-> f .getSimpleName str symbol)
+     :type (-> f .asType (typesym env))})
+
+  TypeElement ; => class, interface, enum
+  (parse-info* [c env]
+    {:class   (typesym c env)
+     :members (->> (.getEnclosedElements c)
+                   (filter #(#{ElementKind/CONSTRUCTOR
+                               ElementKind/METHOD
+                               ElementKind/FIELD
+                               ElementKind/ENUM_CONSTANT}
+                             (.getKind ^Element %)))
+                   (map #(parse-info % env))
+                   ;; Index by name, argtypes. Args for fields are nil.
+                   (group-by :name)
+                   (reduce (fn [ret [n ms]]
+                             (assoc ret n (zipmap (map :argtypes ms) ms)))
+                           {}))}))
+
+(defn- resolve
+  "Workaround for CLJ-1403, fixed in Clojure 1.10. Once 1.9 support is
+  discontinued, this function may simply be removed."
+  [sym]
+  (try (clojure.core/resolve sym)
+       (catch Exception _)))
+
+(defn module-name
+  "Return the module name, or nil if modular"
+  [klass]
+  (some-> klass ^Class resolve .getModule .getName))
+
+(defn source-path
+  "Return the relative `.java` source path for the top-level class."
+  [klass]
+  (when-let [^Class cls (resolve klass)]
+    (let [path (-> (.getName cls)
+                   (string/replace #"\$.*" "")
+                   (string/replace "." "/")
+                   (str ".java"))]
+      (if-let [module (-> cls .getModule .getName)]
+        (str module "/" path)
+        path))))
+
+(def lock (Object.))
+
+(defn source-info
+  "If the source for the Java class is available on the classpath, parse it
+  and return info to supplement reflection. Specifically, this includes source
+  file and position, docstring, and argument name info. Info returned has the
+  same structure as that of `orchard.java/reflect-info`."
+  [klass]
+  {:pre [(symbol? klass)]}
+  (locking lock ;; the jdk.javadoc.doclet classes aren't meant for concurrent modification/access.
+    (try
+      (when-let [path (source-path klass)]
+        (when-let [^DocletEnvironment root (parse-java path (module-name klass))]
+          (try
+            (let [path-resource (io/resource path)]
+              (assoc (->> (.getIncludedElements root)
+                          (filter #(#{ElementKind/CLASS
+                                      ElementKind/INTERFACE
+                                      ElementKind/ENUM}
+                                    (.getKind ^Element %)))
+                          (map #(parse-info % root))
+                          (filter #(= klass (:class %)))
+                          (first))
+                     ;; relative path on the classpath
+                     :file path
+                     ;; Legacy key. Please do not remove - we don't do breaking changes!
+                     :path (.getPath path-resource)
+                     ;; Full URL, e.g. file:.. or jar:...
+                     :resource-url path-resource))
+            (finally (.close (.getJavaFileManager root))))))
+      (catch Throwable _ (throw _)))))
+
+(comment
+
+  (do
+    (source-info `String)
+    Thread/sleep
+    (-> (source-info `Thread)
+        (get-in [:members 'sleep ['long] :doc-fragments])
+        (clojure.pprint/pprint ))
+
+    ;; XXX
+    Thread/sleep ;; has params, not rendered
+    Thread/onSpinWait ;; has @code inside <pre>, should be unwrapped
+    nil))
+
+;; a good unit test: every present doc for string and thread has doc-fragments counterpart

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -158,7 +158,7 @@
      (seq stack) pop)
    [(if (-> node .getName str (.equals "a"))
       {:type "html"
-       :content "</a>"}
+       :content "</pre>"}
       {:type "html"
        :content (str node)})]])
 

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -13,19 +13,18 @@
 
 (defn dispatch [node _stack]
   (cond
-    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCParam"))
+    (-> node class (= com.sun.tools.javac.tree.DCTree$DCParam))
     ::param
 
-    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCThrows"))
+    (-> node class (= com.sun.tools.javac.tree.DCTree$DCThrows))
     ::throws
 
-    (-> node class .getName (= "com.sun.tools.javac.tree.DCTree$DCReturn"))
+    (-> node class (= com.sun.tools.javac.tree.DCTree$DCReturn))
     ::return
 
-    (->> node class ancestors (filter class?) (map (fn [^Class c]
-                                                     (.getName c)))
-         (some #{"com.sun.tools.javac.tree.DCTree$DCBlockTag"}))
+    (->> node class ancestors (= com.sun.tools.javac.tree.DCTree$DCBlockTag))
     ::block-tag
+
     :else (class node)))
 
 (defmulti process-node #'dispatch
@@ -239,9 +238,9 @@
                      ;; Full URL, e.g. file:.. or jar:...
                      :resource-url path-resource))
             (finally (.close (.getJavaFileManager root))))))
-      (catch Throwable _
-        ;; for debugging for now
-        #_(throw _)))))
+      (catch Throwable e
+        (when (= "true" (System/getProperty "orchard.internal.test-suite-running"))
+          (throw e))))))
 
 (comment
   (do

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -69,7 +69,7 @@
     [stack
      (reduce into [] [[newline-fragment
                        {:type "html"
-                        :content (format "<i>Param</i>%s<>%s</pre>:%s" nbsp (.getName node) nbsp)}]
+                        :content (format "<i>Param</i>%s<pre>%s</pre>:%s" nbsp (.getName node) nbsp)}]
                       result])]))
 
 (defmethod process-node ::return [^com.sun.tools.javac.tree.DCTree$DCReturn node stack found-closing-tags-types]

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -18,6 +18,7 @@
 
   Fragments of \"text\" type have significant, carefully processed leading/trailing whitespace
   such that when joining all fragments, things will look correct without having to add any extra whitespace."
+  {:added "0.15.0"}
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string]

--- a/src-newer-jdks/orchard/java/parser_utils.clj
+++ b/src-newer-jdks/orchard/java/parser_utils.clj
@@ -1,4 +1,6 @@
 (ns orchard.java.parser-utils
+  "The common parts to the `parser` and `parser-next` namespaces."
+  {:added "0.15.0"}
   (:refer-clojure :exclude [resolve])
   (:require
    [clojure.java.io :as io]

--- a/src-newer-jdks/orchard/java/parser_utils.clj
+++ b/src-newer-jdks/orchard/java/parser_utils.clj
@@ -1,0 +1,117 @@
+(ns orchard.java.parser-utils
+  (:refer-clojure :exclude [resolve])
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as string])
+  (:import
+   (java.io StringWriter)
+   (javax.lang.model.element ElementKind ExecutableElement VariableElement)
+   (javax.tools ToolProvider)
+   (jdk.javadoc.doclet Doclet DocletEnvironment)))
+
+(def result (atom nil))
+
+(defn parse-java
+  "Load and parse the resource path, returning a `DocletEnvironment` object."
+  [path module]
+  (when-let [res (io/resource path)]
+    (let [tmpdir   (System/getProperty "java.io.tmpdir")
+          tmpfile  (io/file tmpdir (.getName (io/file path)))
+          compiler (ToolProvider/getSystemDocumentationTool)
+          sources  (-> (.getStandardFileManager compiler nil nil nil)
+                       (.getJavaFileObjectsFromFiles [tmpfile]))
+          doclet   (class (reify Doclet
+                            (init [_this _ _]
+                              (reset! result nil))
+
+                            (run [_this root]
+                              (reset! result root)
+                              true)
+
+                            (getSupportedOptions [_this]
+                              #{})))
+          out      (StringWriter.) ; discard compiler messages
+          opts     (apply conj ["--show-members" "private"
+                                "--show-types" "private"
+                                "--show-packages" "all"
+                                "--show-module-contents" "all"
+                                "-quiet"]
+                          (when module
+                            ["--patch-module" (str module "=" tmpdir)]))]
+      (spit tmpfile (slurp res))
+      (.call (.getTask compiler out nil nil doclet opts sources))
+      (.delete tmpfile)
+      @result)))
+
+;;; ## Java Parse Tree Traversal
+;;
+;; From the parse tree returned by the compiler, create a nested map structure
+;; as produced by `orchard.java/reflect-info`: class members
+;; are indexed first by name, then argument types.
+
+(defn typesym
+  "Using parse tree info, return the type's name equivalently to the `typesym`
+  function in `orchard.java`."
+  ([n ^DocletEnvironment env]
+   (let [t (string/replace (str n) #"<.*>" "") ; drop generics
+         util (.getElementUtils env)]
+     (if-let [c (.getTypeElement util t)]
+       (let [pkg (str (.getPackageOf util c) ".")
+             cls (-> (string/replace-first t pkg "")
+                     (string/replace "." "$"))]
+         (symbol (str pkg cls))) ; classes
+       (symbol t)))))            ; primitives
+
+(defn position
+  "Get line and column of `Element` e using parsed source information in env"
+  [e ^DocletEnvironment env]
+  (let [trees (.getDocTrees env)]
+    (when-let [path (.getPath trees e)]
+      (let [file (.getCompilationUnit path)
+            lines (.getLineMap file)
+            pos (.getStartPosition (.getSourcePositions trees)
+                                   file (.getLeaf path))]
+        {:line (.getLineNumber lines pos)
+         :column (.getColumnNumber lines pos)}))))
+
+(defprotocol Parsed
+  (parse-info* [o env]))
+
+(extend-protocol Parsed
+  ExecutableElement ; => method, constructor
+  (parse-info* [m env]
+    {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
+             (-> m .getEnclosingElement (typesym env)) ; class name
+             (-> m .getSimpleName str symbol))         ; method name
+     :type (-> m .getReturnType (typesym env))
+     :argtypes (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))
+     :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))})
+
+  VariableElement ; => field, enum constant
+  (parse-info* [f env]
+    {:name (-> f .getSimpleName str symbol)
+     :type (-> f .asType (typesym env))}))
+
+(defn- resolve
+  "Workaround for CLJ-1403, fixed in Clojure 1.10. Once 1.9 support is
+  discontinued, this function may simply be removed."
+  [sym]
+  (try (clojure.core/resolve sym)
+       (catch Exception _)))
+
+(defn module-name
+  "Return the module name, or nil if modular"
+  [klass]
+  (some-> klass ^Class resolve .getModule .getName))
+
+(defn source-path
+  "Return the relative `.java` source path for the top-level class."
+  [klass]
+  (when-let [^Class cls (resolve klass)]
+    (let [path (-> (.getName cls)
+                   (string/replace #"\$.*" "")
+                   (string/replace "." "/")
+                   (str ".java"))]
+      (if-let [module (-> cls .getModule .getName)]
+        (str module "/" path)
+        path))))

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -403,9 +403,12 @@
                                       (javadoc-base-urls 11))))))
       path))
 
+(defn- imported-classes [ns-sym]
+  (->> (ns-imports ns-sym)
+       (map #(-> % ^Class val .getName symbol))))
+
 (defn- initialize-cache!* []
-  (doseq [class (->> (ns-imports 'clojure.core)
-                     (map #(-> % ^Class val .getName symbol)))]
+  (doseq [class (imported-classes (symbol (namespace ::_)))]
     (class-info class)))
 
 (def initialize-cache-silently?

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -10,7 +10,7 @@
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)
   (deftest source-info-test
-    (is (class? DummyClass))
+    (assert (class? DummyClass))
 
     (testing "file on the filesystem"
       (is (= '{:file "orchard/java/DummyClass.java",

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -1,5 +1,6 @@
 (ns orchard.java.parser-next-test
   (:require
+   [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [orchard.java :as java]
    [orchard.java.parser-next :as sut]
@@ -89,7 +90,27 @@
            (-> `Thread
                sut/source-info
                (get-in [:members 'holdsLock '[java.lang.Object] :doc-fragments 5])))
-        "Formats params correctly")))
+        "Formats params correctly")
+
+    (is (= {:content "<i>Param</i>&nbsp;<pre>obj</pre>:&nbsp;", :type "html"}
+           (-> `Thread
+               sut/source-info
+               (get-in [:members 'holdsLock '[java.lang.Object] :doc-fragments 5])))
+        "Formats params correctly")
+
+    (let [fragments (-> `String
+                        sut/source-info
+                        (get-in [:members
+                                 'format
+                                 ['java.util.Locale 'java.lang.String (symbol "java.lang.Object[]")]
+                                 :doc-fragments])
+                        (->> (map :content)))
+          s (string/join fragments)]
+      (assert (seq fragments))
+      (testing "Flattens links, since they can't be clicked from most Orchard clients"
+        (testing s
+          (is (not (string/includes? s "<a")))
+          (is (not (string/includes? s "<a href"))))))))
 
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -1,17 +1,14 @@
 (ns orchard.java.parser-next-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [orchard.java :as java]
    [orchard.java.parser-next :as sut]
    [orchard.test.util :as util])
   (:import
    (orchard.java DummyClass)))
 
 (when (and util/has-enriched-classpath?
-           (try
-             (Class/forName "com.sun.tools.javac.tree.DCTree$DCBlockTag")
-             true
-             (catch Throwable _
-               false)))
+           java/parser-next-available?)
   (deftest source-info-test
     (is (class? DummyClass))
 

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -21,9 +21,7 @@
                :line 12,
                :class orchard.java.DummyClass,
                :doc-fragments
-               [{:type "text", :content "Class level docstring.
-
-"}
+               [{:type "text", :content "Class level docstring.\n\n"}
                 {:type "html",
                  :content
                  "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>"}],
@@ -38,6 +36,7 @@
                   :line 12,
                   :argnames [],
                   :doc-fragments [],
+                  :doc-block-tags-fragments [],
                   :doc nil}},
                 dummyMethod
                 {[]
@@ -50,23 +49,16 @@
                   :line 18,
                   :argnames [],
                   :doc-fragments
-                  [{:type "text", :content "Method-level docstring.
-
-"}
+                  [{:type "text", :content "Method-level docstring."}],
+                  :doc-block-tags-fragments
+                  [{:type "text", :content "\n"}
                    {:type "html",
                     :content "<i>returns</i>: <pre>the string \"hello\"</pre>"}],
                   :doc
-                  "Method-level docstring.
-
- @returns the string \"hello\""}}},
+                  "Method-level docstring.\n\n @returns the string \"hello\""}}},
+               :doc-block-tags-fragments [],
                :doc
-               "Class level docstring.
-
- <pre>
-   DummyClass dc = new DummyClass();
- </pre>
-
- @author Arne Brasseur"}
+               "Class level docstring.\n\n <pre>\n   DummyClass dc = new DummyClass();\n </pre>\n\n @author Arne Brasseur"}
              (dissoc (sut/source-info 'orchard.java.DummyClass)
                      :path
                      :resource-url))))
@@ -81,26 +73,28 @@
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)
   (deftest doc-fragments-test
-    (is (= [{:content "Returns an estimate of the number of active threads in the current\n thread's ", :type "text"}
-            {:content "<pre>java.lang.ThreadGroup</pre> ", :type "html"}
-            {:content " and its\n subgroups. Recursively iterates over all subgroups in the current\n thread's thread group.\n\nThe value returned is only an estimate because the number of\n threads may change dynamically while this method traverses internal\n data structures, and might be affected by the presence of certain\n system threads. This method is intended primarily for debugging\n and monitoring purposes.\n\n", :type "text"}
-            {:content "<i>Returns</i>:&nbsp;", :type "html"}
-            {:content "an estimate of the number of active threads in the current\n          thread's thread group and in any other thread group that\n          has the current thread's thread group as an ancestor", :type "text"}]
+    (is (= [{:type "text",
+             :content
+             "Returns an estimate of the number of active threads in the current\nthread's "}
+            {:type "html", :content "<pre>java.lang.ThreadGroup</pre> "}
+            {:type "text",
+             :content
+             " and its\nsubgroups. Recursively iterates over all subgroups in the current\nthread's thread group.\n\nThe value returned is only an estimate because the number of\nthreads may change dynamically while this method traverses internal\ndata structures, and might be affected by the presence of certain\nsystem threads. This method is intended primarily for debugging\nand monitoring purposes."}]
            (-> `Thread
                sut/source-info
                (get-in [:members 'activeCount [] :doc-fragments])))
         "Returns a data structure with carefully managed whitespace location")
 
-    (is (= {:content "<i>Param</i>&nbsp;<pre>obj</pre>:&nbsp;", :type "html"}
-           (-> `Thread
-               sut/source-info
-               (get-in [:members 'holdsLock '[java.lang.Object] :doc-fragments 5])))
-        "Formats params correctly")
+    (is (some #{{:type "text", :content " permission as well as\n"}}
+              (-> `Thread
+                  sut/source-info
+                  (get-in [:members 'getAllStackTraces [] :doc-fragments])))
+        "A specific fragment starts with a single space and ends in a single newline")
 
     (is (= {:content "<i>Param</i>&nbsp;<pre>obj</pre>:&nbsp;", :type "html"}
            (-> `Thread
                sut/source-info
-               (get-in [:members 'holdsLock '[java.lang.Object] :doc-fragments 5])))
+               (get-in [:members 'holdsLock '[java.lang.Object] :doc-block-tags-fragments 1])))
         "Formats params correctly")
 
     (let [fragments (-> `String

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -83,7 +83,13 @@
            (-> `Thread
                sut/source-info
                (get-in [:members 'activeCount [] :doc-fragments])))
-        "Returns a data structure with carefully managed whitespace location")))
+        "Returns a data structure with carefully managed whitespace location")
+
+    (is (= {:content "<i>Param</i>&nbsp;<pre>obj</pre>:&nbsp;", :type "html"}
+           (-> `Thread
+               sut/source-info
+               (get-in [:members 'holdsLock '[java.lang.Object] :doc-fragments 5])))
+        "Formats params correctly")))
 
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -10,7 +10,7 @@
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)
   (deftest source-info-test
-    (assert (class? DummyClass))
+    (is (class? DummyClass))
 
     (testing "file on the filesystem"
       (is (= '{:file "orchard/java/DummyClass.java",

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -74,6 +74,19 @@
 
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)
+  (deftest doc-fragments-test
+    (is (= [{:content "Returns an estimate of the number of active threads in the current\n thread's ", :type "text"}
+            {:content "<pre>java.lang.ThreadGroup</pre> ", :type "html"}
+            {:content " and its\n subgroups. Recursively iterates over all subgroups in the current\n thread's thread group.\n\nThe value returned is only an estimate because the number of\n threads may change dynamically while this method traverses internal\n data structures, and might be affected by the presence of certain\n system threads. This method is intended primarily for debugging\n and monitoring purposes.\n\n", :type "text"}
+            {:content "<i>Returns</i>:&nbsp;", :type "html"}
+            {:content "an estimate of the number of active threads in the current\n          thread's thread group and in any other thread group that\n          has the current thread's thread group as an ancestor", :type "text"}]
+           (-> `Thread
+               sut/source-info
+               (get-in [:members 'activeCount [] :doc-fragments])))
+        "Returns a data structure with carefully managed whitespace location")))
+
+(when (and util/has-enriched-classpath?
+           java/parser-next-available?)
   (deftest smoke-test
     (let [annotations #{'java.lang.Override
                         'java.lang.Deprecated

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -23,8 +23,7 @@
                :line 12,
                :class orchard.java.DummyClass,
                :doc-fragments
-               [{:content "Class level docstring.\n\n "
-                 :type "text"}
+               [{:content "Class level docstring.", :type "text"}
                 {:content "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>",
                  :type "html"}],
                :members
@@ -32,29 +31,39 @@
                 {[]
                  {:name orchard.java.DummyClass,
                   :type void,
-                  :argtypes [],
-                  :argnames [],
-                  :doc nil,
+                  :doc-first-sentence-fragments [],
                   :column 8,
-                  :line 12}},
+                  :argtypes [],
+                  :line 12,
+                  :argnames [],
+                  :doc-fragments [],
+                  :doc nil}},
                 dummyMethod
                 {[]
                  {:name dummyMethod,
                   :type java.lang.String,
-                  :argtypes [],
-                  :argnames [],
-                  :doc "Method-level docstring. @returns the string \"hello\"",
+                  :doc-first-sentence-fragments
+                  [{:content "Method-level docstring.", :type "text"}],
                   :column 3,
-                  :line 18}}},
+                  :argtypes [],
+                  :line 18,
+                  :argnames [],
+                  :doc-fragments
+                  [{:content "Method-level docstring.", :type "text"}
+                   {:content "<i>returns</i>: <pre>the string \"hello\"</pre>",
+                    :type "html"}],
+                  :doc
+                  "Method-level docstring.
+
+ @returns the string \"hello\""}}},
                :doc
-               " Class level docstring.
+               "Class level docstring.
 
  <pre>
    DummyClass dc = new DummyClass();
  </pre>
 
- @author Arne Brasseur
-"}
+ @author Arne Brasseur"}
              (dissoc (sut/source-info 'orchard.java.DummyClass)
                      :path
                      :resource-url))))

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -1,0 +1,67 @@
+(ns orchard.java.parser-next-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [orchard.java.parser-next :as sut]
+   [orchard.test.util :as util])
+  (:import
+   (orchard.java DummyClass)))
+
+(when (and util/has-enriched-classpath?
+           (try
+             (Class/forName "com.sun.tools.javac.tree.DCTree$DCBlockTag")
+             true
+             (catch Throwable _
+               false)))
+  (deftest source-info-test
+    (is (class? DummyClass))
+
+    (testing "file on the filesystem"
+      (is (= '{:file "orchard/java/DummyClass.java",
+               :doc-first-sentence-fragments
+               [{:content "Class level docstring.", :type "text"}],
+               :column 1,
+               :line 12,
+               :class orchard.java.DummyClass,
+               :doc-fragments
+               [{:content "Class level docstring.\n\n "
+                 :type "text"}
+                {:content "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>",
+                 :type "html"}],
+               :members
+               {orchard.java.DummyClass
+                {[]
+                 {:name orchard.java.DummyClass,
+                  :type void,
+                  :argtypes [],
+                  :argnames [],
+                  :doc nil,
+                  :column 8,
+                  :line 12}},
+                dummyMethod
+                {[]
+                 {:name dummyMethod,
+                  :type java.lang.String,
+                  :argtypes [],
+                  :argnames [],
+                  :doc "Method-level docstring. @returns the string \"hello\"",
+                  :column 3,
+                  :line 18}}},
+               :doc
+               " Class level docstring.
+
+ <pre>
+   DummyClass dc = new DummyClass();
+ </pre>
+
+ @author Arne Brasseur
+"}
+             (dissoc (sut/source-info 'orchard.java.DummyClass)
+                     :path
+                     :resource-url))))
+
+    (testing "java file in a jar"
+      (let [rt-info (sut/source-info 'clojure.lang.RT)]
+        (is (= {:file "clojure/lang/RT.java"}
+               (select-keys rt-info [:file])))
+        (is (re-find #"jar:file:/.*/.m2/repository/org/clojure/clojure/.*/clojure-.*-sources.jar!/clojure/lang/RT.java"
+                     (str (:resource-url rt-info))))))))

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -16,14 +16,17 @@
     (testing "file on the filesystem"
       (is (= '{:file "orchard/java/DummyClass.java",
                :doc-first-sentence-fragments
-               [{:content "Class level docstring.", :type "text"}],
+               [{:type "text", :content "Class level docstring."}],
                :column 1,
                :line 12,
                :class orchard.java.DummyClass,
                :doc-fragments
-               [{:content "Class level docstring.", :type "text"}
-                {:content "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>",
-                 :type "html"}],
+               [{:type "text", :content "Class level docstring.
+
+"}
+                {:type "html",
+                 :content
+                 "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>"}],
                :members
                {orchard.java.DummyClass
                 {[]
@@ -41,15 +44,17 @@
                  {:name dummyMethod,
                   :type java.lang.String,
                   :doc-first-sentence-fragments
-                  [{:content "Method-level docstring.", :type "text"}],
+                  [{:type "text", :content "Method-level docstring."}],
                   :column 3,
                   :argtypes [],
                   :line 18,
                   :argnames [],
                   :doc-fragments
-                  [{:content "Method-level docstring.", :type "text"}
-                   {:content "<i>returns</i>: <pre>the string \"hello\"</pre>",
-                    :type "html"}],
+                  [{:type "text", :content "Method-level docstring.
+
+"}
+                   {:type "html",
+                    :content "<i>returns</i>: <pre>the string \"hello\"</pre>"}],
                   :doc
                   "Method-level docstring.
 

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.java.parser-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [orchard.java.parser :as parser]
+   [orchard.java.parser :as sut]
    [orchard.test.util :as util])
   (:import
    (orchard.java DummyClass)))
@@ -39,11 +39,11 @@
               :resource-url (java.net.URL. (str "file:"
                                                 (System/getProperty "user.dir")
                                                 "/test-java/orchard/java/DummyClass.java"))}
-             (dissoc (parser/source-info 'orchard.java.DummyClass)
+             (dissoc (sut/source-info 'orchard.java.DummyClass)
                      :path))))
 
     (testing "java file in a jar"
-      (let [rt-info (parser/source-info 'clojure.lang.RT)]
+      (let [rt-info (sut/source-info 'clojure.lang.RT)]
         (is (= {:file "clojure/lang/RT.java"}
                (select-keys rt-info [:file])))
         (is (re-find #"jar:file:/.*/.m2/repository/org/clojure/clojure/.*/clojure-.*-sources.jar!/clojure/lang/RT.java"

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -115,7 +115,8 @@
           m4 (member-info 'java.awt.Point 'x)
           m5 (member-info 'java.lang.Class 'forName)
           m6 (member-info 'java.util.AbstractMap 'finalize)
-          m7 (member-info 'java.util.HashMap 'finalize)]
+          m7 (member-info 'java.util.HashMap 'finalize)
+          m8 (member-info `Thread 'resume)]
       (testing "Member"
         (testing "source file"
           (is (string? (:file m1)))
@@ -138,7 +139,7 @@
         (testing "implemented on ancestor superclass"
           (is (not= 'java.lang.Object (:class m7)))
           (testing (-> m6 :doc pr-str)
-            (is (-> m6 :doc (string/starts-with? "Called by the garbage collector on an object when garbage collection "))
+            (is (-> m6 :doc (string/starts-with? "Called by the garbage collector on an object when garbage collection"))
                 "Contains doc that is clearly defined in Object (the superclass)")))
         (when sut/parser-next-available?
           (testing "Doc fragments"
@@ -147,8 +148,8 @@
               (is (seq (:doc-first-sentence-fragments m4))))
 
             (testing "For a method"
-              (is (seq (:doc-fragments m7)))
-              (is (seq (:doc-first-sentence-fragments m7))))))))))
+              (is (seq (:doc-fragments m8)))
+              (is (seq (:doc-first-sentence-fragments m8))))))))))
 
 (deftest arglists-test
   (let [+this (comp #{'this} first)]

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -55,7 +55,7 @@
 
 (deftest map-structure-test
   (testing "Parsed map structure = reflected map structure"
-    (let [cols #{:file :line :column :doc :argnames :doc-first-sentence-fragments :doc-fragments :argtypes :path :resource-url}
+    (let [cols #{:file :line :column :doc :argnames :doc-first-sentence-fragments :doc-fragments :doc-block-tags-fragments :argtypes :path :resource-url}
           keys= #(= (set (keys (apply dissoc %1 cols)))
                     (set (keys %2)))
           c1 (class-info* 'clojure.lang.Compiler)

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -4,7 +4,7 @@
    [clojure.java.javadoc :as javadoc]
    [clojure.string :as string]
    [clojure.test :refer [are deftest is testing]]
-   [orchard.java :refer [cache class-info class-info* javadoc-url jdk-tools member-info resolve-class resolve-javadoc-path resolve-member resolve-symbol resolve-type source-info]]
+   [orchard.java :as sut :refer [cache class-info class-info* javadoc-url jdk-tools member-info resolve-class resolve-javadoc-path resolve-member resolve-symbol resolve-type source-info]]
    [orchard.misc :as misc]
    [orchard.test.util :as util]))
 
@@ -80,7 +80,8 @@
   (deftest class-info-test
     (let [c1 (class-info 'clojure.lang.Agent)
           c2 (class-info 'clojure.lang.Range$BoundsCheck)
-          c3 (class-info 'not.actually.AClass)]
+          c3 (class-info 'not.actually.AClass)
+          thread-class-info (class-info `Thread)]
       (testing "Class"
         (testing "source file"
           (is (string? (:file c1)))
@@ -100,7 +101,11 @@
                 sym (symbol (.getName (class reified)))]
             (is (class-info sym))))
         (testing "that doesn't exist"
-          (is (nil? c3)))))))
+          (is (nil? c3))))
+      (when sut/parser-next-available?
+        (testing "Doc fragments"
+          (is (seq (:doc-fragments thread-class-info)))
+          (is (seq (:doc-first-sentence-fragments thread-class-info))))))))
 
 (when util/has-enriched-classpath?
   (deftest member-info-test
@@ -132,8 +137,18 @@
           (is (not= 'java.lang.Object (:class m6))))
         (testing "implemented on ancestor superclass"
           (is (not= 'java.lang.Object (:class m7)))
-          (is (-> m6 :doc (string/starts-with? "Called by the garbage collector on an object when garbage collection "))
-              "Contains doc that is clearly defined in Object (the superclass)"))))))
+          (testing (-> m6 :doc pr-str)
+            (is (-> m6 :doc (string/starts-with? "Called by the garbage collector on an object when garbage collection "))
+                "Contains doc that is clearly defined in Object (the superclass)")))
+        (when sut/parser-next-available?
+          (testing "Doc fragments"
+            (testing "For a field"
+              (is (seq (:doc-fragments m4)))
+              (is (seq (:doc-first-sentence-fragments m4))))
+
+            (testing "For a method"
+              (is (seq (:doc-fragments m7)))
+              (is (seq (:doc-first-sentence-fragments m7))))))))))
 
 (deftest arglists-test
   (let [+this (comp #{'this} first)]

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -55,7 +55,7 @@
 
 (deftest map-structure-test
   (testing "Parsed map structure = reflected map structure"
-    (let [cols #{:file :line :column :doc :argnames :argtypes :path :resource-url}
+    (let [cols #{:file :line :column :doc :argnames :doc-first-sentence-fragments :doc-fragments :argtypes :path :resource-url}
           keys= #(= (set (keys (apply dissoc %1 cols)))
                     (set (keys %2)))
           c1 (class-info* 'clojure.lang.Compiler)

--- a/test/orchard/test/util.clj
+++ b/test/orchard/test/util.clj
@@ -1,6 +1,6 @@
-(ns orchard.test.util)
+(ns orchard.test.util
+  (:require [clojure.java.io :as io]))
 
 (def has-enriched-classpath?
-  (let [v (System/getProperty "orchard.internal.has-enriched-classpath")]
-    (assert (#{"true" "false"} v))
-    (= "true" v)))
+  (boolean (or (io/resource "java/lang/Thread.java")
+               (io/resource "java.base/java/lang/Thread.java"))))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/orchard/issues/179

## Context

For Java stuff, we return `:doc` which is the parsed doc comments form the Java sources.

They're originally in a html-like markup language.

The existing approach parsed that html-like text with a HTML parser. Then, the HTML was converted to Markdown, which certainly does read more nicely.

However, that approach had a number of flaws:

* Newlines (not expressed as `<br>`, e.g. `\n`) were lost
  * I find this flaw critical - without newlines, docstrings won't look nice in a UI
    * e.g. eldoc trimming won't work properly.
  * There's no workaround for this, since the HTML parser we were using eats newlines before we can do anything with them.
* Tables were not aligned, which hindered their readability
* non-html bits like `@code`, `@since`, etc were not parsed at all
  * since that isn't html, the html parser could not help us at all, and would demand further bespoke solutions.

This is the state of things:

<img width="776" alt="image" src="https://github.com/clojure-emacs/orchard/assets/1162994/6a6b7e13-3a75-4535-b93d-fe224988809f">

## Proposed changes

* Stop parsing converting html to markdown
* Return the original doc comments under `:doc` - they're of interest (many IDEs _can_ render html) and a fallback if our alternatives fail.
* Parse the doc comments using the official 'doc comment' parser that is bundled with newer JDKs.
* Include two new keys:  `:doc-fragments`, `:doc-first-sentence-fragments`
  * Both represent the same thing - the latter is limited to the first sentence
  * Example value: `[{:content "Class level docstring.\n\n " :type "text"} {:content "<pre> foo </pre>", :type "html"}]`
  * These represent a succession (vector) of html and non-html content
  * Orchard clients can take this succession, and render the html parts with a renderer of choice, and then join all the fragments separated by a newline.

This is how things are looking after integrating my solution into cider-nrepl and cider.el:

![image (6)](https://github.com/clojure-emacs/orchard/assets/1162994/32856846-e74d-4d80-88d3-e026cd5655d8)

...I render the html fragments with [shr.el](https://github.com/emacs-mirror/emacs/blob/01ba4d6c5f9622ce861b53760ddd05b788e27c95/lisp/net/shr.el), which gives us table alignment, italics, bold, etc.

One also can custom-render things. For instance I can tell shr to render `<pre>` blocks with java-mode:

![image (7)](https://github.com/clojure-emacs/orchard/assets/1162994/f20d2bd6-2b99-4c93-bab6-ed4b19ba2f5d)

Cheers - V