### PR TITLE
[print] Prevent writer going over the total limit

### DIFF
--- a/java/mx/cider/orchard/TruncatingStringWriter.java
+++ b/java/mx/cider/orchard/TruncatingStringWriter.java
@@ -61,6 +61,7 @@ public class TruncatingStringWriter extends StringWriter {
                 writeEllipsis();
         } else if (totalLimit >= 0) {
             super.write(cbuf, off, totalLimit);
+            totalLimit = 0;
             writeEllipsis();
         }
     }
@@ -81,6 +82,7 @@ public class TruncatingStringWriter extends StringWriter {
                 writeEllipsis();
         } else if (totalLimit >= 0) {
             super.write(str, off, totalLimit);
+            totalLimit = 0;
             writeEllipsis();
         }
     }

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -37,7 +37,7 @@
   "Default configuration values for the inspector."
   {:page-size        32    ; = Clojure's default chunked sequences chunk size.
    :max-atom-length  150
-   :max-value-length 50000 ; Only to avoid printing graphs with loops.
+   :max-value-length 10000 ; To avoid printing huge graphs and Exceptions.
    :max-coll-size    5
    :max-nested-depth nil})
 

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -14,6 +14,9 @@
                        (.put a :b b)
                        (.put b :a a)
                        a))
+(def infinite-map (let [m (java.util.HashMap.)]
+                    (.put m (symbol "long key to ensure total length works accurately") m)
+                    m))
 
 (defn nasty [lvl]
   (if (= lvl 0)
@@ -101,7 +104,11 @@
       "( 1 1 1 1 1 1 1 1 1 1 1 1 1 1 ..." (java.util.ArrayList. ^java.util.Collection (repeat 100 1))
       "java.lang....[] { 0, 1, 2, 3, ..." (into-array Long (range 10))
       "{ :m { :m { :m { :m { :m 1234,..." (nasty 5)
-      "{ :b { :a { :b { :a { :b { :a ..." graph-with-loop)))
+      "{ :b { :a { :b { :a { :b { :a ..." graph-with-loop))
+
+  (testing "writer won't go much over total-length"
+    (is (= 2003 (count (binding [sut/*max-total-length* 2000]
+                         (sut/print-str infinite-map)))))))
 
 (deftest print-clojure-limits
   (are [result form] (= result (binding [*print-length* 5


### PR DESCRIPTION
The bug is minor (in certain scenarios the printer can overflow the limit by <5%), so `0.24.0` is still good enough for cider-nrepl.
