### PR TITLE
[inspector] Rework inspector index, reimplement path tracking and sibling*, fix navigation with metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 * [#245](https://github.com/clojure-emacs/orchard/issues/245): Drop support for Clojure 1.9.
 * [#241](https://github.com/clojure-emacs/orchard/issues/241): Extract inspector value printing into a separate namespace `orchard.print`.
 * [#244](https://github.com/clojure-emacs/orchard/issues/244): Make `orchard.inspect/start` the single entrypoint to the inspector, deprecate `orchard.inspect/fresh` and `orchard.inspect/clear`.
+* [#246](https://github.com/clojure-emacs/orchard/issues/246): Reimplement path tracking and sibling navigation.
+* [#246](https://github.com/clojure-emacs/orchard/issues/246): Enable sibling navigation for arrays.
+
+### Bugs Fixed
+
+* [#247](https://github.com/clojure-emacs/orchard/issues/247): Inspector works incorrectly when jumping to child values in a collection with metadata.
+* [#248](https://github.com/clojure-emacs/orchard/issues/248): Inspector works incorrectly when jumping to an array element if paging is enabled.
 
 ## 0.23.3 (2024-03-24)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -354,7 +354,8 @@
         (render-indexed-chunk ins chunk-to-display start-idx
                               (and primary-object?
                                    ;; Set items are not indexed - don't mark.
-                                   (instance? List obj))))
+                                   (or (instance? List obj)
+                                       (.isArray (class obj))))))
 
       (if (< current-page last-page)
         (-> (render-indent ins "...")

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -526,19 +526,29 @@
                inspect/next-sibling
                inspect/next-sibling))))
   (testing "next and previous siblings with pagination"
-    (is (= {:value 32 :current-page 1}
+    (is (= {:value 32 :pages-stack [1]}
            (-> long-vector
                inspect
                (inspect/down 32)
                (inspect/next-sibling)
-               (select-keys [:value :current-page]))))
-    (is (= {:value 31 :current-page 0}
+               (select-keys [:value :pages-stack]))))
+    (is (= {:value 31 :pages-stack [0]}
            (-> long-vector
                inspect
                (inspect/next-page)
                (inspect/down 1)
                (inspect/previous-sibling)
-               (select-keys [:value :current-page]))))
+               (select-keys [:value :pages-stack]))))
+    (is (= 3
+           (-> long-vector
+               inspect
+               (inspect/set-page-size 1)
+               (inspect/down 1)
+               (inspect/next-sibling)
+               (inspect/next-sibling)
+               (inspect/next-sibling)
+               (inspect/up)
+               :current-page)))
     (is (= 28 (-> long-vector
                   inspect
                   (inspect/down 32)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -582,7 +582,17 @@
                   (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)
-                  :value)))))
+                  :value))))
+  (testing "sibling functions work with arrays"
+    (is (= {:value 35, :pages-stack [1], :path '[(nth 35)]}
+           (-> (byte-array (range 40))
+               inspect
+               (inspect/down 34)
+               (inspect/next-sibling)
+               (inspect/next-sibling)
+               (inspect/next-sibling)
+               (inspect/next-sibling)
+               (select-keys [:value :pages-stack :path]))))))
 
 (deftest path-test
   (let [t {:a (list 1 2 {:b {:c (vec (map (fn [x] {:foo (* x 10)}) (range 100)))}})

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -405,74 +405,62 @@
                  (inspect/down 20)
                  :value))))
   (testing "down with pagination"
-    (is (= 19 (-> long-sequence
-                  inspect
-                  (inspect/set-page-size 2)
-                  (inspect/down 20)
-                  :value)))
-    (is (= 9 (-> long-map
-                 inspect
-                 (inspect/set-page-size 2)
-                 (inspect/down 20)
-                 :value)))
+    (is (= long-sequence (-> long-sequence
+                             inspect
+                             (inspect/set-page-size 2)
+                             (inspect/down 20)
+                             :value)))
+    (is (= long-map (-> long-map
+                        inspect
+                        (inspect/set-page-size 2)
+                        (inspect/down 20)
+                        :value)))
     (is (= 19 (-> long-map
                   inspect
                   (inspect/down 40)
-                  :value)))
-    (is (= {:current-page 65 :value 65}
-           (-> long-map
-               inspect
-               (inspect/set-page-size 1)
-               (inspect/down 131)
-               (select-keys [:value :current-page])))))
+                  :value))))
   (testing "doesn't go out of boundaries"
+    (is (= [1 2] (-> [1 2]
+                     inspect
+                     (inspect/down 10)
+                     :value)))
+    (is (= [1 2] (-> [1 2]
+                     inspect
+                     (inspect/set-page-size 1)
+                     (inspect/down 10)
+                     :value)))
+    (is (= [1 2] (-> [1 2]
+                     inspect
+                     (inspect/down 5)
+                     (inspect/down -10)
+                     :value)))
     (is (= 2 (-> [1 2]
                  inspect
-                 (inspect/down 10)
-                 :value)))
-    (is (= 2 (-> [1 2]
-                 inspect
-                 (inspect/set-page-size 1)
-                 (inspect/down 10)
-                 :value)))
-    (is (= 2 (-> [1 2]
-                 inspect
-                 (inspect/down 5)
-                 (inspect/down -10)
-                 :value)))
-    (is (= 2 (-> [1 2]
-                 inspect
-                 (inspect/down 100)
+                 (inspect/down 1)
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  :value)))
     (is (= 2 (-> {:a 1 :b 2}
                  inspect
-                 (inspect/down 100)
+                 (inspect/down 4)
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  :value)))
-    (is (= 2 (-> {:a 1 :b 2}
+    (is (= 1 (-> {:a 1 :b 2}
                  inspect
                  (inspect/set-page-size 1)
-                 (inspect/down 100)
+                 (inspect/down 2)
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  (inspect/next-sibling)
                  :value)))
     (is (= 1 (-> [1 2]
                  inspect
-                 (inspect/down 100)
+                 (inspect/down 1)
                  (inspect/previous-sibling)
                  (inspect/previous-sibling)
                  (inspect/previous-sibling)
-                 :value)))
-    (is (= 999 (-> (range 1000)
-                   inspect
-                   (inspect/down 10000)
-                   (inspect/next-sibling)
-                   (inspect/next-sibling)
-                   :value)))))
+                 :value)))))
 
 (deftest sibling*-test
   (is (= :c
@@ -538,51 +526,29 @@
                inspect/next-sibling
                inspect/next-sibling))))
   (testing "next and previous siblings with pagination"
-    (is (= {:value 38 :current-page 1}
+    (is (= {:value 32 :current-page 1}
            (-> long-vector
                inspect
-               (inspect/down 40)
-               (inspect/previous-sibling)
+               (inspect/down 32)
+               (inspect/next-sibling)
                (select-keys [:value :current-page]))))
-    (is (= {:value 38 :current-page 38}
+    (is (= {:value 31 :current-page 0}
            (-> long-vector
                inspect
-               (inspect/set-page-size 1)
-               (inspect/down 40)
+               (inspect/next-page)
+               (inspect/down 1)
                (inspect/previous-sibling)
                (select-keys [:value :current-page]))))
-    (is (= 36 (-> long-vector
+    (is (= 28 (-> long-vector
                   inspect
-                  (inspect/set-page-size 2)
-                  (inspect/down 40)
+                  (inspect/down 32)
                   (inspect/previous-sibling)
                   (inspect/previous-sibling)
                   (inspect/previous-sibling)
                   :value)))
-    (is (= 40 (-> long-vector
+    (is (= 32 (-> long-vector
                   inspect
-                  (inspect/down 40)
-                  (inspect/next-sibling)
-                  :value))))
-  (testing "next sibling does go beyond the current page"
-    (is (= 3 (-> (list 1 2 3)
-                 inspect
-                 (inspect/down 2)
-                 (inspect/next-sibling)
-                 (inspect/next-sibling)
-                 (inspect/next-sibling)
-                 (inspect/next-sibling)
-                 (inspect/next-sibling)
-                 :value)))
-    (is (= 45 (-> long-vector
-                  inspect
-                  (inspect/set-page-size 3)
-                  (inspect/down 40)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
+                  (inspect/down 32)
                   (inspect/next-sibling)
                   :value))))
   (testing "next-sibling doesn't fall beyond the last element."
@@ -596,20 +562,9 @@
                  :value)))
     (is (= 69 (-> long-sequence
                   inspect
-                  (inspect/set-page-size 1)
-                  (inspect/down 67)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  (inspect/next-sibling)
-                  :value)))
-    (is (= 69 (-> long-vector
-                  inspect
-                  (inspect/set-page-size 1)
-                  (inspect/down 67)
+                  (inspect/next-page)
+                  (inspect/next-page)
+                  (inspect/down 4)
                   (inspect/next-sibling)
                   (inspect/next-sibling)
                   (inspect/next-sibling)
@@ -636,7 +591,12 @@
                       (inspect/down 10))]
     (is (= ":a (nth 2) :b :c (nth 73)" (-> inspector render last))))
   (testing "inspector tracks the path in the data structure beyond the first page with custom page size"
-    (is (= "(get 33)" (-> long-map inspect (inspect/set-page-size 2) (inspect/down 68) render last))))
+    (is (= "(get 2)" (-> long-map inspect
+                         (inspect/set-page-size 2)
+                         (inspect/next-page)
+                         (inspect/down 2)
+                         render
+                         last))))
   (testing "doesn't show path if unknown navigation has happened"
     (is (= '(:newline) (-> long-map inspect (inspect/down 39) render last)))
     (is (= '(:newline) (-> long-map inspect (inspect/down 40) (inspect/down 0) render last)))
@@ -727,6 +687,33 @@
       (is (match? (list "  " "100" ". " (list :value "100" number?)
                         '(:newline))
                   tail)))))
+
+(deftest inspect-coll-meta-test
+  (testing "inspecting a collection with metadata renders the metadata section"
+    (testing "renders the meta information section"
+      (let [rendered (render (inspect (with-meta [:a :b :c :d :e] {:m 42})))]
+        (is (match? '("--- Meta Information:"
+                      (:newline)
+                      "  "
+                      (:value ":m" 1)
+                      " = "
+                      (:value "42" 2)
+                      (:newline)
+                      (:newline))
+                    (section "Meta Information" rendered)))))
+
+    (testing "meta values can be navigated to"
+      (is (= 42 (-> (inspect (with-meta [:a :b :c :d :e] {:m 42}))
+                    (inspect/down 2)
+                    :value))))
+
+    (testing "regular values can be navigated to"
+      (is (= :a (-> (inspect (with-meta [:a :b :c :d :e] {:m 42}))
+                    (inspect/down 3)
+                    :value)))
+      (is (= :e (-> (inspect (with-meta [:a :b :c :d :e] {:m 42}))
+                    (inspect/down 7)
+                    :value))))))
 
 (deftest inspect-coll-nav-test
   (testing "inspecting a collection extended with the Datafiable and Navigable protocols"
@@ -831,7 +818,7 @@
                (inspect/next-page)
                (inspect/next-page)
                (inspect/next-page)
-               (inspect/down 100)
+               (inspect/down 1)
                (inspect/next-sibling)
                :path)))
     (is (= '[:b]
@@ -841,7 +828,7 @@
                (inspect/next-page)
                (inspect/next-page)
                (inspect/next-page)
-               (inspect/down 100)
+               (inspect/down 2)
                :path)))
     (is (= '[<unknown>]
            (-> {:a 1 :b 2}
@@ -872,7 +859,12 @@
              (:path (-> inspector (inspect/down 0)))))
       (is (= '[:a (nth 2) :b :c]
              (:path (-> inspector (inspect/down 0) (inspect/down 0)
-                        (inspect/up) (inspect/up) (inspect/up))))))))
+                        (inspect/up) (inspect/up) (inspect/up)))))))
+  (testing "path tracking works if object has metadata"
+    (is (= [:data]
+           (-> (inspect (with-meta {:data 1} {:m 2}))
+               (inspect/down 4)
+               :path)))))
 
 (deftest inspect-object-class-test
   (testing "inspecting the java.lang.Object class"


### PR DESCRIPTION
### Problem

Path tracking is a big ball of hacks and assumptions. When the user goes down an item (= clicks on it in the UI), the path to the item is inferred from the positional idx of active items on the page. This assumption is broken (and there are bugs related to it) if there are other active elements on the page before the main collection items (e.g. rendered metadata values).

Sibling navigation relies on path tracking, so it is affected as well.

Sibling navigation uses inspector index (= rendered elements) to fetch prev/next element. This created problems if navigation goes beyond the current page, so `down` has been recently reworked to handle indices not rendered on the screen currently. This also introduced a bug that `down` works incorrectly if there are extra items rendered on the screen (again, metadata values #247, or arrays where the inspector renders a few extra clickable objects above the main contents #248). `down` is a presentation-level function and shouldn't be used for low-level model navigation.

### Solution

Index (`:index` in the inspector) is modified to keep not only the values rendered on the screen but also their provenance (key if they come from the map, position if they come from a sequence). Path tracking now relies on that information instead of double-guessing the element key/position.

Path tracking now only tracks going to map values and to sequence items. Navigating to `class` or map keys (which produced `(find :somekey) key`) no longer results in a valid path. This feature (tracking path for such navigations) was a gimmick anyway, and not having it simplifies implementation somewhat.

Introduce low-level`down*` that allows to go to an arbitrary child of the current value (not necessarily one that is currently displayed on the screen given the pagination). Sibling functions now `nth` the neighbor element and use `down*` and don't care about pages.

`down` again works only with the presentation level and accepts only valid indices of items really currently rendered. If idx is incorrect, `down` is a no-op (like all presentation-level functions that perform illegal operations – `up` at the root value, `prev-page` on the first page, etc.). `down` now again works correctly with collections that contain metadata.

Ensure that `:current-page` is always correct even if user goes across page boundaries with sibling ops. Recompute the correct current page early, don't do ad-hoc fixes for it during rendering. Because of that, if the user goes down an element, then walks to a sibling that is on another page, and goes up, he ends up on the correct page for the child element he upped from.

Some duplicate work and ad-hoc fixes become unneeded and are now removed.

**BONUS!** Arrays now also support sibling navigation and path tracking.

*This PR can be read commit-by-commit.*