### PR TITLE
[inspector] Make spacious printing customizable

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -39,7 +39,8 @@
    :max-atom-length  150
    :max-value-length 10000 ; To avoid printing huge graphs and Exceptions.
    :max-coll-size    5
-   :max-nested-depth nil})
+   :max-nested-depth nil
+   :spacious         true})
 
 (defn- reset-render-state [inspector]
   (-> inspector
@@ -714,10 +715,12 @@
       inspector)))
 
 (defn inspect-render
-  ([{:keys [max-atom-length max-value-length max-coll-size max-nested-depth value]
+  ([{:keys [max-atom-length max-value-length max-coll-size max-nested-depth value
+            spacious]
      :as inspector}]
    (binding [print/*max-atom-length*  max-atom-length
              print/*max-total-length* max-value-length
+             print/*spacious*         spacious
              *print-length*           max-coll-size
              *print-level*            max-nested-depth]
      (-> inspector

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1364,6 +1364,19 @@
                     (:newline))
                   (header rendered))))))
 
+(deftest non-spacious-test
+  (testing ":spacious false makes value rendering tighter"
+    (is (= '("--- Contents:"
+             (:newline)
+             "  " (:value ":a" 1)
+             " = "
+             (:value "[({:b byte[] {0, 1, 2, 3, 4}})]" 2)
+             (:newline))
+           (->> {:a [(list {:b (byte-array (range 5))})]}
+                (inspect/start {:spacious false})
+                render
+                (section "Contents"))))))
+
 (deftest tap-test
   ;; NOTE: this deftest is flaky - wrap the body in the following (and remove the `Thread/sleep`) to reproduce.
   #_(dotimes [_ 100000])


### PR DESCRIPTION
Still keeping spacious=true by default in Orchard to avoid rewriting the tests for now, in the unlikely case we'll have to revert it back.