### PR TITLE
Introduce new `read-ns-form`, `project-ns-forms`, `ns-form->imports` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## New features
+
+* `orchard.namespace`: introduce new `read-ns-form`, `project-ns-forms`, `ns-form-imports` functions.
+
 ## 0.18.0 (2023-10-30)
 
 ### Changes

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -10,6 +10,50 @@
   (is (contains? (into #{} (sut/project-namespaces))
                  'orchard.namespace)))
 
+(deftest project-ns-forms-test
+  (is (map? (sut/project-ns-forms)))
+  (is (contains? (into #{} (sut/project-ns-forms))
+                 ['orchard.namespace-test
+                  '(ns orchard.namespace-test
+                     (:require
+                      [clojure.java.io :as io]
+                      [clojure.string :as string]
+                      [clojure.test :refer [are deftest is testing]]
+                      [orchard.misc :as misc]
+                      [orchard.namespace :as sut]))])))
+
+(deftest ns-form-imports-test
+  (let [corpus (mapcat sut/ns-form-imports (vals (sut/project-ns-forms)))]
+    (is (seq corpus))
+    (doseq [s corpus]
+      (is (symbol? s))
+      (when-not ('#{com.sun.tools.javadoc.RootDocImpl ;; classes on the project can be JDK dependent
+                    com.sun.tools.javadoc.ModifierFilter
+                    com.sun.tools.javadoc.Messager
+                    com.sun.tools.javadoc.JavadocTool
+                    com.sun.tools.javadoc.JavadocEnter
+                    com.sun.tools.javadoc.DocEnv
+                    com.sun.javadoc.Type
+                    com.sun.javadoc.Tag
+                    com.sun.javadoc.RootDoc
+                    com.sun.javadoc.Parameter
+                    com.sun.javadoc.MethodDoc
+                    com.sun.javadoc.FieldDoc
+                    com.sun.javadoc.Doc
+                    com.sun.javadoc.ConstructorDoc
+                    com.sun.javadoc.ClassDoc
+                    jdk.javadoc.doclet.Doclet
+                    jdk.javadoc.doclet.DocletEnvironment
+                    com.sun.source.tree.ClassTree
+                    com.sun.tools.javac.tree.JCTree
+                    com.sun.tools.javac.util.Abort
+                    com.sun.tools.javac.util.Context
+                    com.sun.tools.javac.util.List
+                    com.sun.source.doctree.DocCommentTree}
+                 s)
+        (is (-> s eval class?)
+            (pr-str s))))))
+
 (deftest loaded-namespaces-test
   ;; If we don't pass the second arg, some cider ns will be returned
   (is (some #(re-find #".*orchard" %) (sut/loaded-namespaces)))

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -85,7 +85,7 @@
 (deftest has-tests-errors
   (is (sut/has-tests? (find-ns 'orchard.namespace-test))))
 
-(deftest read-namespace-test
+(deftest read-ns-name-test
   (testing "Namespace parsing"
     (let [url (-> (System/getProperty "java.io.tmpdir")
                   (io/file "orchard.namespace-test.txt")
@@ -93,30 +93,30 @@
           uri (.toURI url)]
       (testing "of an empty file"
         (spit url "")
-        (is (nil? (sut/read-namespace uri))))
+        (is (nil? (sut/read-ns-name uri))))
       (testing "of an unparsable file"
         (spit url "(]$@(")
-        (is (nil? (sut/read-namespace uri))))
+        (is (nil? (sut/read-ns-name uri))))
       (testing "of non-list tokens"
         (spit url "these are (still) tokens")
-        (is (nil? (sut/read-namespace uri))))
+        (is (nil? (sut/read-ns-name uri))))
       (testing "when tokens precede the ns form"
         (spit url "there [is a] (ns here) after all")
-        (is (= 'here (sut/read-namespace uri))))
+        (is (= 'here (sut/read-ns-name uri))))
       (testing "when multiple ns forms are present"
         (spit url "(ns ns1) (ns ns2) (ns ns3)")
-        (is (= 'ns1 (sut/read-namespace uri))))
+        (is (= 'ns1 (sut/read-ns-name uri))))
       (testing "when ns form is invalid"
         (spit url "(ns (:require [clojure.string]))")
-        (is (nil? (sut/read-namespace uri))))
+        (is (nil? (sut/read-ns-name uri))))
       (testing "of top-level forms only"
         (spit url "(comment (ns ns1)) (ns ns2) (ns ns3)")
-        (is (= 'ns2 (sut/read-namespace uri))))
+        (is (= 'ns2 (sut/read-ns-name uri))))
       (testing "of namespace with read conditionals in its `ns` form"
         (is (= 'orchard.test-ns (-> "orchard/test_ns.cljc"
                                     io/resource
                                     io/as-url
-                                    sut/read-namespace))))
+                                    sut/read-ns-name))))
       (io/delete-file url))))
 
 (deftest namespace-resolution
@@ -130,7 +130,7 @@
       (testing "namespace symbols to source files"
         (is (every? identity (map sut/canonical-source nses))))
       (testing "source files to namespace symbols"
-        (is (= nses (map (comp sut/read-namespace    ; src -> ns
+        (is (= nses (map (comp sut/read-ns-name    ; src -> ns
                                sut/canonical-source) ; ns -> src
                          nses)))))))
 


### PR DESCRIPTION
Supports https://github.com/clojure-emacs/cider-nrepl/issues/830

The idea is to provide a means to easily get a list of `:import`ed classes, even if the underlying namespaces haven't been loaded yet.

Cheers - V