### PR TITLE
[inspector] Allow customizing max-nested-depth

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -38,7 +38,8 @@
   {:page-size        32    ; = Clojure's default chunked sequences chunk size.
    :max-atom-length  150
    :max-value-length 50000 ; Only to avoid printing graphs with loops.
-   :max-coll-size    5})
+   :max-coll-size    5
+   :max-nested-depth nil})
 
 (defn- reset-render-state [inspector]
   (-> inspector

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -848,6 +848,34 @@
                 (-> (inspect/start {:max-atom-length 20
                                     :max-coll-size 3}
                                    [[111111 2222 333 44 5]])
+                    render))))
+  (testing "inspect respects :max-value-length configuration"
+    (is (match? '("Class"
+                  ": "
+                  (:value "clojure.lang.PersistentVector" 0)
+                  (:newline)
+                  "Count: " "1"
+                  (:newline)
+                  (:newline)
+                  "--- Contents:"
+                  (:newline)
+                  "  " "0" ". " (:value "( \"long value\" \"long value\" \"long value\" \"long val..." 1)
+                  (:newline))
+                (-> (inspect/start {:max-value-length 50} [(repeat "long value")])
+                    render))))
+  (testing "inspect respects :max-value-depth configuration"
+    (is (match? '("Class"
+                  ": "
+                  (:value "clojure.lang.PersistentVector" 0)
+                  (:newline)
+                  "Count: " "1"
+                  (:newline)
+                  (:newline)
+                  "--- Contents:"
+                  (:newline)
+                  "  " "0" ". " (:value "[ [ [ [ [ [ ... ] ] ] ] ] ]" 1)
+                  (:newline))
+                (-> (inspect/start {:max-nested-depth 5} [[[[[[[[[[1]]]]]]]]]])
                     render)))))
 
 (deftest inspect-java-hashmap-test


### PR DESCRIPTION
Option was ignored when there was no default value for it in the map.