### PR TITLE
Don't infer indentation for `def`-like macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * Correctly infer indentation for `->`-like macros.
+* Don't infer indentation for `def`-like macros.
 
 ## 0.15.1 (2023-09-21)
 

--- a/src/orchard/indent.clj
+++ b/src/orchard/indent.clj
@@ -118,6 +118,7 @@
                                                                                         (when (string/includes? macro-name k)
                                                                                           entry)))))
         one-arglist? (-> arglists count (= 1))
+        def-like? (re-find #"^def" macro-name)
         result (cond
                  exact-match
                  (when (acceptably-analog? arglists exact-clojure-core-symbol)
@@ -126,6 +127,10 @@
                  fuzzy-match
                  (when (acceptably-analog? arglists fuzzy-clojure-core-symbol)
                    fuzzy-indentation)
+
+                 ;; def-like macros get no inference - these tend to be risky to make any assumption about
+                 def-like?
+                 nil
 
                  (and one-arglist?
                       (->> arglists first (some #{'&})))

--- a/test/orchard/indent_test.clj
+++ b/test/orchard/indent_test.clj
@@ -72,6 +72,11 @@
     'anything    '[[a {} & body]]        2
     'anything    '[[{} & body]]          1
     'anything    '[[{} a & body]]        2
+    ;; macros starting by 'def' get no inference:
+    'defanything '[[a & body]]           nil
+    'defanything '[[a {} & body]]        nil
+    'defanything '[[{} & body]]          nil
+    'defanything '[[{} a & body]]        nil
     ;; un-inferrable:
     'anything    '[[a & body], [& body]] nil
 
@@ -81,12 +86,21 @@
     'anything    '[[body]]               0
     'anything    '[[a body]]             1
     'anything    '[[a b body]]           2
+    ;; macros starting by 'def' get no inference:
+    'defanything '[[body]]               nil
+    'defanything '[[a body]]             nil
+    'defanything '[[a b body]]           nil
     ;; un-inferrable:
     'anything    '[[a b body]
                    [a b C body]]         nil
+    ;; condition-like macros get inference:
     'sdfds       '[[condition
                     then
                     else]]               1
+    ;; condition-like macros starting by 'def' get no inference:
+    'defnfoo     '[[condition
+                    then
+                    else]]               nil
 
     ;; Threading forms:
     '->          '[[x & forms]]          nil


### PR DESCRIPTION
def-like macros should get no inference - these tend to be risky to make any assumption about.

I actually never particularly meant for def-like macros to be applied these rules of thumb - it was an oversight in implementation.