### PR TITLE
`orchard.inspect`: offer new `previous-sibling` and `next-sibling` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### New features
+
+* `orchard.inspect`: offer new `previous-sibling` and `next-sibling` functions.
+  * These help navigate sequential collections one item at a time, in a streamlined fashion.
+
 ## 0.16.1 (2023-10-05)
 
 * Make some internals safer.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LEIN_PROFILES ?= "+dev,+test,+1.11"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.
-ENRICH_CLASSPATH_VERSION="1.18.0"
+ENRICH_CLASSPATH_VERSION="1.18.2"
 
 resources/clojuredocs/export.edn:
 curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn

--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
                                          `add-cognitest)]}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.38.1"]
+             :dev {:plugins [[cider/cider-nrepl "0.40.0"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]


### PR DESCRIPTION
> Part of https://github.com/clojure-emacs/cider/issues/3529

I can confirm these work as intended (as I already tried using them in cider / cider-nrepl)

Cheers - V