### PR TITLE
Fix tests on Clojure 1.12.0-alpha10

### DIFF
--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1245,7 +1245,7 @@
     (let [rendered (-> (byte-array 30) inspect render)]
       (is (match? '("Class"
                     ": "
-                    (:value "[B" 0)
+                    (:value #"\[B|byte/1" 0)
                     (:newline)
                     "Count: " "30"
                     (:newline)


### PR DESCRIPTION
New representation of primitive arrays in 1.12 is `byte/1` and so on.