### PR TITLE
Add a `Name` header to inspected Class objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#215](https://github.com/clojure-emacs/orchard/issues/215): `orchard.inspect`: offer new `tap-indexed` function.
   * It allows to `tap>` a sub-item by `idx`, without navigating to it.
 
+## Changes
+
+* [#217](https://github.com/clojure-emacs/orchard/issues/217): Add a `Name` header to inspected Class objects.
+
 ## 0.20.0 (2023-11-11)
 
 ## New features

--- a/project.clj
+++ b/project.clj
@@ -84,7 +84,7 @@
                                          `add-cognitest)]}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.43.3"]
+             :dev {:plugins [[cider/cider-nrepl "0.44.0"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -769,7 +769,15 @@
                             '(:newline)
                             "  " (list :value ":name" pos?) " = " (list :value "java.lang.Object" pos?)
                             '(:newline))
-                      (datafy-section rendered))))))))
+                      (datafy-section rendered)))))))
+
+  (testing "inspecting the java.lang.Class class"
+    (let [rendered (-> Class inspect render)]
+      (testing "renders the interfaces section"
+        (is (match? (matchers/embeds (list "--- Interfaces:"
+                                           '(:newline)
+                                           "  " (list :value "java.io.Serializable" number?)))
+                    (section "Interfaces" rendered)))))))
 
 (deftest inspect-atom-test
   (testing "inspecting an atom"


### PR DESCRIPTION
> Closes https://github.com/clojure-emacs/orchard/issues/217

Adds a `Name` header to inspected Class objects.

Also makes some tests less fragile - they were breaking on JDK 21.

Cheers - V