### PR TITLE
`java/class-info`: handle `NoClassDefFoundError`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.23.3 (2024-03-24)
+
 ## Changes
 
 * [#232](https://github.com/clojure-emacs/orchard/issues/232): Let`inspector/next-sibling` go beyond the current page, without possibly going out of bounds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Changes
 
 * [#232](https://github.com/clojure-emacs/orchard/issues/232): Let`inspector/next-sibling` go beyond the current page, without possibly going out of bounds.
+* `java/class-info`: handle `NoClassDefFoundError`s.
 
 ## 0.23.2 (2024-03-10)
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ lint: kondo cljfmt eastwood
 deploy: check-env clean
 	lein with-profile -user,-dev,+$(VERSION),-provided deploy clojars
 
-# Usage: PROJECT_VERSION=0.23.2 make install
+# Usage: PROJECT_VERSION=0.23.3 make install
 install: clean check-install-env
 	lein with-profile -user,-dev,+$(VERSION),-provided install
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Documentation for the master branch as well as tagged releases are available
 Just add `orchard` as a dependency and start hacking.
 
 ```clojure
-[cider/orchard "0.23.2"]
+[cider/orchard "0.23.3"]
 ```
 
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
@@ -156,7 +156,7 @@ make repl
 You can install Orchard locally like this:
 
 ```
-PROJECT_VERSION=0.23.2 make install
+PROJECT_VERSION=0.23.3 make install
 ```
 
 For releasing to [Clojars](https://clojars.org/):

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -322,9 +322,11 @@
   "For the class symbol, return Java class and member info. Members are indexed
   first by name, and then by argument types to list all overloads."
   [class]
-  (when-let [^Class c (try (Class/forName (str class))
-                           (catch Exception _)
-                           (catch LinkageError _))]
+  (when-let [^Class c (try
+                        (Class/forName (str class)) ;; NOTE: we don't pass the `false` argumnt since that complicates the analysis for deftype/defrecord classes.
+                        (catch Exception _)
+                        (catch NoClassDefFoundError _)
+                        (catch LinkageError _))]
     (let [package (some-> c package symbol)
           {:keys [members] :as result} (misc/deep-merge (reflect-info (reflection-for c))
                                                         (when *analyze-sources*


### PR DESCRIPTION
See also: https://github.com/clojure-emacs/cider-nrepl/blob/d4bd53bc3145bf5627c44d336ce44eaad0fae55c/src/cider/nrepl.clj#L67-L69

Cheers - V