### PR TITLE
`orchard.java`: add `*analyze-sources*` dynamic var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## New features
+
+* `orchard.java`: add `*analyze-sources*` dynamic var.
+  * You can bind this to `false` in order to increase performance / decrease the amount of information returned.
+
 ## 0.19.0 (2023-11-04)
 
 ## New features

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
                                          `add-cognitest)]}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.41.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.43.1"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -528,3 +528,13 @@
             (is (not (string/includes? s "^function.Function java.util.function.Function")))
             (is (not (string/includes? s "^java.util.function.Function java.util.function.Function")))
             (assert (is (not (string/includes? s "java.lang"))))))))))
+
+(when (and util/has-enriched-classpath?
+           @@sut/parser-next-available?)
+  (deftest *analyze-sources*-test
+    (with-redefs [cache (LruMap. 100)]
+      (binding [sut/*analyze-sources* false]
+        (is (nil? (:doc (sut/resolve-symbol 'user `Thread/activeCount)))
+            "Binding this var to `false` results in source info being omitted"))
+      (is (seq (:doc (sut/resolve-symbol 'user `Thread/activeCount)))
+          "Subsequent calls aren't affected, since there's no caching interference"))))


### PR DESCRIPTION
Haystack's Java needs are rather humble https://github.com/clojure-emacs/haystack/blob/3b0d8a464f60cb0c0e4114b9d853165d6d2f59ae/src/haystack/analyzer.clj#L91-L95 and we were responding slowly to those requests as we were parsing the underlying .java files when possible.

The introduced dyn var makes it possible for consumers to request less info, faster.