### PR TITLE
Fix inspector navigation fns to work with pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* [#216](https://github.com/clojure-emacs/orchard/issues/216): Fix inspector navigation (`down` and `next-sibling`) with pagination.
+
 ## 0.23.0 (2024-03-03)
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugs Fixed
 
 * [#216](https://github.com/clojure-emacs/orchard/issues/216): Fix some pagination issues with inspector navigation.
-  * `down` fn goes beyond current page. `next-sibling` and `previous-sibling` fns work in all pages.
+  * `orchard.inspect/down` fn is now able to go beyond the current page. `next-sibling` and `previous-sibling` fns work in all pages.
 
 ## 0.23.0 (2024-03-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bugs Fixed
 
-* [#216](https://github.com/clojure-emacs/orchard/issues/216): Fix inspector navigation (`down` and `next-sibling`) with pagination.
+* [#216](https://github.com/clojure-emacs/orchard/issues/216): Fix some pagination issues with inspector navigation.
+  * `down` fn goes beyond current page. `next-sibling` and `previous-sibling` fns work in all pages.
 
 ## 0.23.0 (2024-03-03)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -144,14 +144,18 @@
 (defn next-page
   "Jump to the next page when inspecting a paginated sequence/map. Does nothing
   if already on the last page."
-  [inspector]
-  (inspect-render (update-in inspector [:current-page] inc)))
+  [{:keys [current-page] :as inspector}]
+  (if (= current-page (last-page inspector))
+    inspector
+    (inspect-render (update inspector :current-page inc))))
 
 (defn prev-page
   "Jump to the previous page when inspecting a paginated sequence/map. Does
   nothing if already on the first page."
-  [inspector]
-  (inspect-render (update-in inspector [:current-page] dec)))
+  [{:keys [current-page] :as inspector}]
+  (if (zero? current-page)
+    inspector
+    (inspect-render (update inspector :current-page dec))))
 
 (defn up
   "Pop the stack and re-render an earlier value."

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -117,9 +117,6 @@
   ([inspector] (last-page inspector (:value inspector)))
   ([{:keys [current-page page-size]} obj]
    (cond
-     (map? obj)
-     (quot (dec (* 2 (count obj))) page-size)
-
      (instance? clojure.lang.Counted obj)
      (quot (dec (count obj)) page-size)
 
@@ -145,7 +142,7 @@
   "Jump to the next page when inspecting a paginated sequence/map. Does nothing
   if already on the last page."
   [{:keys [current-page] :as inspector}]
-  (if (= current-page (last-page inspector))
+  (if (>= current-page (last-page inspector))
     inspector
     (inspect-render (update inspector :current-page inc))))
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -141,7 +141,6 @@
             new-path (push-item-to-path index idx path current-page page-size)]
         (-> (update-in inspector [:stack] conj val)
             (update-in [:pages-stack] conj current-page)
-            (assoc :current-page 0)
             (assoc :path new-path)
             (inspect-render new))))))
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -110,12 +110,12 @@
 (defn up
   "Pop the stack and re-render an earlier value."
   [inspector]
-  (let [{:keys [stack pages-stack]} inspector]
+  (let [{:keys [stack]} inspector]
     (if (empty? stack)
       (inspect-render inspector)
       (-> inspector
           (update-in [:path] pop-item-from-path)
-          (assoc :current-page (peek pages-stack))
+          (assoc :current-page 0)
           (update-in [:pages-stack] pop)
           (inspect-render (last stack))
           (update-in [:stack] pop)))))
@@ -166,9 +166,7 @@
   "Increment the index of the last 'nth in the path by 1,
   if applicable, and re-render the updated value."
   [inspector]
-  (sibling* inspector 2 (fn [index inspector]
-                          (< index
-                             (-> inspector :index count)))))
+  (sibling* inspector 2 (constantly true)))
 
 (defn set-page-size
   "Set the page size in pagination mode to the specified value. Current page

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -501,6 +501,15 @@
                   (inspect/next-sibling)
                   :value))))
   (testing "next sibling doesn't go beyond the current page"
+    (is (= 3 (-> '(1 2 3)
+                 inspect
+                 (inspect/down 2)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 :value)))
     (is (= 41 (-> long-vector
                   inspect
                   (inspect/set-page-size 6)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -411,37 +411,7 @@
     (is (= 9 (-> long-map
                  inspect
                  (inspect/down 20)
-                 :value)))
-    (testing "doesn't go out of boundaries"
-      (is (= 2 (-> [1 2]
-                   inspect
-                   (inspect/down 10)
-                   :value)))
-      (is (= 2 (-> [1 2]
-                   inspect
-                   (inspect/down 100)
-                   (inspect/next-sibling)
-                   (inspect/next-sibling)
-                   :value)))
-      (is (= 2 (-> {:a 1 :b 2}
-                   inspect
-                   (inspect/down 100)
-                   (inspect/next-sibling)
-                   (inspect/next-sibling)
-                   :value)))
-      (is (= 1 (-> [1 2]
-                   inspect
-                   (inspect/down 100)
-                   (inspect/previous-sibling)
-                   (inspect/previous-sibling)
-                   (inspect/previous-sibling)
-                   :value)))
-      (is (= 999 (-> (range 1000)
-                     inspect
-                     (inspect/down 10000)
-                     (inspect/next-sibling)
-                     (inspect/next-sibling)
-                     :value)))))
+                 :value))))
   (testing "down with pagination"
     (is (= 19 (-> long-sequence
                   inspect
@@ -462,7 +432,49 @@
                inspect
                (inspect/set-page-size 1)
                (inspect/down 131)
-               (select-keys [:value :current-page]))))))
+               (select-keys [:value :current-page])))))
+  (testing "doesn't go out of boundaries"
+    (is (= 2 (-> [1 2]
+                 inspect
+                 (inspect/down 10)
+                 :value)))
+    (is (= 2 (-> [1 2]
+                 inspect
+                 (inspect/down 5)
+                 (inspect/down -10)
+                 :value)))
+    (is (= 2 (-> [1 2]
+                 inspect
+                 (inspect/down 100)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 :value)))
+    (is (= 2 (-> {:a 1 :b 2}
+                 inspect
+                 (inspect/down 100)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 :value)))
+    (is (= 2 (-> {:a 1 :b 2}
+                 inspect
+                 (inspect/set-page-size 1)
+                 (inspect/down 100)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 :value)))
+    (is (= 1 (-> [1 2]
+                 inspect
+                 (inspect/down 100)
+                 (inspect/previous-sibling)
+                 (inspect/previous-sibling)
+                 (inspect/previous-sibling)
+                 :value)))
+    (is (= 999 (-> (range 1000)
+                   inspect
+                   (inspect/down 10000)
+                   (inspect/next-sibling)
+                   (inspect/next-sibling)
+                   :value)))))
 
 (deftest sibling*-test
   (is (= :c

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -281,6 +281,10 @@
                   inspect
                   (inspect/set-page-size 20)
                   :counter)))
+    (is (= 41 (-> long-map
+                  inspect
+                  (inspect/set-page-size 20)
+                  :counter)))
     (is (= '(:newline) (-> long-sequence
                            inspect
                            (inspect/set-page-size 200)
@@ -329,6 +333,13 @@
                inspect/prev-page
                inspect/prev-page
                :current-page)))
+    (is (= (-> []
+               inspect)
+           (-> []
+               inspect
+               inspect/prev-page
+               inspect/prev-page
+               inspect/prev-page)))
     (is (= 1
            (-> long-vector
                inspect
@@ -440,6 +451,11 @@
                  :value)))
     (is (= 2 (-> [1 2]
                  inspect
+                 (inspect/set-page-size 1)
+                 (inspect/down 10)
+                 :value)))
+    (is (= 2 (-> [1 2]
+                 inspect
                  (inspect/down 5)
                  (inspect/down -10)
                  :value)))
@@ -459,6 +475,7 @@
                  inspect
                  (inspect/set-page-size 1)
                  (inspect/down 100)
+                 (inspect/next-sibling)
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  :value)))
@@ -852,6 +869,39 @@
                                        (clojure.lang.TaggedLiteral/create 'foo ())))))))
 
 (deftest inspect-path
+  (testing "basic paths"
+    (is (= []
+           (-> [1 2]
+               inspect
+               :path)))
+    (is (= '[(nth 1)]
+           (-> [1 2]
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/down 100)
+               (inspect/next-sibling)
+               :path)))
+    (is (= '[:b]
+           (-> {:a 1 :b 2}
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/down 100)
+               :path)))
+    (is (= '[(find :b) key]
+           (-> {:a 1 :b 2}
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/next-page)
+               (inspect/down 1)
+               :path))))
   (testing "inspector keeps track of the path in the inspected structure"
     (let [t {:a (list 1 2 {:b {:c (vec (map (fn [x] {:foo (* x 10)}) (range 100)))}})
              :z 42}

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -351,7 +351,7 @@
                     inspect/next-page
                     inspect/next-page)]
         (is (= 2 (:current-page ins)))
-        (is (= 4 (:current-page (inspect/up ins))))))))
+        (is (= 0 (:current-page (inspect/up ins))))))))
 
 (deftest eval-and-inspect-test
   (testing "evaluate expr in the context of currently inspected value"
@@ -440,7 +440,7 @@
              (inspect/previous-sibling)
              (inspect/previous-sibling)
              :value)))
-  (is (= :c
+  (is (= nil
          (-> '{:foo [:a :b :c]}
              inspect
              (inspect/down 2)
@@ -471,10 +471,37 @@
                                       (inspect/next-sibling))]
     (is (= inspector-at-last-sibling
            (-> inspector-at-last-sibling
+               inspect/previous-sibling
                inspect/next-sibling
-               inspect/next-sibling
-               inspect/next-sibling
-               inspect/next-sibling)))))
+               inspect/previous-sibling
+               inspect/next-sibling))))
+  (testing "siblings with pagination"
+    (is (= 38 (-> long-vector
+                  inspect
+                  (inspect/down 40)
+                  (inspect/previous-sibling)
+                  :value)))
+    (is (= 36 (-> long-vector
+                  inspect
+                  (inspect/down 40)
+                  (inspect/set-page-size 2)
+                  (inspect/previous-sibling)
+                  (inspect/previous-sibling)
+                  (inspect/previous-sibling)
+                  :value)))
+    (is (= 40 (-> long-vector
+                  inspect
+                  (inspect/down 40)
+                  (inspect/next-sibling)
+                  :value)))
+    (is (= 42 (-> long-vector
+                  inspect
+                  (inspect/down 40)
+                  (inspect/set-page-size 2)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  :value)))))
 
 (deftest path-test
   (testing "inspector tracks the path in the data structure"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -351,7 +351,7 @@
                     inspect/next-page
                     inspect/next-page)]
         (is (= 2 (:current-page ins)))
-        (is (= 0 (:current-page (inspect/up ins))))))))
+        (is (= 4 (:current-page (inspect/up ins))))))))
 
 (deftest eval-and-inspect-test
   (testing "evaluate expr in the context of currently inspected value"
@@ -440,7 +440,7 @@
              (inspect/previous-sibling)
              (inspect/previous-sibling)
              :value)))
-  (is (= nil
+  (is (= :c
          (-> '{:foo [:a :b :c]}
              inspect
              (inspect/down 2)
@@ -471,20 +471,26 @@
                                       (inspect/next-sibling))]
     (is (= inspector-at-last-sibling
            (-> inspector-at-last-sibling
-               inspect/previous-sibling
                inspect/next-sibling
-               inspect/previous-sibling
+               inspect/next-sibling
+               inspect/next-sibling
                inspect/next-sibling))))
-  (testing "siblings with pagination"
+  (testing "next and previous siblings with pagination"
     (is (= 38 (-> long-vector
                   inspect
                   (inspect/down 40)
                   (inspect/previous-sibling)
                   :value)))
+    (is (= 38 (-> long-vector
+                  inspect
+                  (inspect/set-page-size 1)
+                  (inspect/down 40)
+                  (inspect/previous-sibling)
+                  :value)))
     (is (= 36 (-> long-vector
                   inspect
-                  (inspect/down 40)
                   (inspect/set-page-size 2)
+                  (inspect/down 40)
                   (inspect/previous-sibling)
                   (inspect/previous-sibling)
                   (inspect/previous-sibling)
@@ -493,11 +499,15 @@
                   inspect
                   (inspect/down 40)
                   (inspect/next-sibling)
-                  :value)))
-    (is (= 42 (-> long-vector
+                  :value))))
+  (testing "next sibling doesn't go beyond the current page"
+    (is (= 41 (-> long-vector
                   inspect
+                  (inspect/set-page-size 6)
                   (inspect/down 40)
-                  (inspect/set-page-size 2)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -383,6 +383,18 @@
 
 (deftest down-test
   (testing "basic down"
+    (is (= 2 (-> (list 1 2)
+                 inspect
+                 (inspect/down 2)
+                 :value)))
+    (is (= 2 (-> [1 2]
+                 inspect
+                 (inspect/down 2)
+                 :value)))
+    (is (= 1 (-> {:a 1 :b 2}
+                 inspect
+                 (inspect/down 2)
+                 :value)))
     (is (= 2 (-> #{1 2}
                  inspect
                  (inspect/down 2)
@@ -399,7 +411,37 @@
     (is (= 9 (-> long-map
                  inspect
                  (inspect/down 20)
-                 :value))))
+                 :value)))
+    (testing "doesn't go out of boundaries"
+      (is (= 2 (-> [1 2]
+                   inspect
+                   (inspect/down 10)
+                   :value)))
+      (is (= 2 (-> [1 2]
+                   inspect
+                   (inspect/down 100)
+                   (inspect/next-sibling)
+                   (inspect/next-sibling)
+                   :value)))
+      (is (= 2 (-> {:a 1 :b 2}
+                   inspect
+                   (inspect/down 100)
+                   (inspect/next-sibling)
+                   (inspect/next-sibling)
+                   :value)))
+      (is (= 1 (-> [1 2]
+                   inspect
+                   (inspect/down 100)
+                   (inspect/previous-sibling)
+                   (inspect/previous-sibling)
+                   (inspect/previous-sibling)
+                   :value)))
+      (is (= 999 (-> (range 1000)
+                     inspect
+                     (inspect/down 10000)
+                     (inspect/next-sibling)
+                     (inspect/next-sibling)
+                     :value)))))
   (testing "down with pagination"
     (is (= 19 (-> long-sequence
                   inspect
@@ -513,7 +555,7 @@
                   (inspect/next-sibling)
                   :value))))
   (testing "next sibling doesn't go beyond the current page"
-    (is (= 3 (-> '(1 2 3)
+    (is (= 3 (-> (list 1 2 3)
                  inspect
                  (inspect/down 2)
                  (inspect/next-sibling)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -383,6 +383,10 @@
 
 (deftest down-test
   (testing "basic down"
+    (is (= 2 (-> #{1 2}
+                 inspect
+                 (inspect/down 2)
+                 :value)))
     (is (= :a (-> '{:foo [:a :b :c]}
                   inspect
                   (inspect/down 2)
@@ -410,7 +414,13 @@
     (is (= 19 (-> long-map
                   inspect
                   (inspect/down 40)
-                  :value)))))
+                  :value)))
+    (is (= {:current-page 65 :value 65}
+           (-> long-map
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/down 131)
+               (select-keys [:value :current-page]))))))
 
 (deftest sibling*-test
   (is (= :c
@@ -476,17 +486,19 @@
                inspect/next-sibling
                inspect/next-sibling))))
   (testing "next and previous siblings with pagination"
-    (is (= 38 (-> long-vector
-                  inspect
-                  (inspect/down 40)
-                  (inspect/previous-sibling)
-                  :value)))
-    (is (= 38 (-> long-vector
-                  inspect
-                  (inspect/set-page-size 1)
-                  (inspect/down 40)
-                  (inspect/previous-sibling)
-                  :value)))
+    (is (= {:value 38 :current-page 1}
+           (-> long-vector
+               inspect
+               (inspect/down 40)
+               (inspect/previous-sibling)
+               (select-keys [:value :current-page]))))
+    (is (= {:value 38 :current-page 38}
+           (-> long-vector
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/down 40)
+               (inspect/previous-sibling)
+               (select-keys [:value :current-page]))))
     (is (= 36 (-> long-vector
                   inspect
                   (inspect/set-page-size 2)


### PR DESCRIPTION
Closes https://github.com/clojure-emacs/orchard/issues/216

- Makes `next-sibling`, `previous-sibling`, and `down` fns work well with pagination.
- `next-sibling` will continue to not go beyond the current page.
- Adds out-of-bound checks for `down`, `next-sibling`, `next-page`, and `previous-page` fns.
- Handle discrepancy with page-size and items-on-page when inspecting hash-maps.

