### PR TITLE
`orchard.xref`: avoid occasional null pointer access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 * [#224](https://github.com/clojure-emacs/orchard/issues/224): Don't error on NoClassDefFoundError.
+* `orchard.xref`: avoid occasional null pointer access.
 
 ## 0.22.0 (2024-01-14)
 

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -47,14 +47,15 @@
                              v
                              (locking eval-lock
                                (eval v)))]
-    (into #{} (keep (fn [^java.lang.reflect.Field f]
-                      (or (and (identical? clojure.lang.Var (.getType f))
-                               (java.lang.reflect.Modifier/isPublic (.getModifiers f))
-                               (java.lang.reflect.Modifier/isStatic (.getModifiers f))
-                               (-> f .getName (.startsWith "const__"))
-                               (.get f (fn-name v)))
-                          nil))
-                    (.getDeclaredFields v)))))
+    (when (class? v)
+      (into #{} (keep (fn [^java.lang.reflect.Field f]
+                        (or (and (identical? clojure.lang.Var (.getType f))
+                                 (java.lang.reflect.Modifier/isPublic (.getModifiers f))
+                                 (java.lang.reflect.Modifier/isStatic (.getModifiers f))
+                                 (-> f .getName (.startsWith "const__"))
+                                 (.get f (fn-name v)))
+                            nil))
+                      (.getDeclaredFields v))))))
 
 (def ^:private class-cache
   "Reference to Clojures class cache.

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -47,7 +47,7 @@
                              v
                              (locking eval-lock
                                (eval v)))]
-    (when (class? v)
+    (when (class? v) ;; maybe a non-class was evaled
       (into #{} (keep (fn [^java.lang.reflect.Field f]
                         (or (and (identical? clojure.lang.Var (.getType f))
                                  (java.lang.reflect.Modifier/isPublic (.getModifiers f))

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -20,7 +20,7 @@
   (is (nil? (xref/fn-deps-class 2))
       "Is garbage-safe (important, as it uses `eval` which can return anything)")
 
-  (is (set/superset? (xref/fn-deps-class (.getClass xref/fn-deps-class))
+  (is (set/superset? (xref/fn-deps-class (.getClass ^Object xref/fn-deps-class))
                      #{#'clojure.core/keep
                        #'clojure.core/into
                        #'clojure.core/class?

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -71,9 +71,6 @@
 (def yyy (symbol (str (gensym))
                  (str (gensym))))
 
-(not (= #{#'orchard.xref-test/fn-deps-test #'clojure.core/filter #'orchard.xref-test/fn-transitive-dep #'clojure.core/inc' #'clojure.core/range #'clojure.test/test-var #'clojure.core/even? #'clojure.core/map #'orchard.xref-test/fn-dep}
-        #{#'orchard.xref-test/fn-deps-test #'orchard.xref-test/fn-deps-class-test #'clojure.core/filter #'orchard.xref-test/fn-transitive-dep #'clojure.core/inc' #'clojure.core/range #'clojure.test/test-var #'clojure.core/even? #'clojure.core/map #'orchard.xref-test/fn-dep}))
-
 (deftest fn-transitive-deps-test
   (testing "basics"
     (let [expected #{#'orchard.xref-test/fn-deps-test #'orchard.xref-test/fn-dep #'clojure.core/even?

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -12,6 +12,19 @@
 (defn- dummy-fn [_x]
   (map #(fn-dep % 2) (filter even? (range 1 10))))
 
+(deftest fn-deps-class-test
+  (is (nil? (xref/fn-deps-class nil))
+      "Is nil-safe (important, as it uses `eval` which can return anything)")
+
+  (is (nil? (xref/fn-deps-class 2))
+      "Is garbage-safe (important, as it uses `eval` which can return anything)")
+
+  (is (= #{#'clojure.core/keep
+           #'clojure.core/into
+           #'clojure.core/class?
+           #'orchard.xref/eval-lock}
+         (xref/fn-deps-class (.getClass xref/fn-deps-class)))))
+
 ;; Supports #'fn-deps-test
 (deftest sample-test
   (is (some? xref/eval-lock))


### PR DESCRIPTION
Performing `xref` over an invalid symbol (e.g. not a function) could result in an `eval` that would not return a `Class` object, which would then make the `.getDeclaredFields` call invalid.