### PR TITLE
[inspector] Misc improvements

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -254,19 +254,6 @@
   {:pre [(integer? max-nested-depth)]}
   (inspect-render (assoc inspector :max-nested-depth max-nested-depth)))
 
-(defn eval-and-inspect
-  "Evaluate the given expression where `v` is bound to the currently inspected
-  value. Open the evaluation result in the inspector."
-  [inspector expr]
-  (let [{:keys [current-page value]} inspector
-        eval-fn `(fn [~'v] ~(read-string expr))
-        result ((eval eval-fn) value)]
-    (-> (update inspector :stack conj value)
-        (update :pages-stack conj current-page)
-        (assoc :current-page 0)
-        (update :path conj '<unknown>)
-        (inspect-render result))))
-
 (defn def-current-value
   "Define the currently inspected value as a var with the given name in the
   provided namespace."

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -51,7 +51,7 @@
         (cond
           ;; If value's class is a map, going down means jumping into either key
           ;; or value.
-          ((supers klass) clojure.lang.IPersistentMap)
+          (.isAssignableFrom Map klass)
           (if (even? idx)
             ;; Even index means jumping into the value by the key.
             (let [key (nth index (dec idx))]
@@ -62,7 +62,7 @@
             (conj path (list 'find (nth index idx)) 'key))
 
           ;; For sequential things going down means getting the nth value.
-          ((supers klass) clojure.lang.Sequential)
+          (.isAssignableFrom List klass)
           (let [coll-idx (+ (* (or current-page 0) page-size)
                             (dec idx))]
             (conj path (list 'nth coll-idx)))
@@ -161,11 +161,11 @@
     (if (empty? stack)
       (inspect-render inspector)
       (-> inspector
-          (update-in [:path] pop-item-from-path)
+          (update :path pop-item-from-path)
           (assoc :current-page (peek pages-stack))
-          (update-in [:pages-stack] pop)
+          (update :pages-stack pop)
           (inspect-render (last stack))
-          (update-in [:stack] pop)))))
+          (update :stack pop)))))
 
 (defn down
   "Drill down to an indexed object referred to by the previously
@@ -186,8 +186,9 @@
               new (get index idx)
               val (:value inspector)
               new-path (push-item-to-path index idx path current-page page-size)]
-          (-> (update-in inspector [:stack] conj val)
-              (update-in [:pages-stack] conj current-page)
+          (-> inspector
+              (update :stack conj val)
+              (update :pages-stack conj current-page)
               (assoc :path new-path)
               (inspect-render new)))))))
 
@@ -278,7 +279,7 @@
 (def ^:private default-max-coll-size 5)
 
 (defn render-onto [inspector coll]
-  (update-in inspector [:rendered] concat coll))
+  (update inspector :rendered concat coll))
 
 (defn render [inspector & values]
   (render-onto inspector values))
@@ -314,9 +315,9 @@
         inspected-value (print/print-str value)
         expr (list :value inspected-value counter)]
     (-> inspector
-        (update-in [:index] conj value)
-        (update-in [:counter] inc)
-        (update-in [:rendered] concat (list expr)))))
+        (update :index conj value)
+        (update :counter inc)
+        (update :rendered concat (list expr)))))
 
 (defn render-labeled-value [inspector label value]
   (-> inspector

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -82,7 +82,7 @@
   [inspector]
   (merge (reset-index inspector)
          {:value nil, :stack [], :path [], :pages-stack [],
-          :current-page 0, :rendered '(), :indentation 0}))
+          :current-page 0, :rendered [], :indentation 0}))
 
 (defn fresh
   "Return an empty inspector."
@@ -279,13 +279,15 @@
 (def ^:private default-max-coll-size 5)
 
 (defn render-onto [inspector coll]
-  (update inspector :rendered concat coll))
+  (update inspector :rendered into coll))
 
 (defn render [inspector & values]
   (render-onto inspector values))
 
 (defn render-ln [inspector & values]
-  (render-onto inspector (concat values '((:newline)))))
+  (-> inspector
+      (render-onto values)
+      (render '(:newline))))
 
 (defn- indent [inspector]
   (update inspector :indentation + 2))
@@ -317,7 +319,7 @@
     (-> inspector
         (update :index conj value)
         (update :counter inc)
-        (update :rendered concat (list expr)))))
+        (update :rendered conj expr))))
 
 (defn render-labeled-value [inspector label value]
   (-> inspector
@@ -696,7 +698,8 @@
          (render-reference)
          (inspect value)
          (render-page-info value)
-         (render-path)))))
+         (render-path)
+         (update :rendered seq)))))
 
 ;; Get a human readable printout of rendered sequence
 (defmulti inspect-print-component first)

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -5,6 +5,8 @@
   - honor `*print-level*` and `*print-length*` variables
   - provide sufficiently good performance
   - limit the maximum print size and stop printing after it is reached"
+  {:author "Oleksandr Yakushev"
+   :added "0.24"}
   (:refer-clojure :exclude [print print-str])
   (:import
    (clojure.core Eduction)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -365,25 +365,6 @@
         (is (= 2 (:current-page ins)))
         (is (= 4 (:current-page (inspect/up ins))))))))
 
-(deftest eval-and-inspect-test
-  (testing "evaluate expr in the context of currently inspected value"
-    (is (match? (list "Class"
-                      ": " (list :value "java.lang.String" number?)
-                      '(:newline)
-                      "Value: " "\"1001\""
-                      '(:newline)
-                      '(:newline)
-                      "--- Print:"
-                      '(:newline)
-                      "  " "1001"
-                      '(:newline))
-                (-> eval-result
-                    inspect
-                    (inspect/down 2)
-                    (inspect/down 2)
-                    (inspect/eval-and-inspect "(str (+ v 1000))")
-                    render)))))
-
 (deftest def-value-test
   (testing "define var with the currently inspected value"
     (-> eval-result


### PR DESCRIPTION
Nothing user-facing here except removing `eval-and-inspect`.

The controversial change of using vector for `:rendered` is in its own commit. No tests added because of Clojure's list/vector equality semantics.  Besides, `:rendered` still becomes a seq in the end for now, until this transformation is moved into cider-nrepl instead.