### PR TITLE
More post-1.9 cleanup

### DIFF
--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -6,8 +6,6 @@
    [clojure.string :as string]
    [orchard.util.io :as util.io]))
 
-(require 'clojure.core.protocols)
-
 (defn os-windows? []
   (.startsWith (System/getProperty "os.name") "Windows"))
 

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -7,32 +7,10 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; These are all wrappers for Clojure Spec functions.                                   ;;
-;; - clojure.spec (released between Clojure 1.8 and 1.9, but never included in Clojure) ;;
 ;; - clojure.spec.alpha (renamed from clojure.spec and included in Clojure 1.9)         ;;
 ;; - clojure.alpha.spec (spec-2, the new experimental version)                          ;;
 ;; We can't simply require the ns because it's existence depends on the Clojure version ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; clojure.spec
-
-(def ^:private clojure-spec-get-spec
-  (misc/call-when-resolved 'clojure.spec/get-spec))
-
-(def ^:private clojure-spec-describe
-  (misc/call-when-resolved 'clojure.spec/describe))
-
-(def ^:private clojure-spec-form
-  (misc/call-when-resolved 'clojure.spec/form))
-
-(def ^:private clojure-spec-gen
-  (misc/call-when-resolved 'clojure.spec/gen))
-
-(def ^:private clojure-spec-registry
-  (misc/call-when-resolved 'clojure.spec/registry))
-
-(def clojure-spec?
-  "True if `clojure.spec` is supported, otherwise false."
-  (some? (resolve (symbol "clojure.spec" "get-spec"))))
 
 ;; clojure.spec.alpha
 
@@ -77,8 +55,8 @@
   (some? (resolve (symbol "clojure.alpha.spec" "get-spec"))))
 
 (def spec?
-  "True if `clojure.spec`, `clojure.spec.alpha` or`clojure.alpha.spec` is supported, otherwise false."
-  (or clojure-spec? clojure-spec-alpha? clojure-alpha-spec?))
+  "True if `clojure.spec.alpha` or`clojure.alpha.spec` is supported, otherwise false."
+  (or clojure-spec-alpha? clojure-alpha-spec?))
 
 (defn- try-fn [f & args]
   (try (apply f args) (catch Exception _)))
@@ -88,31 +66,26 @@
 
 (defn get-spec [k]
   (or (clojure-alpha-spec-get-spec k)
-      (clojure-spec-alpha-get-spec k)
-      (clojure-spec-get-spec k)))
+      (clojure-spec-alpha-get-spec k)))
 
 (defn describe [s]
   (or (try-fn clojure-alpha-spec-describe s)
       (try-fn clojure-spec-alpha-describe s)
-      (try-fn clojure-spec-describe s)
       (throw (ex-unable-to-resolve-spec s))))
 
 (defn registry []
   (apply merge
-         (clojure-spec-registry)
          (clojure-spec-alpha-registry)
          (clojure-alpha-spec-registry)))
 
 (defn form [s]
   (or (try-fn clojure-alpha-spec-form s)
       (try-fn clojure-spec-alpha-form s)
-      (try-fn clojure-spec-form s)
       (throw (ex-unable-to-resolve-spec s))))
 
 (defn gen [s]
   (or (try-fn clojure-alpha-spec-gen s)
       (try-fn clojure-spec-alpha-gen s)
-      (try-fn clojure-spec-gen s)
       (throw (ex-unable-to-resolve-spec s))))
 
 (def ^:private generate*

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1198,7 +1198,7 @@
                    200
                    100))]
 
-      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
+      (add-tap test-tap-handler)
 
       (-> (inspect {:a {:b 1}})
           (inspect/tap-current-value)
@@ -1219,7 +1219,7 @@
 
         (is (= expected @proof)))
 
-      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler)))
+      (remove-tap test-tap-handler)))
 
   (testing "tap-indexed"
     (let [proof (atom [])
@@ -1230,7 +1230,7 @@
                    200
                    100))]
 
-      ((misc/call-when-resolved 'clojure.core/add-tap) test-tap-handler)
+      (add-tap test-tap-handler)
 
       (-> (inspect {:a {:b 1}})
           (inspect/tap-indexed 1)
@@ -1252,7 +1252,7 @@
 
         (is (= expected @proof)))
 
-      ((misc/call-when-resolved 'clojure.core/remove-tap) test-tap-handler))))
+      (remove-tap test-tap-handler))))
 
 (deftest datafy-test
   (testing "When `(datafy x)` is identical to `x`, no Datafy section is included"


### PR DESCRIPTION
Some things that slipped past me in the 1.9 removal cleanup.

Also, remove handling of obscure `clojure.spec` namespace which only existed in some 1.9 alphas.
