### PR TITLE
Inspector - misc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Changes
 
 * `orchard.inspect`: don't render keyword/symbol/number values as strings.
+* `orchard.inspect`: don't use `pr-str` over the main `Value: ` being inspected. 
+  * All values are already formatted as strings, so this `pr-str` was redundant.
 
 ## 0.16.1 (2023-10-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * `orchard.inspect`: don't render keyword/symbol/number values as strings.
 * `orchard.inspect`: don't use `pr-str` over the main `Value: ` being inspected. 
   * All values are already formatted as strings, so this `pr-str` was redundant.
+* `orchard.inspect`: render non-accessible fields better.
+  * If a given field cannot be inspected (because it's private and the JDK module system prevents opening it), we return the fixed symbol `<non-inspectable value>` for representing its value, clients being free to elide its rendering.
+  * Now, for a given inspected Object (except Class objects), we return these sections, if present: `Instance fields`, `Static fields` ,`Private instance fields`, `Private static fields`.
+  * For Class objects, we keep grouping the fields under a single `Fields` section.
+* `orchard.inspect`: render field names as symbols, not strings.
 
 ## 0.16.1 (2023-10-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * `orchard.inspect`: offer new `previous-sibling` and `next-sibling` functions.
   * These help navigate sequential collections one item at a time, in a streamlined fashion.
 
+### Changes
+
+* `orchard.inspect`: don't render keyword/symbol/number values as strings.
+
 ## 0.16.1 (2023-10-05)
 
 * Make some internals safer.

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,8 @@
                                      [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
 
 
-             :test {:dependencies [[org.clojure/java.classpath "1.0.0"]]
+             :test {:dependencies [[org.clojure/java.classpath "1.0.0"]
+                                   [nubank/matcher-combinators "3.8.8"]]
                     :resource-paths ["test-resources"
                                      "not-a.jar"
                                      "does-not-exist.jar"]

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -216,8 +216,8 @@
 ;;
 ;; Good for method extenders to use
 
-(defn- atom? [val]
-  (some #(% val) [number? string? symbol? keyword?]))
+(defn- scalar? [val]
+  (some #(% val) [number? symbol? keyword?]))
 
 (defn safe-pr-seq
   ([value fmt]
@@ -250,7 +250,8 @@
 (defn value-types [value]
   (cond
     (nil? value)                                   nil
-    (atom? value)                                  :atom
+    (string? value)                                :string
+    (scalar? value)                                :scalar
     (and (instance? Seqable value) (empty? value)) :seq-empty
     (and (map? value) (short? value))              :map
     (map-entry? value)                             :map-entry
@@ -276,7 +277,10 @@
 (defmethod inspect-value nil [_value]
   "nil")
 
-(defmethod inspect-value :atom [value]
+(defmethod inspect-value :scalar [value]
+  (pr-str value))
+
+(defmethod inspect-value :string [value]
   (truncate-string (pr-str value)))
 
 (defmethod inspect-value :map-entry [[k v]]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -496,6 +496,7 @@
 
 (deftest inspect-value-test
   (is (= "1" (inspect/inspect-value 1)))
+  (is (= "(0 1 2 3 4 5 6 7 8 9)" (inspect/inspect-value (eduction (range 10)))))
   (is (= ":a" (inspect/inspect-value :a)))
   (is (= "a" (inspect/inspect-value 'a)))
   (is (= "\"a\"" (inspect/inspect-value "a")))
@@ -624,17 +625,17 @@
                   ": "
                   (:value "clojure.lang.TaggedLiteral" 0)
                   (:newline)
-                  "Value" ": " (:value "\"#foo ()\"" 1)
+                  "Value" ": " (:value "#foo ()" 1)
                   (:newline)
                   (:newline)
-                  "--- Fields:"
-                  (:newline) "  " (:value "\"form\"" 2) " = " (:value "()" 3)
-                  (:newline) "  " (:value "\"tag\"" 4) " = " (:value "foo" 5)
+                  "--- Instance fields:"
+                  (:newline) "  " (:value "form" 2) " = " (:value "()" 3)
+                  (:newline) "  " (:value "tag" 4) " = " (:value "foo" 5)
                   (:newline)
                   (:newline)
                   "--- Static fields:"
-                  (:newline) "  " (:value "\"FORM_KW\"" 6) " = " (:value ":form" 7)
-                  (:newline) "  " (:value "\"TAG_KW\"" 8) " = " (:value ":tag" 9)
+                  (:newline) "  " (:value "FORM_KW" 6) " = " (:value ":form" 7)
+                  (:newline) "  " (:value "TAG_KW" 8) " = " (:value ":tag" 9)
                   (:newline))
                 (render (inspect/start (inspect/fresh)
                                        (clojure.lang.TaggedLiteral/create 'foo ())))))))
@@ -930,9 +931,7 @@
                                     ":via\\n [{:type clojure.lang.ExceptionInfo\\n   "
                                     ":message \\\"BOOM\\\"\\n   "
                                     ":data {}\\n   :at nil}]\\n :trace\\n []}\""))
-                          (str "\"#error {\\n :cause \\\"BOOM\\\"\\n :data {}\\n :via\\n "
-                               "[{:type clojure.lang.ExceptionInfo\\n   "
-                               ":message \\\"BOOM\\\"\\n   :data {}}]\\n :trace\\n []}\"")) 1)
+                          "#error {\n :cause \"BOOM\"\n :data {}\n :via\n [{:type clojure.lang.ExceptionInfo\n   :message \"BOOM\"\n   :data {}}]\n :trace\n []}") 1)
                       (:newline)
                       (:newline))
                     (header rendered))))
@@ -972,7 +971,7 @@
                       (:newline)
                       "Value"
                       ": "
-                      (:value "\"(0 1 2 3 4 5 6 7 8 9)\"" 1)
+                      (:value "(0 1 2 3 4 5 6 7 8 9)" 1)
                       (:newline)
                       (:newline))
                     (header rendered)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -494,6 +494,14 @@
         "[ ( 1 1 1 1 1 1 ... ) ]" [(repeat 1)]
         "{ :a { ( 0 1 2 3 4 5 ... ) 1, 2 3, 4 5, 6 7, 8 9, 10 11 } }" {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}))))
 
+(deftest inspect-value-test
+  (is (= "1" (inspect/inspect-value 1)))
+  (is (= ":a" (inspect/inspect-value :a)))
+  (is (= "a" (inspect/inspect-value 'a)))
+  (is (= "\"a\"" (inspect/inspect-value "a")))
+  (binding [inspect/*max-atom-length* 5]
+    (is (= "\"1..." (inspect/inspect-value "1234567890")))))
+
 (deftest inspect-class-fields-test
   (testing "inspecting a class with fields renders correctly"
     (is (match? (case java-api-version


### PR DESCRIPTION
* `orchard.inspect`: don't use `pr-str` over the main `Value: ` being inspected. 
  * All values are already formatted as strings, so this `pr-str` was redundant.
* `orchard.inspect`: render non-accessible fields better.
  * If a given field cannot be inspected (because it's private and the JDK module system prevents opening it), we return the fixed symbol `<non-inspectable value>` for representing its value, clients being free to elide its rendering.
  * Now, for a given inspected Object (except Class objects), we return these sections, if present: `Instance fields`, `Static fields` ,`Private instance fields`, `Private static fields`.
  * For Class objects, we keep grouping the fields under a single `Fields` section.
* `orchard.inspect`: render field names as symbols, not strings.

Cheers - V