### PR TITLE
Catch NoClassDefFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* [#224](https://github.com/clojure-emacs/orchard/issues/224): Don't error on NoClassDefFoundError.
+
 ## 0.22.0 (2024-01-14)
 
 ## Changes

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -462,6 +462,7 @@
   [ns sym]
   (when-let [ns (find-ns ns)]
     (let [c (try (ns-resolve ns sym)
+                 (catch java.lang.NoClassDefFoundError _)
                  (catch Exception _))]
       (if (class? c)
         (class-info (-> ^Class c .getName symbol))

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -103,9 +103,9 @@
          (catch ClassNotFoundException _
            nil)
          (catch java.lang.NoClassDefFoundError _
-           ;; this can happen if there is a java class with a camel cased name
+           ;; This can happen if there is a java class with a camel cased name
            ;; that otherwise matches the name of a clojure namespace, on a case
-           ;; indifferent filesystem, eg. on OS X.
+           ;; indifferent filesystem, eg. on macOS.
            nil)
          ;; TODO: Preserve and display the exception info
          (catch Exception _

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -102,6 +102,11 @@
          ;; Impl might try to resolve it as a class, which may fail
          (catch ClassNotFoundException _
            nil)
+         (catch java.lang.NoClassDefFoundError _
+           ;; this can happen if there is a java class with a camel cased name
+           ;; that otherwise matches the name of a clojure namespace, on a case
+           ;; indifferent filesystem, eg. on OS X.
+           nil)
          ;; TODO: Preserve and display the exception info
          (catch Exception _
            nil))))


### PR DESCRIPTION
This exception can be thrown on a case indifferent filesystem, eg. on
macOS.

One way this happens is if there is a java class with a camel cased name
that otherwise matches the name of a clojure namespace.

For some reason, when this exception was thrown, the classes in the
class cache were also getting initialised.