### PR TITLE
Allow `inspector/next-sibling` to go beyond the current page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## Changes
+
+* `inspector/next-sibling`: can beyond the current page.
+
 ## 0.23.2 (2024-03-10)
 
 ### Bugs Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Changes
 
-* `inspector/next-sibling`: can beyond the current page.
+* [#232](https://github.com/clojure-emacs/orchard/issues/232): Let`inspector/next-sibling` go beyond the current page, without possibly going out of bounds.
 
 ## 0.23.2 (2024-03-10)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -218,8 +218,8 @@
   "Increment the index of the last 'nth in the path by 1,
   if applicable, and re-render the updated value."
   [inspector]
-  (sibling* inspector 2 (fn [idx {:keys [index page-size current-page] :as _inspector}]
-                          (< idx (+ (count index) (* page-size current-page))))))
+  (sibling* inspector 2 (fn [idx inspector]
+                          (<= idx (total-items inspector)))))
 
 (defn set-page-size
   "Set the page size in pagination mode to the specified value. Current page

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -609,6 +609,26 @@
                   (inspect/next-sibling)
                   :value))))
   (testing "next-sibling doesn't fall beyond the last element."
+    (is (= 3 (-> [1 2 3]
+                 inspect
+                 (inspect/down 2)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 (inspect/next-sibling)
+                 :value)))
+    (is (= 69 (-> long-sequence
+                  inspect
+                  (inspect/set-page-size 1)
+                  (inspect/down 67)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  :value)))
     (is (= 69 (-> long-vector
                   inspect
                   (inspect/set-page-size 1)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -587,7 +587,7 @@
                   (inspect/down 40)
                   (inspect/next-sibling)
                   :value))))
-  (testing "next sibling doesn't go beyond the current page"
+  (testing "next sibling does go beyond the current page"
     (is (= 3 (-> (list 1 2 3)
                  inspect
                  (inspect/down 2)
@@ -597,10 +597,23 @@
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  :value)))
-    (is (= 41 (-> long-vector
+    (is (= 45 (-> long-vector
                   inspect
-                  (inspect/set-page-size 6)
+                  (inspect/set-page-size 3)
                   (inspect/down 40)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  (inspect/next-sibling)
+                  :value))))
+  (testing "next-sibling doesn't fall beyond the last element."
+    (is (= 69 (-> long-vector
+                  inspect
+                  (inspect/set-page-size 1)
+                  (inspect/down 67)
+                  (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)


### PR DESCRIPTION
Closes https://github.com/clojure-emacs/orchard/issues/232

I haven't faced any issues using `previous-sibling` across pages. Described the steps to reproduce in the issue.

This change allows `next-sibling` also to jump across pages.