### PR TITLE
`info*`, offer `:var-meta-allowlist` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.23.0 (2024-03-03)
+
 ## Changes
 
 * [cider-nrepl#851](https://github.com/clojure-emacs/cider-nrepl/issues/851): `info*`, offer `:var-meta-allowlist` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master (unreleased)
 
+## Changes
+
+* [cider-nrepl#851](https://github.com/clojure-emacs/cider-nrepl/issues/851): `info*`, offer `:var-meta-allowlist` option.
+  * It allows consumers to specify var metadata beyond Orchard's fixed whitelist.
+* Rename `orchard.meta/var-meta-whitelist` var to `orchard.meta/var-meta-allowlist`.
+  * `orchard.meta/var-meta-whitelist` remains offered as a `^:deprecated` var.
+
 ### Bugs Fixed
 
 * [#224](https://github.com/clojure-emacs/orchard/issues/224): Don't error on NoClassDefFoundError.

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ lint: kondo cljfmt eastwood
 deploy: check-env clean
 	lein with-profile -user,-dev,+$(VERSION),-provided deploy clojars
 
-# Usage: PROJECT_VERSION=0.22.0 make install
+# Usage: PROJECT_VERSION=0.23.0 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.22.0"]
+[cider/orchard "0.23.0"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
@@ -156,7 +156,7 @@ make repl
 You can install Orchard locally like this:
 
 ```
-PROJECT_VERSION=0.22.0 make install
+PROJECT_VERSION=0.23.0 make install
 ```
 
 For releasing to [Clojars](https://clojars.org/):

--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
                                          `add-cognitest)]}
 
              ;; Development tools
-             :dev {:plugins [[cider/cider-nrepl "0.44.0"]
+             :dev {:plugins [[cider/cider-nrepl "0.45.0"]
                              [refactor-nrepl "3.9.0"]]
                    :dependencies [[nrepl/nrepl "1.0.0"]
                                   [org.clojure/tools.namespace "1.4.4"]]

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -63,7 +63,7 @@
 
 (defn clj-meta
   {:added "0.5"}
-  [{:keys [dialect ns sym computed-ns unqualified-sym]}]
+  [{:keys [dialect ns sym computed-ns unqualified-sym var-meta-allowlist]}]
   {:pre [(= dialect :clj)]}
   (let [ns (or ns computed-ns)
         ns (or (when (some-> ns find-ns)
@@ -73,7 +73,7 @@
      ;; it's a special (special-symbol?)
      (m/special-sym-meta sym)
      ;; it's a var
-     (some-> ns (m/resolve-var sym) (m/var-meta))
+     (some-> ns (m/resolve-var sym) (m/var-meta var-meta-allowlist))
      ;; it's a Java constructor/static member symbol
      (some-> ns (java/resolve-symbol sym))
      ;; it's a Java class/record type symbol
@@ -146,12 +146,16 @@
              (cljs-meta/normalize-var-meta)))))
 
 (defn info*
-  "Provide the info map for the input ns and sym.
+  "Provide the info map for the input `:ns` and `:sym`.
 
-  The default dialect is :clj but it can be specified as part of params.
+  The default `:dialect` is `:clj` but it can be specified as part of `params`.
 
-  Note that the :cljs dialect requires the compiler state to be passed
-  in as :env key in params."
+  Note that the `:cljs` dialect requires the compiler state to be passed
+  in as `:env` key in params.
+
+  A `:var-meta-allowlist` can be optionally passed
+  (defaults to `orchard.meta/var-meta-allowlist`;
+   only applies to `:clj` since for `:cljs` there's no allowlisting)."
   [params]
   (let [params  (normalize-params params)
         dialect (:dialect params)

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -232,21 +232,24 @@
   [cljs-env var-map]
   (merge-meta-for-indirect-var* var-map var-map identity cljs-env))
 
-(def var-meta-whitelist
+(def var-meta-allowlist
   [:ns :name :doc :file :arglists :forms :macro :special-form
    :protocol :line :column :static :added :deprecated :resource :style/indent :indent])
+
+(def ^:deprecated var-meta-whitelist
+  var-meta-allowlist)
 
 ;; TODO: Split the responsibility of finding meta and normalizing the meta map.
 (defn var-meta
   "Return a map of metadata for var v.
-  If whitelist is missing use var-meta-whitelist."
-  ([v] (var-meta v var-meta-whitelist))
-  ([v whitelist]
+  If `allowlist` is missing, use `var-meta-allowlist`."
+  ([v] (var-meta v var-meta-allowlist))
+  ([v allowlist]
    (when (var? v)
      (-> v
          meta
          maybe-protocol
-         (select-keys (or whitelist var-meta-whitelist))
+         (select-keys (or allowlist var-meta-allowlist))
          map-seq
          maybe-add-file
          maybe-add-url

--- a/test-resources/orchard/test_ns_dep.cljc
+++ b/test-resources/orchard/test_ns_dep.cljc
@@ -2,7 +2,10 @@
   (:require
    [clojure.string :as string]))
 
-(defn foo-in-dep [foo] :bar)
+(defn foo-in-dep
+  {:custom/meta 1}
+  [foo]
+  :bar)
 
 (def x ::dep-namespaced-keyword)
 

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -140,7 +140,15 @@
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :arglists])))
-          (is (string/includes? (:file i) "test_ns_dep")))))))
+          (is (string/includes? (:file i) "test_ns_dep")))
+        (testing "`:var-meta-allowlist`"
+          (is (= {:ns 'orchard.test-ns-dep
+                  :custom/meta 1
+                  :name 'foo-in-dep}
+                 (-> params
+                     (assoc :var-meta-allowlist [:ns :name :custom/meta])
+                     (info/info*)
+                     (dissoc :file)))))))))
 
 (deftest info-resolve-var-before-alias-test
   (testing "resolve a fully qualified var before an alias - test for bug #53"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -191,33 +191,35 @@
                     (inspect/down 1)
                     render)))))
 
+(def any-var 42)
+
 (deftest inspect-var-test
   (testing "inspecting a var"
-    (let [rendered (-> #'*assert* inspect render)]
+    (let [rendered (-> #'any-var inspect render)]
       (testing "renders the header"
         (is (match? (list "Class"
                           ": "
                           (list :value "clojure.lang.Var" number?)
                           '(:newline)
                           "Value: "
-                          (list :value "true" number?)
+                          (list :value "42" number?)
                           '(:newline)
                           '(:newline))
                     (header rendered))))
       (testing "renders the meta information section"
-        (is (match? (cond-> (list "--- Meta Information:"
-                                  '(:newline)
-                                  "  " (list :value ":ns" number?) " = " (list :value "clojure.core" number?)
-                                  '(:newline)
-                                  "  " (list :value ":name" number?) " = " (list :value "*assert*" number?)
-                                  '(:newline))
-                      datafy? (concat ['(:newline)]))
+        (is (match? (matchers/embeds (cond-> (list "--- Meta Information:"
+                                                   '(:newline)
+                                                   "  " (list :value ":ns" number?) " = " (list :value "orchard.inspect-test" number?)
+                                                   '(:newline)
+                                                   "  " (list :value ":name" number?) " = " (list :value "any-var" number?)
+                                                   '(:newline))
+                                       datafy? (concat ['(:newline)])))
                     (section "Meta Information" rendered))))
       (when datafy?
         (testing "renders the datafy section"
           (is (match? (list "--- Datafy:"
                             '(:newline)
-                            "  " "0" ". " (list :value "true" number?)
+                            "  " "0" ". " (list :value "42" number?)
                             '(:newline))
                       (datafy-section rendered))))))))
 


### PR DESCRIPTION
> Part of https://github.com/clojure-emacs/cider-nrepl/issues/851

It allows consumers to specify var metadata beyond Orchard's fixed whitelist.

Cheers - V