### PR TITLE
[inspect] Right-align indices when rendering indexed collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#202](https://github.com/clojure-emacs/orchard/issues/202): `orchard.inspect`: right-align indices when rendering indexed collections.
+
 ### Bugs fixed
 
 * `orchard.inspect`: don't render `Datafy` sections identical to the data they refer to, for nil-valued maps.

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -409,16 +409,22 @@
           mappable))
 
 (defn render-indexed-values
-  ([inspector obj] (render-indexed-values inspector obj 0))
-  ([inspector obj idx-starts-from]
-   (loop [ins inspector, obj (seq obj), idx idx-starts-from]
-     (if obj
-       (recur (-> ins
-                  (render-indent (str idx) ". ")
-                  (render-value (first obj))
-                  (render-ln))
-              (next obj) (inc idx))
-       ins))))
+  "Render an indexed collection of values. Renders all values in `chunk`, so
+  `chunk` must be finite."
+  ([inspector chunk] (render-indexed-values inspector chunk 0))
+  ([inspector chunk idx-starts-from]
+   (let [n (count chunk)
+         last-idx (+ idx-starts-from n -1)
+         last-idx-len (count (str last-idx))
+         idx-fmt (str "%" last-idx-len "s")]
+     (loop [ins inspector, chunk (seq chunk), idx idx-starts-from]
+       (if chunk
+         (recur (-> ins
+                    (render-indent (format idx-fmt idx) ". ")
+                    (render-value (first chunk))
+                    (render-ln))
+                (next chunk) (inc idx))
+         ins)))))
 
 (defn last-page [{:keys [current-page page-size]} obj]
   (cond

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -550,7 +550,59 @@
                       '(:newline)
                       "  " "3" ". " (list :value "3" number?)
                       '(:newline))
-                (render (inspect/start (inspect/fresh) [1 2 nil 3]))))))
+                (render (inspect/start (inspect/fresh) [1 2 nil 3])))))
+
+  (testing "inspect :coll aligns index numbers so that values appear aligned"
+    (is (match? (list "Class"
+                      ": " (list :value "clojure.lang.PersistentVector" number?)
+                      '(:newline)
+                      '(:newline)
+                      "--- Contents:"
+                      '(:newline)
+                      "  " " 0" ". " (list :value "0" number?)
+                      '(:newline)
+                      "  " " 1" ". " (list :value "1" number?)
+                      '(:newline)
+                      "  " " 2" ". " (list :value "2" number?)
+                      '(:newline)
+                      "  " " 3" ". " (list :value "3" number?)
+                      '(:newline)
+                      "  " " 4" ". " (list :value "4" number?)
+                      '(:newline)
+                      "  " " 5" ". " (list :value "5" number?)
+                      '(:newline)
+                      "  " " 6" ". " (list :value "6" number?)
+                      '(:newline)
+                      "  " " 7" ". " (list :value "7" number?)
+                      '(:newline)
+                      "  " " 8" ". " (list :value "8" number?)
+                      '(:newline)
+                      "  " " 9" ". " (list :value "9" number?)
+                      ;; Numbers above have padding, "10" below doesn't.
+                      '(:newline)
+                      "  " "10" ". " (list :value "10" number?)
+                      '(:newline))
+                (render (inspect/start (inspect/fresh) (vec (range 11)))))))
+
+  (testing "inspect :coll aligns index numbers correctly for page size > 100"
+    (let [rendered (-> (inspect/fresh)
+                       (inspect/start (vec (range 101)))
+                       (inspect/set-page-size 200)
+                       render)
+          head (take 11 rendered)
+          tail (take-last 5 rendered)]
+      (is (match? (list "Class"
+                        ": " (list :value "clojure.lang.PersistentVector" number?)
+                        '(:newline)
+                        '(:newline)
+                        "--- Contents:"
+                        '(:newline)
+                        "  " "  0" ". " (list :value "0" number?))
+                  head))
+      ;; "  0" has two spaces of padding, "100" below has none.
+      (is (match? (list "  " "100" ". " (list :value "100" number?)
+                        '(:newline))
+                  tail)))))
 
 (deftest inspect-coll-nav-test
   (testing "inspecting a collection extended with the Datafiable and Navigable protocols"


### PR DESCRIPTION
When inspecting a linear collection, the indices cause an ugly indentation shift on digit promotions (9->10, 99->100). This PR fixes this. Here's now it looks currently:

<img width="267" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/7b0b738b-7aa8-49d1-8379-fdc39baa4cbf">

Here's how it looks after the patch:
<img width="249" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/fbcf699a-adc1-4bf7-b3c2-290fe14f179b">

In the future, we might want to do the similar for associative collections, but I think it's a more contentious topic. Some people don't like their values aligned to keys if it causes a large gap on the other side (me included). But aligning indices shouldn't be controversial since most of the time it's gonna be 1 space, 2 spaces at the very most in the edge case.