### PR TITLE
`orchard.inspect`: don't render `Datafy` sections identical to the data they refer to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* `orchard.inspect`: don't render `Datafy` sections identical to the data they refer to, for nil-valued maps.
+
 ## 0.17.0 (2023-10-24)
 
 ### New features

--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
                                          `add-cognitest)]}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.40.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.41.0"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -129,7 +129,8 @@
   (->> rendered
        (drop-while #(not (section? name %)))
        (take-while #(or (section? name %)
-                        (not (section? ".*" %))))))
+                        (not (section? ".*" %))))
+       (not-empty)))
 
 (defn- datafy-section [rendered]
   (section "Datafy" rendered))
@@ -988,8 +989,7 @@
 
     (let [rendered (-> (eduction (range 100)) inspect render)]
       (testing "doesn't render page info section"
-        (is (match? '()
-                    (section "Page Info" rendered)))))))
+        (is (nil? (section "Page Info" rendered)))))))
 
 (deftest tap-current-value
   (testing "tap> current value"
@@ -1029,3 +1029,10 @@
           (is (= expected @proof)))
 
         ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))))
+
+(deftest datafy-test
+  (testing "When `(datafy x)` is identical to `x`, no Datafy section is included"
+    (let [rendered (-> {:foo :bar} inspect render)]
+      (is (nil? (datafy-section rendered))))
+    (let [rendered (-> {:foo :bar :nilable nil} inspect render)]
+      (is (nil? (datafy-section rendered))))))


### PR DESCRIPTION
We already were trying this, but for maps, we were comparing `<x>` with `(datafy <x without nil-valued entries>)`, so the comparison was often different.