### PR TITLE
`:doc-block-tags-fragments`: exclude unhandled tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## Changes
+
+* `:doc-block-tags-fragments`: exclude tags other than `Returns`, `Throws` and `Param`.
+  * This helps keeping the rendered docstrings concise, and predictably formatted.
+
 ## 0.15.0 (2023-09-20)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.15.1 (2023-09-21)
+
 ## Changes
 
 * `:doc-block-tags-fragments`: exclude tags other than `Returns`, `Throws` and `Param`.

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint: kondo cljfmt eastwood
 deploy: check-env clean
 	lein with-profile -user,-dev,+$(VERSION),-provided deploy clojars
 
-# Usage: PROJECT_VERSION=0.15.0 make install
+# Usage: PROJECT_VERSION=0.15.1 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.15.0"]
+[cider/orchard "0.15.1"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
@@ -156,7 +156,7 @@ make repl
 You can install Orchard locally like this:
 
 ```
-PROJECT_VERSION=0.15.0 make install
+PROJECT_VERSION=0.15.1 make install
 ```
 
 ...note that projects such as cider-nrepl or refactor-nrepl use copies of Orchard that are inlined with [mranderson](https://github.com/benedekfazekas/mranderson),

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                                 :enrich-classpath {:shorten true}}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.37.1"]
+             :dev {:plugins [[cider/cider-nrepl "0.38.0"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -40,7 +40,7 @@
     ::return
 
     (->> node class ancestors (some #{com.sun.tools.javac.tree.DCTree$DCBlockTag}))
-    ::block-tag
+    ::discard
 
     :else (class node)))
 
@@ -108,26 +108,9 @@
                         :content (format "<i>Throws</i>:%s<pre>%s</pre>:%s" nbsp (.getExceptionName node) nbsp)}]
                       result])]))
 
-(defmethod process-node ::block-tag [^com.sun.tools.javac.tree.DCTree$DCBlockTag node stack _]
-  (let [tag-name (.getTagName node)]
-    (if (or (.equals tag-name "author")
-            (.equals tag-name "since")
-            (.equals tag-name "see"))
-      ;; omit the tag - it makes the docstring larger on docstring UIs:
-      [stack []]
-      (let [tag-name (.getTagName node)
-            s (string/replace (str node) #"^@" "")
-            [_ b] (string/split s (re-pattern tag-name))
-            content (when-let [bt (some-> b string/trim)]
-                      (case tag-name
-                        ("implNote" "jls") (format "<i>%s</i>: %s" tag-name bt)
-                        (format "<i>%s</i>: <pre>%s</pre>" tag-name bt)))]
-        [stack
-         (if content
-           [newline-fragment
-            {:type "html"
-             :content content}]
-           [])]))))
+(defmethod process-node ::discard [_node stack _]
+  ;; omit the tag - it makes the docstring larger on docstring UIs:
+  [stack []])
 
 (defmethod process-node com.sun.tools.javac.tree.DCTree$DCLiteral [^com.sun.tools.javac.tree.DCTree$DCLiteral node stack _]
   (let [^String tag-name (-> node .getKind .tagName)

--- a/test-java/orchard/java/DummyClass.java
+++ b/test-java/orchard/java/DummyClass.java
@@ -10,12 +10,12 @@ package orchard.java;
  * @author Arne Brasseur
  */
 public class DummyClass {
-  /**
-   * Method-level docstring.
-   *
-   * @returns the string "hello"
-   */
-  public String dummyMethod() {
-    return "hello";
-  }
+    /**
+     * Method-level docstring.
+     *
+     * @return the string "hello"
+     */
+    public String dummyMethod() {
+        return "hello";
+    }
 }

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -44,18 +44,18 @@
                   :type java.lang.String,
                   :doc-first-sentence-fragments
                   [{:type "text", :content "Method-level docstring."}],
-                  :column 3,
+                  :column 5,
                   :argtypes [],
                   :line 18,
                   :argnames [],
                   :doc-fragments
                   [{:type "text", :content "Method-level docstring."}],
                   :doc-block-tags-fragments
-                  [{:type "text", :content "\n"}
-                   {:type "html",
-                    :content "<i>returns</i>: <pre>the string \"hello\"</pre>"}],
+                  [{:content "\n", :type "text"}
+                   {:content "<i>Returns</i>:&nbsp;", :type "html"}
+                   {:content "the string \"hello\"", :type "text"}],
                   :doc
-                  "Method-level docstring.\n\n @returns the string \"hello\""}}},
+                  "Method-level docstring.\n\n @return the string \"hello\""}}},
                :doc-block-tags-fragments [],
                :doc
                "Class level docstring.\n\n <pre>\n   DummyClass dc = new DummyClass();\n </pre>\n\n @author Arne Brasseur"}

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -28,9 +28,9 @@
                   :type java.lang.String,
                   :argtypes [],
                   :argnames [],
-                  :doc "Method-level docstring. @returns the string \"hello\"",
+                  :doc "Method-level docstring. @return the string \"hello\"",
                   :line 18,
-                  :column 3}}},
+                  :column 5}}},
               :doc
               "Class level docstring.\n\n```\n   DummyClass dc = new DummyClass();\n```\n\n@author Arne Brasseur",
               :line 12,


### PR DESCRIPTION
* `:doc-block-tags-fragments`: exclude unhandled tags
  * This helps keeping the rendered docstrings concise, and predictably formatted.
  * Fixes https://github.com/clojure-emacs/orchard/issues/188
* 0.15.1