### PR TITLE
[inspector] Rework pagination and datafy rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#246](https://github.com/clojure-emacs/orchard/issues/246): Reimplement path tracking and sibling navigation.
 * [#246](https://github.com/clojure-emacs/orchard/issues/246): Enable sibling navigation for arrays.
 * [#252](https://github.com/clojure-emacs/orchard/issues/252): Display count in the inspector header for objects with known size.
+* [#253](https://github.com/clojure-emacs/orchard/issues/253): Rework pagination and datafy.
 
 ### Bugs Fixed
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -43,26 +43,6 @@
 (defn- reset-render-state [inspector]
   (assoc inspector :counter 0, :index [], :indentation 0, :rendered []))
 
-(defn start
-  "Create a new inspector for the `value`. Optinally accepts a `config` map (which
-  can be an existing inspector with changed config)."
-  ([value] (start {} value))
-  ([config value]
-   (-> default-inspector-config
-       (merge (select-keys config (keys default-inspector-config)))
-       (assoc :stack [], :path [], :pages-stack [], :current-page 0)
-       (inspect-render value))))
-
-(defn ^:deprecated clear
-  "If necessary, use `(start inspector nil) instead.`"
-  [inspector]
-  (start inspector nil))
-
-(defn ^:deprecated fresh
-  "If necessary, use `(start nil)` instead."
-  []
-  (start nil))
-
 (defn- array? [obj]
   (.isArray (class obj)))
 
@@ -667,6 +647,28 @@
          (update :rendered seq))))
   ([inspector value]
    (inspect-render (assoc inspector :value value))))
+
+;; Public entrypoints
+
+(defn start
+  "Create a new inspector for the `value`. Optinally accepts a `config` map (which
+  can be an existing inspector with changed config)."
+  ([value] (start {} value))
+  ([config value]
+   (-> default-inspector-config
+       (merge (select-keys config (keys default-inspector-config)))
+       (assoc :stack [], :path [], :pages-stack [], :current-page 0)
+       (inspect-render value))))
+
+(defn ^:deprecated clear
+  "If necessary, use `(start inspector nil) instead.`"
+  [inspector]
+  (start inspector nil))
+
+(defn ^:deprecated fresh
+  "If necessary, use `(start nil)` instead."
+  []
+  (start nil))
 
 (defn inspect-print
   "Get a human readable printout of rendered sequence."

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -668,20 +668,13 @@
   ([inspector value]
    (inspect-render (assoc inspector :value value))))
 
-;; Get a human readable printout of rendered sequence
-(defmulti inspect-print-component first)
-
-(defmethod inspect-print-component :newline [_]
-  (prn))
-
-(defmethod inspect-print-component :value [[_ & xs]]
-  (print (str (first xs))))
-
-(defmethod inspect-print-component :default [x]
-  (print x))
-
-(defn inspect-print [x]
+(defn inspect-print
+  "Get a human readable printout of rendered sequence."
+  [x]
   (print
    (with-out-str
-     (doseq [component (:rendered (start x))]
-       (inspect-print-component component)))))
+     (doseq [[type value :as component] (:rendered (start x))]
+       (print (case type
+                :newline \newline
+                :value (str value)
+                component))))))


### PR DESCRIPTION
### Problem

Pagination operations apply only to the primary object being inspected. You can't prev/next page large metadata or datafied representation. With datafied, you actually can, but only by luck – if the primary object is pageable, then the datafied representation will also page along. If metadata or datafied value are larger than page size, but the primary value is not, then you only get one page of meta and datafied and no way to jump to next page or full representation.

There are a few bugs around pagination where pressing Space on a non-paged object will raise an exception.

ARef inspection (atoms, for example) also reuses the paginated rendering but doesn't respond to prev/next page.

### Solution

Rework pagination. Pagination data (whether object is pageable, whether it should be paged, chunk to be displayed, last-page) is computed once and early, rendering commands reuse this information. Pagination commands only apply if the inspected value is a collection or array.

Rework datafy. This is a bit tricky because the problem is tricky. Two different cases here:

1. `(datafy inspected-value)` returns something different from the value (so, there is a meaningful datafy implementation for it). Regardless of what is returned, we treat it as detached from the structure of `inspected-value`. So, it doesn't follow pagination rules of the inspected value. If it is small enough (< page-size), then render it completely, otherwise render it as a single clickable value that the user can navigate to and have a full-featured inspector for it.

2. The inspected value is a map or some sequence. We know that we will paginate it, and currently display only one page (chunk). If none of the items displayed on the page datafy into something meaningful, then don't display datafy section at all. Otherwise, render datafied section. As user pages through the collection, the datafied section follows along.

If meta section is < page-size, then render it as a colelction in full, otherwise render it as a single value.

If atom contents is a collection < page-size, then render it as a map in full, otherwise render it as a single value. Don't render datafy section for atoms (we basically do the same manually in the Deref section, but with one less click for the user). 