### PR TITLE
Java source info: return `:formatted-arglists` when possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make --stop test
+                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make test
             # Eastwood is run for every item in the CI matrix, because its results are sensitive to the code in the runtime,
             # so we make the most out of this linter by exercising all profiles, JDK versions, etc.
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
         description: Will be used as part of the cache key. Especially important for unzipped-jdk-source
         type: string
       enrich_classpath:
-        description: Whether the enrich-classpath will be applied.
+        description: Whether enrich-classpath will be applied.
         type: string
       files:
         description: Files to consider when creating the cache key
@@ -160,7 +160,7 @@ jobs:
         description: Maps directly to the TEST_PROFILES var in Makefile
         type: string
       enrich_classpath:
-        description: Whether the enrich-classpath will be applied.
+        description: Whether enrich-classpath will be applied.
         type: string
     executor: << parameters.jdk_version >>
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ commands:
       clojure_version:
         description: Will be used as part of the cache key. Especially important for unzipped-jdk-source
         type: string
-      enrich_classpath:
-        description: Whether enrich-classpath will be applied.
+      parser_target:
+        description: The Java parser to be exercised
         type: string
       files:
         description: Files to consider when creating the cache key
@@ -131,7 +131,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          enrich_classpath: "false"
+          parser_target: "parser"
           cache_version: "util-job-v1"
           jdk_version: << parameters.jdk_version >>
           clojure_version: "1.11"
@@ -159,8 +159,8 @@ jobs:
       test_profiles:
         description: Maps directly to the TEST_PROFILES var in Makefile
         type: string
-      enrich_classpath:
-        description: Whether enrich-classpath will be applied.
+      parser_target:
+        description: The Java parser to be exercised
         type: string
     executor: << parameters.jdk_version >>
     environment:
@@ -171,12 +171,12 @@ jobs:
       - with_cache:
           jdk_version: << parameters.jdk_version >>
           clojure_version: << parameters.clojure_version >>
-          enrich_classpath: << parameters.enrich_classpath >>
+          parser_target: << parameters.parser_target >>
           cache_version: "test_code-v2"
           steps:
             - run:
                 name: Running tests
-                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make test
+                command: PARSER_TARGET=<< parameters.parser_target >> make test
             # Eastwood is run for every item in the CI matrix, because its results are sensitive to the code in the runtime,
             # so we make the most out of this linter by exercising all profiles, JDK versions, etc.
             - run:
@@ -207,7 +207,7 @@ workflows:
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
               test_profiles: ["-user,-dev,+test,-provided", "-user,-dev,+test,+provided"]
-              enrich_classpath: ["true", "false"]
+              parser_target: ["parser-next", "parser", "legacy-parser"]
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ commands:
       clojure_version:
         description: Will be used as part of the cache key. Especially important for unzipped-jdk-source
         type: string
+      enrich_classpath:
+        description: Whether the enrich-classpath will be applied.
+        type: string
       files:
         description: Files to consider when creating the cache key
         type: string
@@ -128,6 +131,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
+          enrich_classpath: "false"
           cache_version: "util-job-v1"
           jdk_version: << parameters.jdk_version >>
           clojure_version: "1.11"
@@ -155,6 +159,9 @@ jobs:
       test_profiles:
         description: Maps directly to the TEST_PROFILES var in Makefile
         type: string
+      enrich_classpath:
+        description: Whether the enrich-classpath will be applied.
+        type: string
     executor: << parameters.jdk_version >>
     environment:
       VERSION: << parameters.clojure_version >>
@@ -164,11 +171,12 @@ jobs:
       - with_cache:
           jdk_version: << parameters.jdk_version >>
           clojure_version: << parameters.clojure_version >>
+          enrich_classpath: << parameters.enrich_classpath >>
           cache_version: "test_code-v2"
           steps:
             - run:
                 name: Running tests
-                command: make test
+                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make test
             # Eastwood is run for every item in the CI matrix, because its results are sensitive to the code in the runtime,
             # so we make the most out of this linter by exercising all profiles, JDK versions, etc.
             - run:
@@ -198,7 +206,8 @@ workflows:
             parameters:
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
-              test_profiles: ["+test,-provided", "+test,+provided", "+test,+provided,+enrich-classpath"]
+              test_profiles: ["+test,-provided", "+test,+provided"]
+              enrich_classpath: ["true", "false"]
           filters:
             branches:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ workflows:
             parameters:
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
-              test_profiles: ["+test,-provided", "+test,+provided"]
+              test_profiles: ["-user,-dev,+test,-provided", "-user,-dev,+test,+provided"]
               enrich_classpath: ["true", "false"]
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
           steps:
             - run:
                 name: Running tests
-                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make test
+                command: ENRICH_CLASSPATH=<< parameters.enrich_classpath >> make --stop test
             # Eastwood is run for every item in the CI matrix, because its results are sensitive to the code in the runtime,
             # so we make the most out of this linter by exercising all profiles, JDK versions, etc.
             - run:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ pom.xml.asc
 nashorn_code_cache/
 .cljs_node_repl/
 .clj-kondo/.cache
+/.test-classpath
+/test-runner

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl lint .EXPORT_ALL_VARIABLES
 .DEFAULT_GOAL := install
 
+# For the @if [[ conditions:
+SHELL = /bin/bash
+
 HOME=$(shell echo $$HOME)
 VERSION ?= 1.11
 TEST_PROFILES ?= "-user,-dev,+test"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	elif [[ "$$PARSER_TARGET" == "legacy-parser" ]] ; then \
 		lein with-profile -user,-dev,+$(VERSION),$(TEST_PROFILES) test; \
 	else \
-    echo "PARSER_TARGET unset!"; \
+		echo "PARSER_TARGET unset!"; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/ex
 # .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
 test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	@if [ "$$ENRICH_CLASSPATH" == "true" ] ; then \
-		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
+		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
 		cat .test-classpath; \
 		eval "$$(cat .test-classpath)"; \
 		rm .test-classpath; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl lint .EXPORT_ALL_VARIABLES
 .DEFAULT_GOAL := install
 
-# For the @if [[ conditions:
-SHELL = /bin/bash
+# Set bash instead of sh for the @if [[ conditions,
+# and use the usual safety flags:
+SHELL = /bin/bash -Eeu
 
 HOME=$(shell echo $$HOME)
 VERSION ?= 1.11

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/ex
 
 # .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
 test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
-	@if [ "$$ENRICH_CLASSPATH" == "true" ] ; then \
+	@if [[ "$$ENRICH_CLASSPATH" == "true" ]] ; then \
 		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
 		cat .test-classpath; \
 		eval "$$(cat .test-classpath)"; \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LEIN_PROFILES ?= "+dev,+test,+1.11"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.
-ENRICH_CLASSPATH_VERSION="1.17.0"
+ENRICH_CLASSPATH_VERSION="1.17.2"
 
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/ex
 # .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
 test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	@if [[ "$$ENRICH_CLASSPATH" == "true" ]] ; then \
-		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
+		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest,+$(VERSION) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
 		cat .test-classpath; \
 		eval "$$(cat .test-classpath)"; \
 		rm .test-classpath; \

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,15 @@ ENRICH_CLASSPATH_VERSION="1.18.0"
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
-# .EXPORT_ALL_VARIABLES passes TEST_PROFILES to Lein so that it can inspect the active profiles, which is needed for a complete Eastwood setup:
+# The enrich-classpath variant runs the suite twice: once with the add-opens (java.parser-next will be used),
+# one without (java.parser will be used).
 test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	@if [[ "$$ENRICH_CLASSPATH" == "true" ]] ; then \
 		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest,+$(VERSION) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
+		cat .test-classpath; \
+		eval "$$(cat .test-classpath)"; \
+		sed -i 's/--add-opens=jdk.compiler\/com.sun.tools.javac.code=ALL-UNNAMED//g' .test-classpath; \
+		sed -i 's/--add-opens=jdk.compiler\/com.sun.tools.javac.tree=ALL-UNNAMED//g' .test-classpath; \
 		cat .test-classpath; \
 		eval "$$(cat .test-classpath)"; \
 		rm .test-classpath; \

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,14 @@ test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 quick-test: test
 
 eastwood:
+	rm -rf $(TEST_RUNNER_SOURCE_DIR)
 	lein with-profile -user,-dev,+$(VERSION),+eastwood,+deploy,$(TEST_PROFILES) eastwood
+	rm -rf $(TEST_RUNNER_SOURCE_DIR)
 
 cljfmt:
+	rm -rf $(TEST_RUNNER_SOURCE_DIR)
 	lein with-profile -user,-dev,+$(VERSION),+deploy,+cljfmt cljfmt check
+	rm -rf $(TEST_RUNNER_SOURCE_DIR)
 
 # Note that -dev is necessary for not hitting OOM errors in CircleCI
 .make_kondo_prep: project.clj .clj-kondo/config.edn

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ $(TEST_RUNNER_SOURCE_DIR):
 # Launches a repl, falling back to vanilla lein repl if something went wrong during classpath calculation.
 lein-repl: .enrich-classpath-lein-repl
 	@if grep --silent " -cp " .enrich-classpath-lein-repl; then \
+		export YOURKIT_SESSION_NAME="$(basename $(PWD))"; \
 		eval "$$(cat .enrich-classpath-lein-repl) --interactive"; \
 	else \
 		echo "Falling back to lein repl... (you can avoid further falling back by removing .enrich-classpath-lein-repl)"; \

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,8 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :jvm-opts ["-Dclojure.main.report=stderr"]
+  :jvm-opts ~(cond-> '["-Dclojure.main.report=stderr"]
+               (not jdk8?) (conj "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"))
 
   :source-paths ["src" "src-jdk8" "src-newer-jdks"]
   :test-paths ~(cond-> ["test"]
@@ -71,7 +72,7 @@
                                 :enrich-classpath {:shorten true}}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.38.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.38.1"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -22,7 +22,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string]
-   [orchard.java.parser-utils :refer [module-name parse-java parse-variable-element position source-path typesym]])
+   [orchard.java.parser-utils :refer [module-name parse-java parse-variable-element position source-path typesym]]
+   [orchard.misc :as misc])
   (:import
    (com.sun.source.doctree DocCommentTree)
    (javax.lang.model.element Element ElementKind ExecutableElement TypeElement VariableElement)
@@ -251,11 +252,6 @@
          (docstring o env)
          (position o env)))
 
-(defn remove-type-param [s]
-  (-> s
-      (string/replace #"<.*" "")
-      (string/replace #"\[.*" "")))
-
 (defn parse-executable-element [^ExecutableElement m env]
   (let [parameters (.getParameters m)
         type->sym #(-> ^VariableElement % .asType (typesym env))]
@@ -277,7 +273,7 @@
                                                             (some-> ast .getUpperBound)
                                                             (some-> ast .getOriginalType))
                                                         str
-                                                        remove-type-param
+                                                        misc/remove-type-param
                                                         symbol))]
                                      (some-> (or best
                                                  (type->sym element))

--- a/src-newer-jdks/orchard/java/parser_utils.clj
+++ b/src-newer-jdks/orchard/java/parser_utils.clj
@@ -7,7 +7,7 @@
    [clojure.string :as string])
   (:import
    (java.io StringWriter)
-   (javax.lang.model.element ElementKind ExecutableElement VariableElement)
+   (javax.lang.model.element VariableElement)
    (javax.tools ToolProvider)
    (jdk.javadoc.doclet Doclet DocletEnvironment)))
 
@@ -75,14 +75,6 @@
                                    file (.getLeaf path))]
         {:line (.getLineNumber lines pos)
          :column (.getColumnNumber lines pos)}))))
-
-(defn parse-executable-element [^ExecutableElement m env]
-  {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
-           (-> m .getEnclosingElement (typesym env)) ; class name
-           (-> m .getSimpleName str symbol)) ; method name
-   :type (-> m .getReturnType (typesym env))
-   :argtypes (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))
-   :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))})
 
 (defn parse-variable-element [^VariableElement f env]
   {:name (-> f .getSimpleName str symbol)

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -86,7 +86,7 @@
              (Class/forName "com.sun.tools.javac.tree.DCTree$DCBlockTag")
              (Class/forName "com.sun.tools.javac.code.Type$ArrayType")
              (do
-               ;; require the whole namespace in case there's some other source of problems (e.g. some other missing opene)
+               ;; require the whole namespace in case there's some other source of problems (e.g. some other missing `opens`)
                (require '[orchard.java.parser-next])
                ((resolve 'orchard.java.parser-next/source-info) `String :throw))
              true)

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -541,9 +541,9 @@
     initialize-cache-silently? util.io/wrap-silently))
 
 (def cache-initializer
-  "On startup, cache info for a few classes.
+  "Cache info for a few classes.
   This also warms up the cache for some underlying, commonly neeed classes (e.g. `Object`).
 
   This is a def for allowing others to wait for this workload to complete (can be useful sometimes)."
-  (future
+  (delay ;; NOTE: this used to be a `future`, but that can cause odd issues.
     (initialize-cache!)))

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -264,13 +264,14 @@
   (let [arglist (extract-arglist static? x)
         parameter-type (extract-parameter-type static? x)
         sb (StringBuilder.)
-        package-re (re-pattern (str "^"
-                                    (string/replace package "." "\\.")
-                                    "\\."))
+        package-re (when package
+                     (re-pattern (str "^"
+                                      (string/replace package "." "\\.")
+                                      "\\.")))
         shorten (fn [s]
-                  (-> s
-                      (string/replace package-re "")
-                      (string/replace #"^java\.lang\." "")))
+                  (cond-> s
+                    package (string/replace package-re "")
+                    true (string/replace #"^java\.lang\." "")))
         fill-arglist!
         (fn []
           (into []

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -254,7 +254,7 @@
    (or (:non-generic-argtypes xs)
        (:parameter-types xs))))
 
-(defn extract-formatted-arglists [static? package {:keys [returns] :as x}]
+(defn extract-annotated-arglists [static? package {:keys [returns] :as x}]
   (let [arglist (extract-arglist static? x)
         parameter-type (extract-parameter-type static? x)
         sb (StringBuilder.)
@@ -322,8 +322,8 @@
                                                  (map (fn [[k arity]]
                                                         [k (let [static? (:static (:modifiers arity))]
                                                              (-> arity
-                                                                 (assoc :formatted-arglists
-                                                                        (extract-formatted-arglists static? package arity))
+                                                                 (assoc :annotated-arglists
+                                                                        (extract-annotated-arglists static? package arity))
                                                                  (dissoc :non-generic-argtypes)))]))
                                                  arities)]))
                             members)))))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -193,3 +193,11 @@
   [x]
   (when (and (coll? x) (not (lazy-seq? x)))
     (count x)))
+
+(defn normalize-subclass [s]
+  (string/replace s "$" "."))
+
+(defn remove-type-param [s]
+  (-> s
+      (string/replace #"<.*" "")
+      (string/replace #"\[.*" "")))

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -9,7 +9,7 @@
    (orchard.java DummyClass)))
 
 (when (System/getenv "CI")
-  (println "has-enriched-classpath?" (pr-str (util/has-enriched-classpath?))))
+  (println "has-enriched-classpath?" (pr-str util/has-enriched-classpath?)))
 
 (when (and util/has-enriched-classpath?
            @@java/parser-next-available?)

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -104,7 +104,7 @@
           (is (not (string/includes? s "<a href"))))))))
 
 (when (and util/has-enriched-classpath?
-           @java/parser-next-available?)
+           @@java/parser-next-available?)
   (deftest smoke-test
     (let [annotations #{'java.lang.Override
                         'java.lang.Deprecated

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -9,7 +9,7 @@
    (orchard.java DummyClass)))
 
 (when (and util/has-enriched-classpath?
-           java/parser-next-available?)
+           @@java/parser-next-available?)
   (deftest source-info-test
     (is (class? DummyClass))
 
@@ -60,7 +60,7 @@
                      (str (:resource-url rt-info))))))))
 
 (when (and util/has-enriched-classpath?
-           java/parser-next-available?)
+           @@java/parser-next-available?)
   (deftest doc-fragments-test
     (is (= [{:type "text",
              :content
@@ -101,7 +101,7 @@
           (is (not (string/includes? s "<a href"))))))))
 
 (when (and util/has-enriched-classpath?
-           java/parser-next-available?)
+           @java/parser-next-available?)
   (deftest smoke-test
     (let [annotations #{'java.lang.Override
                         'java.lang.Deprecated

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -8,6 +8,9 @@
   (:import
    (orchard.java DummyClass)))
 
+(when (System/getenv "CI")
+  (println "has-enriched-classpath?" (pr-str (util/has-enriched-classpath?))))
+
 (when (and util/has-enriched-classpath?
            @@java/parser-next-available?)
   (deftest source-info-test

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -26,19 +26,7 @@
                  :content
                  "<pre> \n   DummyClass dc = new DummyClass();\n  </pre>"}],
                :members
-               {orchard.java.DummyClass
-                {[]
-                 {:name orchard.java.DummyClass,
-                  :type void,
-                  :doc-first-sentence-fragments [],
-                  :column 8,
-                  :argtypes [],
-                  :line 12,
-                  :argnames [],
-                  :doc-fragments [],
-                  :doc-block-tags-fragments [],
-                  :doc nil}},
-                dummyMethod
+               {dummyMethod
                 {[]
                  {:name dummyMethod,
                   :type java.lang.String,
@@ -46,6 +34,7 @@
                   [{:type "text", :content "Method-level docstring."}],
                   :column 5,
                   :argtypes [],
+                  :non-generic-argtypes []
                   :line 18,
                   :argnames [],
                   :doc-fragments
@@ -101,7 +90,7 @@
                         sut/source-info
                         (get-in [:members
                                  'format
-                                 ['java.util.Locale 'java.lang.String (symbol "java.lang.Object[]")]
+                                 ['java.util.Locale 'java.lang.String 'java.lang.Object]
                                  :doc-fragments])
                         (->> (map :content)))
           s (string/join fragments)]
@@ -110,10 +99,6 @@
         (testing s
           (is (not (string/includes? s "<a")))
           (is (not (string/includes? s "<a href"))))))))
-
-(defn imported-classes [ns-sym]
-  (->> (ns-imports ns-sym)
-       (map #(-> % ^Class val .getName symbol))))
 
 (when (and util/has-enriched-classpath?
            java/parser-next-available?)
@@ -124,7 +109,7 @@
           corpus (->> ::_
                       namespace
                       symbol
-                      imported-classes
+                      util/imported-classes
                       (remove annotations)
                       (into ['java.io.File]))]
       (assert (> (count corpus)

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -13,17 +13,7 @@
     (testing "file on the filesystem"
       (is (= {:class 'orchard.java.DummyClass,
               :members
-              '{orchard.java.DummyClass
-                {[]
-                 {:name orchard.java.DummyClass,
-                  :type void,
-                  :argtypes [],
-                  :non-generic-argtypes []
-                  :argnames [],
-                  :doc nil,
-                  :line 12,
-                  :column 8}},
-                dummyMethod
+              '{dummyMethod
                 {[]
                  {:name dummyMethod,
                   :type java.lang.String,

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -18,6 +18,7 @@
                  {:name orchard.java.DummyClass,
                   :type void,
                   :argtypes [],
+                  :non-generic-argtypes []
                   :argnames [],
                   :doc nil,
                   :line 12,
@@ -28,6 +29,7 @@
                   :type java.lang.String,
                   :argtypes [],
                   :argnames [],
+                  :non-generic-argtypes []
                   :doc "Method-level docstring. @return the string \"hello\"",
                   :line 18,
                   :column 5}}},

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -538,14 +538,14 @@
   (deftest info-java-member-precedence-test
     (testing "Integer/max - issue #86"
       (let [i (info/info* {:ns 'user :sym 'Integer/max})]
-        (is (= (select-keys i [:class :member :modifiers :throws :argtypes :arglists :returns])
-               '{:throws ()
+        (is (= '{:throws ()
                  :argtypes [int int]
                  :member max
                  :modifiers #{:public :static}
                  :class java.lang.Integer
                  :arglists ([a b])
-                 :returns int}))
+                 :returns int}
+               (select-keys i [:class :member :modifiers :throws :argtypes :arglists :returns])))
         (is (re-find #"Returns the greater of two" (:doc i)))))))
 
 (def some-var nil)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -934,8 +934,6 @@
 
         ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
 
-        (let [tries (atom 0)])
-
         (-> (inspect/fresh)
             (inspect/start {:a {:b 1}})
             (inspect/tap-current-value)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -918,20 +918,42 @@
                     (section "Page Info" rendered)))))))
 
 (deftest tap-current-value
-  (testing "tap> current value")
-  (when tap?
-    (let [proof (atom [])
-          test-tap-handler (fn [x]
-                             (swap! proof conj x))]
-      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
-      (-> (inspect/fresh)
-          (inspect/start {:a {:b 1}})
-          (inspect/tap-current-value)
-          (inspect/down 2)
-          (inspect/tap-current-value)
-          (inspect/down 1)
-          (inspect/tap-current-value))
-      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)
-      (is (= [{:a {:b 1}}
-              {:b 1}
-              :b] @proof)))))
+  (testing "tap> current value"
+    (when tap?
+
+      ;; NOTE: this deftest is flaky - wrap the body in the following (and remove the `Thread/sleep`) to reproduce.
+      #_(dotimes [_ 100000])
+
+      (let [proof (atom [])
+            test-tap-handler (fn [x]
+                               (swap! proof conj x))
+            sleep (long
+                   (if (System/getenv "CI")
+                     200
+                     100))]
+
+        ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
+
+        (let [tries (atom 0)])
+
+        (-> (inspect/fresh)
+            (inspect/start {:a {:b 1}})
+            (inspect/tap-current-value)
+            (inspect/down 2)
+            (inspect/tap-current-value)
+            (inspect/down 1)
+            (inspect/tap-current-value))
+
+        (let [expected [{:a {:b 1}}
+                        {:b 1}
+                        :b]
+              tries (atom 0)]
+
+          (while (and (not= expected @proof)
+                      (< @tries 1000))
+            (Thread/sleep sleep)
+            (swap! tries inc))
+
+          (is (= expected @proof)))
+
+        ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -10,7 +10,9 @@
   (:import
    (mx.cider.orchard LruMap)))
 
-(def jdk-parser? (or (>= misc/java-api-version 9) jdk-tools))
+(def modern-java? (>= misc/java-api-version 9))
+
+(def jdk-parser? (or modern-java? jdk-tools))
 
 (javadoc/add-remote-javadoc "com.amazonaws." "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/")
 (javadoc/add-remote-javadoc "org.apache.kafka." "https://kafka.apache.org/090/javadoc/")
@@ -71,7 +73,8 @@
                              (remove (set (keys c2)) (keys c1))]))
         (is (keys= c1 c2))))))
 
-(when util/has-enriched-classpath?
+(when (and util/has-enriched-classpath?
+           modern-java?)
   (deftest class-info-test
     (let [c1 (class-info 'clojure.lang.Agent)
           c2 (class-info 'clojure.lang.Range$BoundsCheck)
@@ -421,7 +424,8 @@
        ;; Only methods (and not fields) have arglists:
        (filter :returns)))
 
-(when util/has-enriched-classpath?
+(when (and util/has-enriched-classpath?
+           modern-java?)
   (deftest reflect-and-source-info-match
     (testing "reflect and source info structurally match, allowing a meaningful deep-merge of both"
       (let [extract-arities (fn [info]
@@ -468,7 +472,8 @@
               (is (not-any? nil? all-argnames)
                   "The deep-merge went ok"))))))))
 
-(when util/has-enriched-classpath?
+(when (and util/has-enriched-classpath?
+           modern-java?)
   (deftest annotated-arglists-test
     (doseq [class-symbol (class-corpus)
             :let [info (sut/class-info* class-symbol)

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -97,15 +97,12 @@
                                           (get reflector-class-info-arities i)))
                           full-class-info-arities))))))))
 
-(when (and util/has-enriched-classpath?
-           modern-java?)
+(when util/has-enriched-classpath?
   (deftest class-info-test
     (let [c1 (class-info 'clojure.lang.Agent)
           c2 (class-info 'clojure.lang.Range$BoundsCheck)
           c3 (class-info 'not.actually.AClass)
           thread-class-info (class-info `Thread)]
-      (when-not @@sut/parser-next-available?
-        (throw @sut/parser-available-exception))
       (testing "Class"
         (testing "source file"
           (is (string? (:file c1)))
@@ -118,7 +115,10 @@
           (is (every? map? (vals (:members c1))))
           (let [members (mapcat vals (vals (:members c1)))]
             (assert (seq members))
-            (doseq [m members]
+            (doseq [m members
+                    ;; No constructors for now:
+                    :when (not (= (:name m)
+                                  (:class c1)))]
               (is (contains? m :name))
               (assert (is (contains? m :modifiers))))))
         (testing "doesn't throw on classes without dots in classname"

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -428,8 +428,9 @@
                               (->> info :members vals (map keys) (reduce into)
                                    (remove nil?) ;; fields
                                    (sort-by pr-str)))]
+        (require 'orchard.java.parser-next)
         (doseq [class-symbol (class-corpus)
-                :let [f @(requiring-resolve 'orchard.java.parser-next/source-info)
+                :let [f @(resolve 'orchard.java.parser-next/source-info)
                       source-info (f class-symbol)
                       reflect-info (sut/reflect-info (#'sut/reflection-for (eval class-symbol)))
                       arities-from-source (extract-arities source-info)

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -77,6 +77,8 @@
           c2 (class-info 'clojure.lang.Range$BoundsCheck)
           c3 (class-info 'not.actually.AClass)
           thread-class-info (class-info `Thread)]
+      (when-not @@sut/parser-next-available?
+        (throw @sut/parser-available-exception))
       (testing "Class"
         (testing "source file"
           (is (string? (:file c1)))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -427,7 +427,8 @@
                                    (remove nil?) ;; fields
                                    (sort-by pr-str)))]
         (doseq [class-symbol (class-corpus)
-                :let [source-info (sut/source-info class-symbol)
+                :let [f @(requiring-resolve 'orchard.java.parser-next/source-info)
+                      source-info (f class-symbol)
                       reflect-info (sut/reflect-info (#'sut/reflection-for (eval class-symbol)))
                       arities-from-source (extract-arities source-info)
                       arities-from-reflector (extract-arities reflect-info)]]
@@ -436,7 +437,9 @@
                        (count arities-from-reflector))
                     [class-symbol
                      (count arities-from-source)
-                     (count arities-from-reflector)])
+                     (count arities-from-reflector)
+                     :source (sort-by pr-str arities-from-source)
+                     :reflector (sort-by pr-str arities-from-reflector)])
             (assert (or (pos? (count arities-from-source))
                         (pos? (count arities-from-reflector)))
                     class-symbol)

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -57,7 +57,7 @@
 
 (deftest map-structure-test
   (testing "Parsed map structure = reflected map structure"
-    (let [excluded-cols #{:file :line :column :doc :argnames :non-generic-argtypes :formatted-arglists
+    (let [excluded-cols #{:file :line :column :doc :argnames :non-generic-argtypes :annotated-arglists
                           :doc-first-sentence-fragments :doc-fragments :doc-block-tags-fragments :argtypes :path :resource-url}
           keys= (fn [a b]
                   (is (= (set (keys (apply dissoc a excluded-cols)))
@@ -460,15 +460,15 @@
                   "The deep-merge went ok"))))))))
 
 (when util/has-enriched-classpath?
-  (deftest formatted-arglists-test
+  (deftest annotated-arglists-test
     (doseq [class-symbol (class-corpus)
             :let [info (sut/class-info* class-symbol)
                   arities (extract-method-arities info)
-                  all-formatted-arglists (map :formatted-arglists arities)]]
+                  all-annotated-arglists (map :annotated-arglists arities)]]
       (testing class-symbol
-        (assert (pos? (count all-formatted-arglists))
+        (assert (pos? (count all-annotated-arglists))
                 class-symbol)
-        (doseq [s all-formatted-arglists]
+        (doseq [s all-annotated-arglists]
           (assert (is (string? s)))
           (testing s
             (is (re-find #"\^.*\[" s))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -87,8 +87,11 @@
         (testing "member info"
           (is (map? (:members c1)))
           (is (every? map? (vals (:members c1))))
-          (is (apply (every-pred :name :modifiers)
-                     (mapcat vals (vals (:members c1))))))
+          (let [members (mapcat vals (vals (:members c1)))]
+            (assert (seq members))
+            (doseq [m members]
+              (is (contains? m :name))
+              (assert (is (contains? m :modifiers))))))
         (testing "doesn't throw on classes without dots in classname"
           (let [reified (binding [*ns* (create-ns 'foo)]
                           (clojure.core/eval
@@ -478,4 +481,4 @@
             (is (not (string/includes? s "^Object Object")))
             (is (not (string/includes? s "^function.Function java.util.function.Function")))
             (is (not (string/includes? s "^java.util.function.Function java.util.function.Function")))
-            (is (not (string/includes? s "java.lang")))))))))
+            (assert (is (not (string/includes? s "java.lang"))))))))))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -449,7 +449,7 @@
        (filter :returns)))
 
 (when (and util/has-enriched-classpath?
-           modern-java?)
+           @@sut/parser-next-available?)
   (deftest reflect-and-source-info-match
     (testing "reflect and source info structurally match, allowing a meaningful deep-merge of both"
       (let [extract-arities (fn [info]
@@ -497,7 +497,7 @@
                   "The deep-merge went ok"))))))))
 
 (when (and util/has-enriched-classpath?
-           modern-java?)
+           @@sut/parser-next-available?)
   (deftest annotated-arglists-test
     (doseq [class-symbol (class-corpus)
             :let [info (sut/class-info* class-symbol)

--- a/test/orchard/test/util.clj
+++ b/test/orchard/test/util.clj
@@ -4,3 +4,8 @@
 (def has-enriched-classpath?
   (boolean (or (io/resource "java/lang/Thread.java")
                (io/resource "java.base/java/lang/Thread.java"))))
+
+(defn imported-classes [ns-sym]
+  {:post [(seq %)]}
+  (->> (ns-imports ns-sym)
+       (map #(-> % ^Class val .getName symbol))))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/orchard/issues/190

Performs some necessary preliminary fixes and then implements #190.

* Correctly consolidate arities info from two different sources (the Clojure Reflector, and .java source analysis) for a meaningful deep merge between then by computing `:non-generic-argtypes`
  * Without arities that match 1:1 between the two sources, we cannot deep merge correctly: there will be duplicate entries (given the slightly different keys), which results in extra (and incorrect) entries shown to end users.
  * This was a subtle bug in hidden in Orchard.
* Remove constructor info for now, given it's was incorrect and incomplete (and unused from cider.el) for both Reflector and Sources
  * e.g. for a given constructor with 4 different signatures, maybe just 1 was being shown, so it wasn't reliable enough.
  * See also https://github.com/clojure-emacs/orchard/pull/87 for evidence of constructors being a pending spot
  * Will be re-added soon enough
* Implement and return `:formatted-arglists` for CIDER usage

A few examples of `:formatted-arglists`:

```
^void [this, ^function.BiConsumer action]
^void [^int begin, ^int end, ^int length]
^Map$Entry [^Object k, ^Object v]
^StackTraceElement[][] [^Thread threads]
```

Showing `^StackTraceElement[][] [^Thread threads]` is far more useful to display to end users than merely `[threads]`.

A larger corpus of samples: https://gist.github.com/vemv/45c04bf8cd794c0902077f7db9cd5f3a

Cheers - V