### PR TITLE
Restore constuctor info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ test: clean $(SPEC2_SOURCE_DIR) $(TEST_RUNNER_SOURCE_DIR) .EXPORT_ALL_VARIABLES
 	elif [[ "$$PARSER_TARGET" == "parser" ]] ; then \
 		bash 'lein' 'update-in' ':plugins' 'conj' "[mx.cider/lein-enrich-classpath \"$(ENRICH_CLASSPATH_VERSION)\"]" '--' 'with-profile' $(TEST_PROFILES),+cognitest,+$(VERSION) 'update-in' ':middleware' 'conj' 'cider.enrich-classpath.plugin-v2/middleware' '--' 'repl' | grep " -cp " > .test-classpath; \
 		cat .test-classpath; \
-		sed  $(SED_INPLACE) 's/--add-opens=jdk.compiler\/com.sun.tools.javac.code=ALL-UNNAMED//g' .test-classpath; \
-		sed  $(SED_INPLACE) 's/--add-opens=jdk.compiler\/com.sun.tools.javac.tree=ALL-UNNAMED//g' .test-classpath; \
+		sed $(SED_INPLACE) 's/--add-opens=jdk.compiler\/com.sun.tools.javac.code=ALL-UNNAMED//g' .test-classpath; \
+		sed $(SED_INPLACE) 's/--add-opens=jdk.compiler\/com.sun.tools.javac.tree=ALL-UNNAMED//g' .test-classpath; \
 		cat .test-classpath; \
 		eval "$$(cat .test-classpath)"; \
 		rm .test-classpath; \

--- a/src-jdk8/orchard/java/legacy_parser.clj
+++ b/src-jdk8/orchard/java/legacy_parser.clj
@@ -220,17 +220,17 @@
 (extend-protocol Parsed
   ConstructorDoc
   (parse-info [c]
-    (let [a (mapv #(-> ^Parameter % .type typesym) (.parameters c))]
+    (let [argtypes (mapv #(-> ^Parameter % .type typesym) (.parameters c))]
       {:name (-> c .qualifiedName symbol)
-       :argtypes a
-       :non-generic-argtypes (->> a (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
+       :argtypes argtypes
+       :non-generic-argtypes (->> argtypes (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
        :argnames (mapv #(-> ^Parameter % .name symbol) (.parameters c))}))
 
   MethodDoc
   (parse-info [m]
-    (let [a (mapv #(-> ^Parameter % .type typesym) (.parameters m))]
-      {:argtypes a
-       :non-generic-argtypes (->> a (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
+    (let [argtypes (mapv #(-> ^Parameter % .type typesym) (.parameters m))]
+      {:argtypes argtypes
+       :non-generic-argtypes (->> argtypes (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
        :argnames (mapv #(-> ^Parameter % .name symbol) (.parameters m))
        :type (str (.returnType m))}))
 

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -181,13 +181,13 @@
          (position o env)))
 
 (defn parse-executable-element [^ExecutableElement m env]
-  (let [a (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))]
+  (let [argtypes (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))]
     {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
              (-> m .getEnclosingElement (typesym env)) ; class name
              (-> m .getSimpleName str symbol))         ; method name
      :type (-> m .getReturnType (typesym env))
-     :argtypes a
-     :non-generic-argtypes (->> a (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
+     :argtypes argtypes
+     :non-generic-argtypes (->> argtypes (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
      :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))}))
 
 (extend-protocol Parsed

--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -176,22 +176,19 @@
 
 (defn parse-info
   [o env]
-  (when-let [p (parse-info* o env)]
-    (merge p
-           (docstring o env)
-           (position o env))))
+  (merge (parse-info* o env)
+         (docstring o env)
+         (position o env)))
 
 (defn parse-executable-element [^ExecutableElement m env]
-  (let [a (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))
-        constructor? (= (.getKind m) ElementKind/CONSTRUCTOR)]
-    (when-not constructor? ;; no constructors for now
-      {:name (if constructor?
-               (-> m .getEnclosingElement (typesym env)) ; class name
-               (-> m .getSimpleName str symbol))         ; method name
-       :type (-> m .getReturnType (typesym env))
-       :argtypes a
-       :non-generic-argtypes (->> a (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
-       :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))})))
+  (let [a (mapv #(-> ^VariableElement % .asType (typesym env)) (.getParameters m))]
+    {:name (if (= (.getKind m) ElementKind/CONSTRUCTOR)
+             (-> m .getEnclosingElement (typesym env)) ; class name
+             (-> m .getSimpleName str symbol))         ; method name
+     :type (-> m .getReturnType (typesym env))
+     :argtypes a
+     :non-generic-argtypes (->> a (mapv (comp symbol misc/normalize-subclass misc/remove-type-param str)))
+     :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))}))
 
 (extend-protocol Parsed
   TypeElement ;; => class, interface, enum

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -288,7 +288,7 @@
   (parse-info* [c env]
     {:class   (typesym c env)
      :members (->> (.getEnclosedElements c)
-                   (filterv #(#{ElementKind/CONSTRUCTOR ;; will be enabled when it's also properly implemented at reflector level
+                   (filterv #(#{ElementKind/CONSTRUCTOR
                                 ElementKind/METHOD
                                 ElementKind/FIELD
                                 ElementKind/ENUM_CONSTANT}

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -288,7 +288,7 @@
   (parse-info* [c env]
     {:class   (typesym c env)
      :members (->> (.getEnclosedElements c)
-                   (filterv #(#{#_ElementKind/CONSTRUCTOR ;; will be enabled when it's also properly implemented at reflector level
+                   (filterv #(#{ElementKind/CONSTRUCTOR ;; will be enabled when it's also properly implemented at reflector level
                                 ElementKind/METHOD
                                 ElementKind/FIELD
                                 ElementKind/ENUM_CONSTANT}

--- a/test-newer-jdks/orchard/java/parser_next_test.clj
+++ b/test-newer-jdks/orchard/java/parser_next_test.clj
@@ -47,7 +47,20 @@
                    {:content "<i>Returns</i>:&nbsp;", :type "html"}
                    {:content "the string \"hello\"", :type "text"}],
                   :doc
-                  "Method-level docstring.\n\n @return the string \"hello\""}}},
+                  "Method-level docstring.\n\n @return the string \"hello\""}}
+                orchard.java.DummyClass
+                {[]
+                 {:non-generic-argtypes [],
+                  :name orchard.java.DummyClass,
+                  :type void,
+                  :doc-first-sentence-fragments [],
+                  :column 8,
+                  :argtypes [],
+                  :line 12,
+                  :argnames [],
+                  :doc-fragments [],
+                  :doc-block-tags-fragments [],
+                  :doc nil}}},
                :doc-block-tags-fragments [],
                :doc
                "Class level docstring.\n\n <pre>\n   DummyClass dc = new DummyClass();\n </pre>\n\n @author Arne Brasseur"}

--- a/test-newer-jdks/orchard/java/parser_test.clj
+++ b/test-newer-jdks/orchard/java/parser_test.clj
@@ -22,7 +22,17 @@
                   :non-generic-argtypes []
                   :doc "Method-level docstring. @return the string \"hello\"",
                   :line 18,
-                  :column 5}}},
+                  :column 5}}
+                orchard.java.DummyClass
+                {[]
+                 {:name orchard.java.DummyClass,
+                  :type void,
+                  :argtypes [],
+                  :non-generic-argtypes [],
+                  :argnames [],
+                  :doc nil,
+                  :line 12,
+                  :column 8}}},
               :doc
               "Class level docstring.\n\n```\n   DummyClass dc = new DummyClass();\n```\n\n@author Arne Brasseur",
               :line 12,

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -115,10 +115,7 @@
           (is (every? map? (vals (:members c1))))
           (let [members (mapcat vals (vals (:members c1)))]
             (assert (seq members))
-            (doseq [m members
-                    ;; No constructors for now:
-                    :when (not (= (:name m)
-                                  (:class c1)))]
+            (doseq [m members]
               (is (contains? m :name))
               (assert (is (contains? m :modifiers))))))
         (testing "doesn't throw on classes without dots in classname"

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -57,45 +57,67 @@
                               [:members 'size])
                       first val :line)))))))
 
+(defn class-corpus []
+  {:post [(> (count %)
+             50)]}
+  (->> (util/imported-classes 'clojure.core)
+       (into ['java.util.Map 'java.io.File])
+       (into (util/imported-classes (-> ::_ namespace symbol)))
+       ;; Remove classes without methods:
+       (remove (some-fn
+                #{`ThreadDeath
+                  `Void
+                  `RuntimePermission
+                  'clojure.core.Vec
+                  'clojure.core.VecNode
+                  'clojure.core.VecSeq
+                  'clojure.core.ArrayChunk
+                  'clojure.core.Eduction}
+                (fn [s]
+                  (or (-> s str Class/forName .isInterface)
+                      (-> s str Class/forName .isEnum)))
+                (fn [s]
+                  (->> s str (re-find #"(Exception|Error)$")))))))
+
 (deftest map-structure-test
   (testing "Parsed map structure = reflected map structure"
-    (let [class-sym 'clojure.lang.Compiler ;; XXX more
-          excluded-cols #{:file :line :column :doc :argnames :non-generic-argtypes :annotated-arglists
-                          :doc-first-sentence-fragments :doc-fragments :doc-block-tags-fragments :argtypes :path :resource-url}
-          extract-keys (fn [x]
-                         (->> excluded-cols
-                              (apply dissoc x)
-                              (keys)
-                              (set)
-                              (sort-by pr-str)))
-          assert-keys= (fn [a b]
-                         (let [aa (extract-keys a)
-                               bb (extract-keys b)]
-                           (testing (pr-str {:only-in-reflector (remove (set aa) bb)
-                                             :only-in-full (remove (set bb) aa)})
-                             (doall
-                              (map-indexed (fn [i _]
-                                             (is (= (get aa i)
-                                                    (get bb i))))
-                                           aa)))))
-          full-class-info (class-info* 'clojure.lang.Compiler)
-          reflector-class-info (with-redefs [source-info (constantly nil)]
-                                 (class-info* class-sym))]
-      (testing class-sym
-        (testing "Class info"
-          (assert-keys= full-class-info reflector-class-info))
-        (testing "Members info"
-          (is (keys (:members full-class-info)))
-          (assert-keys= (:members full-class-info)
-                        (:members reflector-class-info)))
-        (testing "Arities info"
-          (let [full-class-info-arities (-> full-class-info :members vals vec)
-                reflector-class-info-arities (-> reflector-class-info :members vals vec)]
-            (doall
-             (map-indexed (fn [i _]
-                            (assert-keys= (get full-class-info-arities i)
-                                          (get reflector-class-info-arities i)))
-                          full-class-info-arities))))))))
+    (doseq [class-sym (conj (class-corpus) 'clojure.lang.Compiler)]
+      (let [excluded-cols #{:file :line :column :doc :argnames :non-generic-argtypes :annotated-arglists
+                            :doc-first-sentence-fragments :doc-fragments :doc-block-tags-fragments :argtypes :path :resource-url}
+            extract-keys (fn [x]
+                           (->> excluded-cols
+                                (apply dissoc x)
+                                (keys)
+                                (set)
+                                (sort-by pr-str)))
+            assert-keys= (fn [a b]
+                           (let [aa (extract-keys a)
+                                 bb (extract-keys b)]
+                             (testing (pr-str {:only-in-reflector (remove (set aa) bb)
+                                               :only-in-full (remove (set bb) aa)})
+                               (doall
+                                (map-indexed (fn [i _]
+                                               (is (= (get aa i)
+                                                      (get bb i))))
+                                             aa)))))
+            full-class-info (class-info* 'clojure.lang.Compiler)
+            reflector-class-info (with-redefs [source-info (constantly nil)]
+                                   (class-info* class-sym))]
+        (testing class-sym
+          (testing "Class info"
+            (assert-keys= full-class-info reflector-class-info))
+          (testing "Members info"
+            (is (keys (:members full-class-info)))
+            (assert-keys= (:members full-class-info)
+                          (:members reflector-class-info)))
+          (testing "Arities info"
+            (let [full-class-info-arities (-> full-class-info :members vals vec)
+                  reflector-class-info-arities (-> reflector-class-info :members vals vec)]
+              (doall
+               (map-indexed (fn [i _]
+                              (assert-keys= (get full-class-info-arities i)
+                                            (get reflector-class-info-arities i)))
+                            full-class-info-arities)))))))))
 
 (when util/has-enriched-classpath?
   (deftest class-info-test
@@ -415,35 +437,17 @@
          (subs s (inc (.lastIndexOf s "."))))
     s))
 
-(defn class-corpus []
-  {:post [(> (count %)
-             50)]}
-  (->> (util/imported-classes 'clojure.core)
-       (into ['java.util.Map 'java.io.File])
-       (into (util/imported-classes (-> ::_ namespace symbol)))
-       ;; Remove classes without methods:
-       (remove (some-fn
-                #{`ThreadDeath
-                  `Void
-                  `RuntimePermission
-                  'clojure.core.Vec
-                  'clojure.core.VecNode
-                  'clojure.core.VecSeq
-                  'clojure.core.ArrayChunk
-                  'clojure.core.Eduction}
-                (fn [s]
-                  (-> s str Class/forName .isInterface))
-                (fn [s]
-                  (->> s str (re-find #"(Exception|Error)$")))))))
-
-(defn extract-method-arities [info]
+(defn extract-method-arities [class-symbol info]
+  {:pre [(symbol? class-symbol)]}
   (->> (-> info
            :members
            vals)
        (map vals)
        (reduce into)
        ;; Only methods (and not fields) have arglists:
-       (filter :returns)))
+       (filter (fn [{:keys [returns] n :name}]
+                 (or returns
+                     (= n class-symbol))))))
 
 (when (and util/has-enriched-classpath?
            @@sut/parser-next-available?)
@@ -487,7 +491,7 @@
             (assert (is (= arities-from-source
                            arities-from-reflector)))
 
-            (let [arities-data (extract-method-arities (misc/deep-merge reflect-info source-info))
+            (let [arities-data (extract-method-arities class-symbol (misc/deep-merge reflect-info source-info))
                   all-argnames (map :argnames arities-data)]
               (assert (pos? (count all-argnames)))
               (is (not-any? nil? all-argnames)
@@ -498,15 +502,21 @@
   (deftest annotated-arglists-test
     (doseq [class-symbol (class-corpus)
             :let [info (sut/class-info* class-symbol)
-                  arities (extract-method-arities info)
-                  all-annotated-arglists (map :annotated-arglists arities)]]
+                  arities (extract-method-arities class-symbol info)
+                  all-annotated-arglists (->> arities
+                                              (map (fn [{:keys [annotated-arglists]
+                                                         n :name}]
+                                                     [annotated-arglists
+                                                      (= n class-symbol)])))]]
       (testing class-symbol
         (assert (pos? (count all-annotated-arglists))
                 class-symbol)
-        (doseq [s all-annotated-arglists]
+        (doseq [[s constructor?] all-annotated-arglists]
           (assert (is (string? s)))
           (testing s
-            (is (re-find #"\^.*\[" s))
+            (if constructor?
+              (is (re-find #"^\[" s))
+              (is (re-find #"\^.*\[" s)))
             ;; Assert that the format doesn't include past bugs:
             (is (not (string/includes? s "<")))
             (is (not (string/includes? s "^Object java.lang.Object")))

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -444,7 +444,7 @@
            vals)
        (map vals)
        (reduce into)
-       ;; Only methods (and not fields) have arglists:
+       ;; Only methods/constructors (and not fields) have arglists:
        (filter (fn [{:keys [returns] n :name}]
                  (or returns
                      (= n class-symbol))))))


### PR DESCRIPTION
Restores all the constructor info that was temporarily disabled in https://github.com/clojure-emacs/orchard/pull/192, expanding related test coverage.