### PR TITLE
[java] Improve Java parsing performance

### DIFF
--- a/src-newer-jdks/orchard/java/parser.clj
+++ b/src-newer-jdks/orchard/java/parser.clj
@@ -230,14 +230,14 @@
         (when-let [^DocletEnvironment root (parse-java path (module-name klass))]
           (try
             (let [path-resource (io/resource path)]
-              (assoc (->> (.getIncludedElements root)
-                          (filter #(#{ElementKind/CLASS
-                                      ElementKind/INTERFACE
-                                      ElementKind/ENUM}
-                                    (.getKind ^Element %)))
-                          (keep #(parse-info % root))
-                          (filter #(= klass (:class %)))
-                          (first))
+              (assoc (some #(when (#{ElementKind/CLASS
+                                     ElementKind/INTERFACE
+                                     ElementKind/ENUM}
+                                   (.getKind ^Element %))
+                              (let [info (parse-info % root)]
+                                (when (= (:class info) klass)
+                                  info)))
+                           (.getIncludedElements root))
                      ;; relative path on the classpath
                      :file path
                      ;; Legacy key. Please do not remove - we don't do breaking changes!

--- a/src-newer-jdks/orchard/java/parser_next.clj
+++ b/src-newer-jdks/orchard/java/parser_next.clj
@@ -323,14 +323,14 @@
         (when-let [^DocletEnvironment root (parse-java path (module-name klass))]
           (try
             (let [path-resource (io/resource path)]
-              (assoc (->> (.getIncludedElements root)
-                          (filterv #(#{ElementKind/CLASS
-                                       ElementKind/INTERFACE
-                                       ElementKind/ENUM}
-                                     (.getKind ^Element %)))
-                          (mapv #(parse-info % root))
-                          (filterv #(= klass (:class %)))
-                          (first))
+              (assoc (some #(when (#{ElementKind/CLASS
+                                     ElementKind/INTERFACE
+                                     ElementKind/ENUM}
+                                   (.getKind ^Element %))
+                              (let [info (parse-info % root)]
+                                (when (= (:class info) klass)
+                                  info)))
+                           (.getIncludedElements root))
                      ;; relative path on the classpath
                      :file path
                      ;; Legacy key. Please do not remove - we don't do breaking changes!

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -476,8 +476,7 @@
   [ns sym]
   (when-let [ns (find-ns ns)]
     (->> (vals (ns-imports ns))
-         (map #(member-info (-> ^Class % .getName symbol) sym))
-         (filter identity)
+         (keep #(member-info (-> ^Class % .getName symbol) sym))
          (distinct))))
 
 (defn trim-one-dot


### PR DESCRIPTION
I've noticed that most of the time spent during running tests is calling `source-info` from different places.