### PR TITLE
Nuke support for Clojure 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
 #
 # - run tests against the target matrix
 #   - Java 8, 11, 17, 21, 22
-#   - Clojure 1.9, 1.10, 1.11, master
+#   - Clojure 1.10, 1.11, master
 # - linter, eastwood and cljfmt
 
 workflows:
@@ -192,8 +192,7 @@ workflows:
             alias: "test_code_jdk8"
             parameters:
               jdk_version: [openjdk8]
-              # Clojure 1.9 is tested only against JDK8.
-              clojure_version: ["1.9", "1.10", "1.11", "master"]
+              clojure_version: ["1.10", "1.11", "master"]
               test_profiles: ["-user,-dev,+test,-provided", "-user,-dev,+test,+provided"]
               # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
               # (given that JDK8 is explicitly excluded by those parsers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Changes
 
+* [#245](https://github.com/clojure-emacs/orchard/issues/245): Drop support for Clojure 1.9.
 * [#241](https://github.com/clojure-emacs/orchard/issues/241): Extract inspector value printing into a separate namespace `orchard.print`.
 * [#244](https://github.com/clojure-emacs/orchard/issues/244): Make `orchard.inspect/start` the single entrypoint to the inspector, deprecate `orchard.inspect/fresh` and `orchard.inspect/clear`.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Documentation for the master branch as well as tagged releases are available
 
 ## Usage
 
-**orchard requires Clojure 1.8+ and Java 8+.**
+**orchard requires Clojure 1.10+ and Java 8+.**
 
 Just add `orchard` as a dependency and start hacking.
 

--- a/doc/inspector.org
+++ b/doc/inspector.org
@@ -195,8 +195,8 @@ different kinds of objects.
 *** Class
 
 Classes are rendered with their name, the implemented interfaces, the
-available constructors, their fields and methods. In Clojure versions
->= 1.10 an optional =Datafy= section is added.
+available constructors, their fields and methods, and their datafied
+representation.
 
 #+begin_src clojure :exports both :results output :wrap example
   (inspect/inspect-print Boolean)
@@ -260,8 +260,6 @@ using =nav= and calling =datafy= again on them.
 Since the [[https://github.com/clojure/clojure/blob/master/src/clj/clojure/core/protocols.clj#L182][Datafiable]] protocol is implemented for every object, this
 section will only be rendered if the datafy-ed version of the object
 is different than the original object.
-
-Minimum requirement for this feature is a Clojure version >= 1.10.
 
 #+begin_src clojure :exports both :results output :wrap example
   (-> {:name "John Doe"}
@@ -429,8 +427,6 @@ Objects implementing the [[https://github.com/clojure/clojure/blob/master/src/cl
 optional =Datafy= section. The ='clojure.core.protocols/nav= function
 of the object will be used for navigation, instead of the default
 implementation declared on object.
-
-Minimum requirement for this feature is a Clojure version >= 1.10.
 
 #+begin_src clojure :exports both :results output :wrap example
   (-> {:name "John Doe"}

--- a/project.clj
+++ b/project.clj
@@ -34,8 +34,6 @@
                                        [org.clojure/clojure "1.11.2" :classifier "sources"]
                                        [org.clojure/clojurescript "1.11.4"]]
                         :test-paths ["test-cljs"]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojure "1.9.0" :classifier "sources"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [org.clojure/clojure "1.10.3" :classifier "sources"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.2"]

--- a/src-newer-jdks/orchard/java/parser_utils.clj
+++ b/src-newer-jdks/orchard/java/parser_utils.clj
@@ -1,7 +1,6 @@
 (ns orchard.java.parser-utils
   "The common parts to the `parser` and `parser-next` namespaces."
   {:added "0.15.0"}
-  (:refer-clojure :exclude [resolve])
   (:require
    [clojure.java.io :as io]
    [clojure.string :as string])
@@ -87,15 +86,6 @@
 (defn parse-variable-element [^VariableElement f env]
   {:name (-> f .getSimpleName str symbol)
    :type (-> f .asType (typesym env))})
-
-(defn- resolve
-  "Workaround for CLJ-1403, fixed in Clojure 1.10. Once 1.9 support is
-  discontinued, this function may simply be removed."
-  [sym]
-  (try
-    (clojure.core/resolve sym)
-    (catch Exception _
-      nil)))
 
 (defn module-name
   "Return the module name, or nil if modular"

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -1,6 +1,5 @@
 (ns orchard.info
   "Retrieve the info map from var and symbols."
-  (:refer-clojure :exclude [qualified-symbol?])
   (:require
    [clojure.java.io :as io]
    [orchard.cljs.analysis :as cljs-ana]
@@ -19,15 +18,6 @@
   {:added "0.5"}
   [ns sym]
   (when sym (symbol (some-> ns str) (str sym))))
-
-(defn qualified-symbol?
-  "Return true if `x` is a symbol with a namespace
-
-  This is only available from Clojure 1.9 so we backport it until we
-  drop support for Clojure 1.8."
-  {:added "0.5"}
-  [x]
-  (boolean (and (symbol? x) (namespace x) true)))
 
 (defn normalize-params
   "Normalize the info params.

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -9,24 +9,13 @@
 
   Pretty wild, right?"
   (:require
+   [clojure.core.protocols :refer [datafy nav]]
    [clojure.string :as string]
-   [orchard.misc :as misc]
    [orchard.print :as print])
   (:import
    (java.lang.reflect Constructor Field Method Modifier)
    (java.util List Map)))
 
-;; Datafy Nav and tap> are only available since Clojure 1.10
-(require 'clojure.core.protocols)
-
-(def ^:private datafy
-  (misc/call-when-resolved 'clojure.core.protocols/datafy))
-
-(def ^:private nav
-  (misc/call-when-resolved 'clojure.core.protocols/nav))
-
-(def ^:private maybe-tap>
-  (misc/call-when-resolved 'clojure.core/tap>))
 ;;
 ;; Navigating Inspector State
 ;;
@@ -272,13 +261,13 @@
 (defn tap-current-value
   "Tap the currently inspected value."
   [inspector]
-  (maybe-tap> (:value inspector))
+  (tap> (:value inspector))
   (inspect-render inspector))
 
 (defn tap-indexed
   "Tap the value found at `idx`, without navigating to it."
   [{:keys [index] :as inspector} idx]
-  (maybe-tap> (get index idx))
+  (tap> (get index idx))
   (inspect-render inspector))
 
 (defn render-onto [inspector coll]
@@ -435,9 +424,7 @@
           (map datafy data))))
 
 (defn- render-datafy? [inspector obj]
-  (cond (not misc/datafy?)
-        false
-        (map? obj)
+  (cond (map? obj)
         (not= obj (nav-datafy obj false))
         (or (sequential? obj) (set? obj))
         (not= (chunk-to-display inspector obj)

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -542,9 +542,8 @@
                 (when (.startsWith classname prefix)
                   (str url path))))
             (into @javadoc/*remote-javadocs*
-                  ;; clojure 1.8 has no javadoc for anything beyond java
-                  ;; 8. clojure 1.10.1 doesn't have 13. We just backport them
-                  ;; regardless of clojure version
+                  ;; Older Clojure versions don't have javadoc for newer JDKs.
+                  ;; We just backport them regardless of Clojure version.
                   (zipmap ["java." "javax." "org.ietf.jgss." "org.omg." "org.w3c.dom." "org.xml.sax"]
                           (repeat (or (javadoc-base-urls misc/java-api-version)
                                       (javadoc-base-urls 11))))))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -160,16 +160,6 @@
         (catch Exception _ nil)))
     (some-> sym find-var var-get)))
 
-(def datafy?
-  "True if Datafy and Nav (added in Clojure 1.10) are supported,
-  otherwise false."
-  (some? (resolve 'clojure.core.protocols/datafy)))
-
-(def tap?
-  "True if tap> (added in Clojure 1.10) is supported,
-  otherwise false."
-  (some? (resolve 'clojure.core/tap>)))
-
 (defn call-when-resolved
   "Return a fn that calls the fn resolved through `var-sym` with the
   arguments passed to it. `var-sym` will be required and resolved

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -108,21 +108,18 @@
     (apply f (filter identity xs))))
 
 (defn parse-java-version
-  "Parse a Java version string according to JEP 223 and return the appropriate version."
+  "Parse a Java version string according to JEP 223 and return the appropriate
+  version."
   [java-ver]
-  (try
-    ;; the no-opt split is because a java version string can end with
-    ;; an optional string consisting of a hyphen followed by other characters
-    (let [[no-opt _] (string/split java-ver #"-")
-          [major minor _] (string/split no-opt #"\.")
-          major (Integer/parseInt major)]
-      (if (> major 1)
-        major
-        (Integer/parseInt (or minor "7"))))
-    (catch Exception _ 7)))
+  (try (let [[major minor _] (string/split java-ver #"\.")
+             major (Integer/parseInt major)]
+         (if (> major 1)
+           major
+           (Integer/parseInt minor)))
+       (catch Exception _ 8)))
 
 (def java-api-version
-  (parse-java-version (System/getProperty "java.version")))
+  (parse-java-version (System/getProperty "java.specification.version")))
 
 ;; TODO move back to analysis.cljs
 (defn add-ns-macros

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -8,15 +8,6 @@
    [clojure.string :as string]
    [orchard.query :as q]))
 
-(defn- var->symbol
-  ;; TODO: use `symbol` once we start targeting Clojure >= 1.10 after CIDER 1.8 is released.
-  "Normally one could just use `(symbol var-ref)`,
-  but that doesn't work in older Clojures."
-  [var-ref]
-  (let [{:keys [ns name]} (meta var-ref)]
-    (symbol (str (ns-name ns))
-            (str name))))
-
 (defn- var->fn [var-ref]
   (let [{:keys [test]} (meta var-ref)]
     (if (fn? test)
@@ -99,7 +90,7 @@
             ;; group duplicates. This is important
             ;; because there can be two seemingly equal #'foo.bar/baz var objects in the result.
             ;; That can happen as one re-evaluates code and the old var hasn't been GC'd yet.
-            (keys (group-by var->symbol result))))))
+            (keys (group-by symbol result))))))
 
 (defn fn-transitive-deps
   "Returns a set with all the functions invoked inside `v` or inside those functions.

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -11,7 +11,7 @@
    [matcher-combinators.matchers :as matchers]
    [orchard.inspect :as inspect]
    [orchard.meta :as m]
-   [orchard.misc :refer [datafy? java-api-version tap?]]
+   [orchard.misc :refer [java-api-version]]
    [orchard.misc :as misc])
   (:import
    (java.io File)
@@ -208,21 +208,20 @@
                           '(:newline))
                     (header rendered))))
       (testing "renders the meta information section"
-        (is (match? (matchers/embeds (cond-> (list "--- Meta Information:"
-                                                   '(:newline)
-                                                   "  " (list :value ":ns" number?) " = " (list :value "orchard.inspect-test" number?)
-                                                   '(:newline)
-                                                   "  " (list :value ":name" number?) " = " (list :value "any-var" number?)
-                                                   '(:newline))
-                                       datafy? (concat ['(:newline)])))
+        (is (match? (matchers/embeds (list "--- Meta Information:"
+                                           '(:newline)
+                                           "  " (list :value ":ns" number?) " = " (list :value "orchard.inspect-test" number?)
+                                           '(:newline)
+                                           "  " (list :value ":name" number?) " = " (list :value "any-var" number?)
+                                           '(:newline)
+                                           '(:newline)))
                     (section "Meta Information" rendered))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? (list "--- Datafy:"
-                            '(:newline)
-                            "  " "0" ". " (list :value "42" number?)
-                            '(:newline))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? (list "--- Datafy:"
+                          '(:newline)
+                          "  " "0" ". " (list :value "42" number?)
+                          '(:newline))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-expr-test
   (testing "rendering an expr"
@@ -740,18 +739,17 @@
                       (:newline)
                       (:newline))
                     (section "Contents" rendered))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? '("--- Datafy:"
-                        (:newline)
-                        "  " "0" ". " (:value "{ :class \"PersistentHashMap\", :x 0 }" 3)
-                        (:newline)
-                        "  " "1" ". " (:value "{ :class \"PersistentHashMap\", :x 1 }" 4)
-                        (:newline)
-                        "  " "..."
-                        (:newline)
-                        (:newline))
-                      (datafy-section rendered)))))
+      (testing "renders the datafy section"
+        (is (match? '("--- Datafy:"
+                      (:newline)
+                      "  " "0" ". " (:value "{ :class \"PersistentHashMap\", :x 0 }" 3)
+                      (:newline)
+                      "  " "1" ". " (:value "{ :class \"PersistentHashMap\", :x 1 }" 4)
+                      (:newline)
+                      "  " "..."
+                      (:newline)
+                      (:newline))
+                    (datafy-section rendered))))
       (testing "renders the page info section"
         (is (match? '("--- Page Info:"
                       (:newline)
@@ -898,26 +896,25 @@
                              "public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException"]]
             (is (match? (matchers/embeds (list "  " (list :value assertion pos?)))
                         methods)))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? (list "--- Datafy:"
-                            '(:newline)
-                            "  " (list :value ":flags" pos?) " = " (list :value "#{ :public }" pos?)
-                            '(:newline)
-                            "  " (list :value ":members" pos?) " = "
-                            (list :value (str "{ clone [ { :name clone, :return-type java.lang.Object, :declaring-class java.lang.Object, "
-                                              ":parameter-types [], :exception-types [ java.lang.CloneNotSupportedException ], ... } ], equals "
-                                              "[ { :name equals, :return-type boolean, :declaring-class java.lang.Object, :parameter-types "
-                                              "[ java.lang.Object ], :exception-types [], ... } ], finalize [ { :name finalize, :return-type void, "
-                                              ":declaring-class java.lang.Object, :parameter-types [], :exception-types [ java.lang.Throwable ], "
-                                              "... } ], getClass [ { :name getClass, :return-type java.lang.Class, :declaring-class java.lang.Object, "
-                                              ":parameter-types [], :exception-types [], ... } ], hashCode [ { :name hashCode, :return-type int, "
-                                              ":declaring-class java.lang.Object, :parameter-types [], :exception-types [], ... } ], ... }")
-                                  pos?)
-                            '(:newline)
-                            "  " (list :value ":name" pos?) " = " (list :value "java.lang.Object" pos?)
-                            '(:newline))
-                      (datafy-section rendered)))))))
+      (testing "renders the datafy section"
+        (is (match? (list "--- Datafy:"
+                          '(:newline)
+                          "  " (list :value ":flags" pos?) " = " (list :value "#{ :public }" pos?)
+                          '(:newline)
+                          "  " (list :value ":members" pos?) " = "
+                          (list :value (str "{ clone [ { :name clone, :return-type java.lang.Object, :declaring-class java.lang.Object, "
+                                            ":parameter-types [], :exception-types [ java.lang.CloneNotSupportedException ], ... } ], equals "
+                                            "[ { :name equals, :return-type boolean, :declaring-class java.lang.Object, :parameter-types "
+                                            "[ java.lang.Object ], :exception-types [], ... } ], finalize [ { :name finalize, :return-type void, "
+                                            ":declaring-class java.lang.Object, :parameter-types [], :exception-types [ java.lang.Throwable ], "
+                                            "... } ], getClass [ { :name getClass, :return-type java.lang.Class, :declaring-class java.lang.Object, "
+                                            ":parameter-types [], :exception-types [], ... } ], hashCode [ { :name hashCode, :return-type int, "
+                                            ":declaring-class java.lang.Object, :parameter-types [], :exception-types [], ... } ], ... }")
+                                pos?)
+                          '(:newline)
+                          "  " (list :value ":name" pos?) " = " (list :value "java.lang.Object" pos?)
+                          '(:newline))
+                    (datafy-section rendered))))))
 
   (testing "inspecting the java.lang.Class class"
     (let [rendered (-> Class inspect render)]
@@ -938,24 +935,23 @@
                       (:newline))
                     (header rendered))))
       (testing "renders the contains section"
-        (is (match? (cond-> '("--- Contains:"
-                              (:newline)
-                              "  " "Class" ": " (:value "clojure.lang.PersistentArrayMap" 1)
-                              (:newline)
-                              (:newline)
-                              "  --- Contents:"
-                              (:newline)
-                              "    " (:value ":a" 2) " = " (:value "1" 3)
-                              (:newline))
-                      datafy? (concat ['(:newline)]))
+        (is (match? '("--- Contains:"
+                      (:newline)
+                      "  " "Class" ": " (:value "clojure.lang.PersistentArrayMap" 1)
+                      (:newline)
+                      (:newline)
+                      "  --- Contents:"
+                      (:newline)
+                      "    " (:value ":a" 2) " = " (:value "1" 3)
+                      (:newline)
+                      (:newline))
                     (section "Contains" rendered))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? '("--- Datafy:"
-                        (:newline)
-                        "  " "0" ". " (:value "{ :a 1 }" 4)
-                        (:newline))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? '("--- Datafy:"
+                      (:newline)
+                      "  " "0" ". " (:value "{ :a 1 }" 4)
+                      (:newline))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-atom-infinite-seq-test
   (testing "inspecting an atom holding an infinite seq"
@@ -968,30 +964,29 @@
                       (:newline))
                     (header rendered))))
       (testing "renders the contains section"
-        (is (match? (cond-> '("--- Contains:"
-                              (:newline)
-                              "  " "Class" ": " (:value "clojure.lang.Repeat" 1)
-                              (:newline)
-                              (:newline)
-                              "  --- Contents:"
-                              (:newline)
-                              "    " "0" ". " (:value "1" 2)
-                              (:newline)
-                              "    " "1" ". " (:value "1" 3)
-                              (:newline)
-                              "    " "2" ". " (:value "1" 4)
-                              (:newline)
-                              "    " "..."
-                              (:newline))
-                      datafy? (concat ['(:newline)]))
+        (is (match? '("--- Contains:"
+                      (:newline)
+                      "  " "Class" ": " (:value "clojure.lang.Repeat" 1)
+                      (:newline)
+                      (:newline)
+                      "  --- Contents:"
+                      (:newline)
+                      "    " "0" ". " (:value "1" 2)
+                      (:newline)
+                      "    " "1" ". " (:value "1" 3)
+                      (:newline)
+                      "    " "2" ". " (:value "1" 4)
+                      (:newline)
+                      "    " "..."
+                      (:newline)
+                      (:newline))
                     (section "Contains" rendered))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? '("--- Datafy:"
-                        (:newline)
-                        "  " "0" ". " (:value "( 1 1 1 1 1 ... )" 5)
-                        (:newline))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? '("--- Datafy:"
+                      (:newline)
+                      "  " "0" ". " (:value "( 1 1 1 1 1 ... )" 5)
+                      (:newline))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-clojure-string-namespace-test
   (testing "inspecting the clojure.string namespace"
@@ -1031,36 +1026,35 @@
                       (:newline))
                     (section "Imports" result))))
       (testing "renders the interns section"
-        (is (match? (cond-> `("--- Interns:"
-                              (:newline)
-                              "  " (:value ~(str "{ ends-with? #'clojure.string/ends-with?, "
-                                                 "replace-first-char #'clojure.string/replace-first-char, "
-                                                 "capitalize #'clojure.string/capitalize, "
-                                                 "reverse #'clojure.string/reverse, join #'clojure.string/join, ... }") 5)
-                              (:newline))
-                      datafy? (concat ['(:newline)]))
+        (is (match? `("--- Interns:"
+                      (:newline)
+                      "  " (:value ~(str "{ ends-with? #'clojure.string/ends-with?, "
+                                         "replace-first-char #'clojure.string/replace-first-char, "
+                                         "capitalize #'clojure.string/capitalize, "
+                                         "reverse #'clojure.string/reverse, join #'clojure.string/join, ... }") 5)
+                      (:newline)
+                      (:newline))
                     (section "Interns" result))))
-      (when datafy?
-        (testing "renders the datafy from section"
-          (is (match? `("--- Datafy:"
-                        (:newline)
-                        "  " (:value ":name" 6) " = " (:value "clojure.string" 7)
-                        (:newline)
-                        "  " (:value ":publics" 8) " = "
-                        (:value ~(str "{ blank? #'clojure.string/blank?, capitalize "
-                                      "#'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
-                                      "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 9)
-                        (:newline)
-                        "  " (:value ":imports" 10) " = "
-                        (:value ~(str "{ AbstractMethodError java.lang.AbstractMethodError, Appendable java.lang.Appendable, "
-                                      "ArithmeticException java.lang.ArithmeticException, ArrayIndexOutOfBoundsException "
-                                      "java.lang.ArrayIndexOutOfBoundsException, ArrayStoreException java.lang.ArrayStoreException, ... }") 11)
-                        (:newline)
-                        "  " (:value ":interns" 12) " = "
-                        (:value ~(str "{ blank? #'clojure.string/blank?, capitalize #'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
-                                      "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 13)
-                        (:newline))
-                      (datafy-section result))))))))
+      (testing "renders the datafy from section"
+        (is (match? `("--- Datafy:"
+                      (:newline)
+                      "  " (:value ":name" 6) " = " (:value "clojure.string" 7)
+                      (:newline)
+                      "  " (:value ":publics" 8) " = "
+                      (:value ~(str "{ blank? #'clojure.string/blank?, capitalize "
+                                    "#'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
+                                    "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 9)
+                      (:newline)
+                      "  " (:value ":imports" 10) " = "
+                      (:value ~(str "{ AbstractMethodError java.lang.AbstractMethodError, Appendable java.lang.Appendable, "
+                                    "ArithmeticException java.lang.ArithmeticException, ArrayIndexOutOfBoundsException "
+                                    "java.lang.ArrayIndexOutOfBoundsException, ArrayStoreException java.lang.ArrayStoreException, ... }") 11)
+                      (:newline)
+                      "  " (:value ":interns" 12) " = "
+                      (:value ~(str "{ blank? #'clojure.string/blank?, capitalize #'clojure.string/capitalize, ends-with? #'clojure.string/ends-with?, "
+                                    "escape #'clojure.string/escape, includes? #'clojure.string/includes?, ... }") 13)
+                      (:newline))
+                    (datafy-section result)))))))
 
 (deftest inspect-datafiable-metadata-extension-test
   (testing "inspecting a map extended with the Datafiable protocol"
@@ -1082,15 +1076,14 @@
                       (:newline)
                       (:newline))
                     (demunge (section "Meta Information" rendered)))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? '("--- Datafy:"
-                        (:newline)
-                        "  " (:value ":name" 5) " = " (:value "\"John Doe\"" 6)
-                        (:newline)
-                        "  " (:value ":class" 7) " = " (:value "\"PersistentArrayMap\"" 8)
-                        (:newline))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? '("--- Datafy:"
+                      (:newline)
+                      "  " (:value ":name" 5) " = " (:value "\"John Doe\"" 6)
+                      (:newline)
+                      "  " (:value ":class" 7) " = " (:value "\"PersistentArrayMap\"" 8)
+                      (:newline))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-navigable-metadata-extension-test
   (testing "inspecting a map extended with the Navigable protocol"
@@ -1110,13 +1103,12 @@
                       (:newline)
                       (:newline))
                     (demunge (section "Meta Information" rendered)))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? '("--- Datafy:"
-                        (:newline)
-                        "  " (:value ":name" 5) " = " (:value "[ :name \"John Doe\" ]" 6)
-                        (:newline))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? '("--- Datafy:"
+                      (:newline)
+                      "  " (:value ":name" 5) " = " (:value "[ :name \"John Doe\" ]" 6)
+                      (:newline))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-throwable-test
   (testing "inspecting a throwable"
@@ -1136,44 +1128,43 @@
                       (:newline)
                       (:newline))
                     (header rendered))))
-      (when datafy?
-        (testing "renders the datafy section"
-          (is (match? (if (> java-api-version 8)
-                        (list "--- Datafy:"
-                              '(:newline)
-                              "  "
-                              (list :value ":via" number?)
-                              " = "
-                              (list :value
-                                    "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]"
-                                    number?)
-                              '(:newline)
-                              "  "
-                              (list :value ":trace" number?)
-                              " = "
-                              (list :value "[]" number?)
-                              '(:newline)
-                              "  "
-                              (list :value ":cause" number?)
-                              " = "
-                              (list :value "\"BOOM\"" number?)
-                              '(:newline)
-                              "  "
-                              (list :value ":data" number?)
-                              " = "
-                              (list :value "{}" number?)
-                              '(:newline))
-                        (list "--- Datafy:"
-                              '(:newline)
-                              "  " (list :value ":via" number?) " = " (list :value "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]" number?)
-                              '(:newline)
-                              "  " (list :value ":trace" number?) " = " (list :value "[]" number?)
-                              '(:newline)
-                              "  " (list :value ":cause" number?) " = " (list :value "\"BOOM\"" number?)
-                              '(:newline)
-                              "  " (list :value ":data" number?) " = " (list :value "{}" number?)
-                              '(:newline)))
-                      (datafy-section rendered))))))))
+      (testing "renders the datafy section"
+        (is (match? (if (> java-api-version 8)
+                      (list "--- Datafy:"
+                            '(:newline)
+                            "  "
+                            (list :value ":via" number?)
+                            " = "
+                            (list :value
+                                  "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]"
+                                  number?)
+                            '(:newline)
+                            "  "
+                            (list :value ":trace" number?)
+                            " = "
+                            (list :value "[]" number?)
+                            '(:newline)
+                            "  "
+                            (list :value ":cause" number?)
+                            " = "
+                            (list :value "\"BOOM\"" number?)
+                            '(:newline)
+                            "  "
+                            (list :value ":data" number?)
+                            " = "
+                            (list :value "{}" number?)
+                            '(:newline))
+                      (list "--- Datafy:"
+                            '(:newline)
+                            "  " (list :value ":via" number?) " = " (list :value "[ { :type clojure.lang.ExceptionInfo, :message \"BOOM\", :data {} } ]" number?)
+                            '(:newline)
+                            "  " (list :value ":trace" number?) " = " (list :value "[]" number?)
+                            '(:newline)
+                            "  " (list :value ":cause" number?) " = " (list :value "\"BOOM\"" number?)
+                            '(:newline)
+                            "  " (list :value ":data" number?) " = " (list :value "{}" number?)
+                            '(:newline)))
+                    (datafy-section rendered)))))))
 
 (deftest inspect-eduction-test
   (testing "inspecting eduction shows its object fields"
@@ -1195,75 +1186,73 @@
         (is (nil? (section "Page Info" rendered)))))))
 
 (deftest tap-test
-  (when tap?
+  ;; NOTE: this deftest is flaky - wrap the body in the following (and remove the `Thread/sleep`) to reproduce.
+  #_(dotimes [_ 100000])
 
-    ;; NOTE: this deftest is flaky - wrap the body in the following (and remove the `Thread/sleep`) to reproduce.
-    #_(dotimes [_ 100000])
+  (testing "tap-current-value"
+    (let [proof (atom [])
+          test-tap-handler (fn [x]
+                             (swap! proof conj x))
+          sleep (long
+                 (if (System/getenv "CI")
+                   200
+                   100))]
 
-    (testing "tap-current-value"
-      (let [proof (atom [])
-            test-tap-handler (fn [x]
-                               (swap! proof conj x))
-            sleep (long
-                   (if (System/getenv "CI")
-                     200
-                     100))]
+      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
 
-        ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
+      (-> (inspect {:a {:b 1}})
+          (inspect/tap-current-value)
+          (inspect/down 2)
+          (inspect/tap-current-value)
+          (inspect/down 1)
+          (inspect/tap-current-value))
 
-        (-> (inspect {:a {:b 1}})
-            (inspect/tap-current-value)
-            (inspect/down 2)
-            (inspect/tap-current-value)
-            (inspect/down 1)
-            (inspect/tap-current-value))
+      (let [expected [{:a {:b 1}}
+                      {:b 1}
+                      :b]
+            tries (atom 0)]
 
-        (let [expected [{:a {:b 1}}
-                        {:b 1}
-                        :b]
-              tries (atom 0)]
+        (while (and (not= expected @proof)
+                    (< @tries 1000))
+          (Thread/sleep sleep)
+          (swap! tries inc))
 
-          (while (and (not= expected @proof)
-                      (< @tries 1000))
-            (Thread/sleep sleep)
-            (swap! tries inc))
+        (is (= expected @proof)))
 
-          (is (= expected @proof)))
+      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))
 
-        ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))
+  (testing "tap-indexed"
+    (let [proof (atom [])
+          test-tap-handler (fn [x]
+                             (swap! proof conj x))
+          sleep (long
+                 (if (System/getenv "CI")
+                   200
+                   100))]
 
-    (testing "tap-indexed"
-      (let [proof (atom [])
-            test-tap-handler (fn [x]
-                               (swap! proof conj x))
-            sleep (long
-                   (if (System/getenv "CI")
-                     200
-                     100))]
+      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
 
-        ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
+      (-> (inspect {:a {:b 1}})
+          (inspect/tap-indexed 1)
+          (inspect/tap-indexed 2)
+          (inspect/down 2)
+          (inspect/tap-indexed 1)
+          (inspect/tap-indexed 2))
 
-        (-> (inspect {:a {:b 1}})
-            (inspect/tap-indexed 1)
-            (inspect/tap-indexed 2)
-            (inspect/down 2)
-            (inspect/tap-indexed 1)
-            (inspect/tap-indexed 2))
+      (let [expected [:a
+                      {:b 1}
+                      :b
+                      1]
+            tries (atom 0)]
 
-        (let [expected [:a
-                        {:b 1}
-                        :b
-                        1]
-              tries (atom 0)]
+        (while (and (not= expected @proof)
+                    (< @tries 1000))
+          (Thread/sleep sleep)
+          (swap! tries inc))
 
-          (while (and (not= expected @proof)
-                      (< @tries 1000))
-            (Thread/sleep sleep)
-            (swap! tries inc))
+        (is (= expected @proof)))
 
-          (is (= expected @proof)))
-
-        ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))))
+      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler))))
 
 (deftest datafy-test
   (testing "When `(datafy x)` is identical to `x`, no Datafy section is included"

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -355,7 +355,7 @@
       (testing "Unrecognized java version doesn't blank out the javadocs"
         (with-redefs [misc/java-api-version 12345
                       cache (LruMap. 100)]
-          (is (= "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html"
+          (is (= "https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/String.html"
                  (get-url ['java.lang.String]))))))))
 
 (deftest class-resolution-test

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -34,7 +34,7 @@
 (deftest parse-java-version-test
   (is (= (misc/parse-java-version "1.8.0") 8))
   (is (= (misc/parse-java-version "11") 11))
-  (is (= (misc/parse-java-version "14-ea") 14)))
+  (is (= (misc/parse-java-version "14") 14)))
 
 (deftest macros-suffix-add-remove
   (testing "add-ns-macros"


### PR DESCRIPTION
What do you say if we bite the bullet and drop 1.9? Short update on the reasons:

1. **1.9** has significant incompatibilities with JDK11+. That's why we only test 1.9 with JDK8 in Orchard and cider-nrepl.
2. **1.9** has been released in 2017. **1.10** has been released in 2018 (6 years ago).
3. Upgrade path **1.9->1.10** is trivial AFAIK. No controversial changes like in **1.8->1.9** (spec, error messages, single JAR split).
4. [State of Clojure 2023](surveymonkey.com/stories/SM-_2BH3b49f_2FXEkUlrb_2BJSThxg_3D_3D/) (1 year ago) had **1.9** usage at ~5%.
5. **1.12** is around the corner.