### PR TITLE
[inspector] Unify inspector entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Changes
 
 * [#241](https://github.com/clojure-emacs/orchard/issues/241): Extract inspector value printing into a separate namespace `orchard.print`.
+* [#244](https://github.com/clojure-emacs/orchard/issues/244): Make `orchard.inspect/start` the single entrypoint to the inspector, deprecate `orchard.inspect/fresh` and `orchard.inspect/clear`.
 
 ## 0.23.3 (2024-03-24)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -172,25 +172,23 @@
    rendered value."
   [inspector ^Integer idx]
   {:pre [(integer? idx)]}
-  (if (nil? inspector)
-    (fresh)
-    (let [idx (min idx (total-items inspector))
-          page-items (items-on-page inspector)]
-      (cond
-        (neg? idx)
-        inspector
-        (> idx page-items)
-        (recur (next-page inspector) (- idx page-items))
-        :else
-        (let [{:keys [index path current-page page-size]} inspector
-              new (get index idx)
-              val (:value inspector)
-              new-path (push-item-to-path index idx path current-page page-size)]
-          (-> inspector
-              (update :stack conj val)
-              (update :pages-stack conj current-page)
-              (assoc :path new-path)
-              (inspect-render new)))))))
+  (let [idx (min idx (total-items inspector))
+        page-items (items-on-page inspector)]
+    (cond
+      (neg? idx)
+      inspector
+      (> idx page-items)
+      (recur (next-page inspector) (- idx page-items))
+      :else
+      (let [{:keys [index path current-page page-size]} inspector
+            new (get index idx)
+            val (:value inspector)
+            new-path (push-item-to-path index idx path current-page page-size)]
+        (-> inspector
+            (update :stack conj val)
+            (update :pages-stack conj current-page)
+            (assoc :path new-path)
+            (inspect-render new))))))
 
 (defn- sibling* [inspector offset pred]
   (let [path (:path inspector)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -149,7 +149,7 @@
 
 (defn inspect
   [value]
-  (inspect/start (inspect/fresh) value))
+  (inspect/start value))
 
 (defn render
   [inspector]
@@ -165,14 +165,14 @@
 (deftest pop-empty-test
   (testing "popping an empty inspector renders nil"
     (is (match? nil-result
-                (-> (inspect/fresh)
+                (-> (inspect nil)
                     inspect/up
                     render)))))
 
 (deftest pop-empty-idempotent-test
   (testing "popping an empty inspector is idempotent"
     (is (match? nil-result
-                (-> (inspect/fresh)
+                (-> (inspect nil)
                     inspect/up
                     inspect/up
                     render)))))
@@ -180,14 +180,14 @@
 (deftest push-empty-test
   (testing "pushing an empty inspector index renders nil"
     (is (match? nil-result
-                (-> (inspect/fresh)
+                (-> (inspect nil)
                     (inspect/down 1)
                     render)))))
 
 (deftest push-empty-idempotent-test
   (testing "pushing an empty inspector index is idempotent"
     (is (match? nil-result
-                (-> (inspect/fresh)
+                (-> (inspect nil)
                     (inspect/down 1)
                     (inspect/down 1)
                     render)))))
@@ -669,7 +669,7 @@
                       '(:newline)
                       "  " "3" ". " (list :value "3" number?)
                       '(:newline))
-                (render (inspect/start (inspect/fresh) [1 2 nil 3])))))
+                (render (inspect [1 2 nil 3])))))
 
   (testing "inspect :coll aligns index numbers so that values appear aligned"
     (is (match? (list "Class"
@@ -701,11 +701,10 @@
                       '(:newline)
                       "  " "10" ". " (list :value "10" number?)
                       '(:newline))
-                (render (inspect/start (inspect/fresh) (vec (range 11)))))))
+                (render (inspect (vec (range 11)))))))
 
   (testing "inspect :coll aligns index numbers correctly for page size > 100"
-    (let [rendered (-> (inspect/fresh)
-                       (inspect/start (vec (range 101)))
+    (let [rendered (-> (inspect (vec (range 101)))
                        (inspect/set-page-size 200)
                        render)
           head (take 11 rendered)
@@ -770,17 +769,15 @@
                   (:newline)
                   "  " "0" ". " (:value "[ 111111 2222 333 ... ]" 1)
                   (:newline))
-                (render (-> (inspect/fresh)
-                            (assoc :max-atom-length 20
-                                   :max-coll-size 3)
-                            (inspect/start [[111111 2222 333 44 5]])))))))
+                (-> (inspect/start {:max-atom-length 20
+                                    :max-coll-size 3}
+                                   [[111111 2222 333 44 5]])
+                    render)))))
 
 (deftest inspect-java-hashmap-test
   (testing "inspecting java.util.Map descendants prints a key-value coll"
     (let [^java.util.Map the-map {:a 1, :b 2, :c 3}
-          rendered (-> (inspect/fresh)
-                       (inspect/start (java.util.HashMap. the-map))
-                       render)]
+          rendered (render (inspect (java.util.HashMap. the-map)))]
       (is (match? (matchers/embeds '("Class"
                                      ": "
                                      (:value "java.util.HashMap" 0)
@@ -814,8 +811,7 @@
                   (:newline) "  " (:value "FORM_KW" 6) " = " (:value ":form" 7)
                   (:newline) "  " (:value "TAG_KW" 8) " = " (:value ":tag" 9)
                   (:newline))
-                (render (inspect/start (inspect/fresh)
-                                       (clojure.lang.TaggedLiteral/create 'foo ())))))))
+                (render (inspect (clojure.lang.TaggedLiteral/create 'foo ())))))))
 
 (deftest inspect-path
   (testing "basic paths"
@@ -854,7 +850,7 @@
   (testing "inspector keeps track of the path in the inspected structure"
     (let [t {:a (list 1 2 {:b {:c (vec (map (fn [x] {:foo (* x 10)}) (range 100)))}})
              :z 42}
-          inspector (-> (inspect/start (inspect/fresh) t)
+          inspector (-> (inspect t)
                         (inspect/down 1)
                         (inspect/up)
                         (inspect/down 2)
@@ -1215,8 +1211,7 @@
 
         ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
 
-        (-> (inspect/fresh)
-            (inspect/start {:a {:b 1}})
+        (-> (inspect {:a {:b 1}})
             (inspect/tap-current-value)
             (inspect/down 2)
             (inspect/tap-current-value)
@@ -1248,8 +1243,7 @@
 
         ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
 
-        (-> (inspect/fresh)
-            (inspect/start {:a {:b 1}})
+        (-> (inspect {:a {:b 1}})
             (inspect/tap-indexed 1)
             (inspect/tap-indexed 2)
             (inspect/down 2)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -375,10 +375,6 @@
     (is (= 1 @(resolve '--test-val--)))))
 
 (deftest down-test
-  (is (= {:path [], :index [], :pages-stack [], :value nil, :page-size 32, :counter 0, :rendered '("nil" (:newline)), :stack [], :indentation 0, :current-page 0}
-         (inspect/down nil 1))
-      "Accepts a nil inspector, rendering a fresh inspector then")
-
   (testing "basic down"
     (is (= 2 (-> (list 1 2)
                  inspect


### PR DESCRIPTION
I tried to make sense of all the ways to initiate a new inspection or re-inspection – `start`, `fresh`, `clear`. The problem with current state is that "an empty inspector" is not really a thing, it has to be inspecting something. So, an API call like `(fresh)` doesn't really make sense. Also, reusing an inspector to inspect a new object (unrelated to the current one) actually means only reusing the dynamically changed config (page size, truncation limits, etc.); we don't want to reuse any part of the state. 

The updated API has `start` as the single entrypoint into an inspector. 1-arg takes a value to be inspected and returns a rendered inspector object. 2-arg takes a value and the config. An already existing inspector object can be passed as the config. There are no other legal ways to obtain a new inspector object besides `start`.

`fresh` and `clear` functions were retained and marked as deprecated in case somebody uses them.

- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)