### PR TITLE
[inspector] Introduce object view mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#267](https://github.com/clojure-emacs/orchard/issues/267): Inspector: don't truncate constructor/field/method names.
 * [#269](https://github.com/clojure-emacs/orchard/issues/269): Inspector: add `refresh` function as a single entrypoint to changing inspector config.
 * [#270](https://github.com/clojure-emacs/orchard/issues/270): Inspector: throw exceptions instead of AssertionErrors when inspector is misconfigured.
+* [#271](https://github.com/clojure-emacs/orchard/issues/271): Inspector: introduce object view mode.
 
 ## 0.25.0 (2024-05-03)
 

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1388,6 +1388,33 @@
                 render
                 (section "Contents"))))))
 
+(deftest object-view-mode-test
+  (testing "in :object view-mode recognized objects are rendered as :default"
+    (let [rendered (->> (list 1 2 3) (inspect/start {:view-mode :object}) render)]
+      (is (match? (matchers/embeds
+                   '("--- Instance fields:"
+                     (:newline)
+                     "  " (:value "_count" 2) " = " (:value "3" 3) (:newline)
+                     "  " (:value "_first" 4) " = " (:value "1" 5) (:newline)
+                     "  " (:value "_hash" 6) " = " (:value "0" 7) (:newline)
+                     (:newline) (:newline)))
+                  (section "Instance fields" rendered)))
+      (is (match? '("--- View mode:" (:newline) "  " ":object")
+                  (section "View mode" rendered))))
+
+    (let [rendered (->> (atom "foo") (inspect/start {:view-mode :object}) render)]
+      (is (match? (matchers/embeds
+                   '("--- Instance fields:"
+                     (:newline)
+                     "  " (:value "_meta" 2) " = " (:value "nil" 3) (:newline)
+                     "  " (:value "state" 4) " = " (:value "foo" 5) (:newline)
+                     "  " (:value "validator" 6) " = " (:value "nil" 7) (:newline)
+                     "  " (:value "watches" 8) " = " (:value "{}" 9) (:newline)
+                     (:newline)))
+                  (section "Instance fields" rendered)))
+      (is (match? '("--- View mode:" (:newline) "  " ":object")
+                  (section "View mode" rendered))))))
+
 (deftest tap-test
   ;; NOTE: this deftest is flaky - wrap the body in the following (and remove the `Thread/sleep`) to reproduce.
   #_(dotimes [_ 100000])


### PR DESCRIPTION
This is a feature that I've been wanting for a long long time. The idea is to have a toggle button (e.g. `v`) that forces inspector to render the current value as an unrecognized Java object – i.e., by displaying its fields.

<img width="500" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/ffe1baa5-d54a-49d7-bb0a-6177dd90ed47"> <br>

<img width="271" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/77797a39-8112-4608-aeea-96caa2e47cb2">  <br>

<img width="726" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/d5c184e2-cd05-4e7e-af5e-53ceee8f9841">  <be>

This is very useful when working on Clojure itself or developing custom data structures that happen to implement List, Map, etc., but you want to see the implementation bits.

There are a couple of details I have not decided on yet:

1. Originally, I wanted this to be a toggle (normal mode <-> java mode). However, this has a potential to add more view modes. I'm not sure which ones those would be right away, but I can possibly imagine something like simple mode (don't show metadata and datafy – for cases where those are too large and distract from viewing the value), a "pretty mode" that does uses pretty printing where currently there is a regular printer, etc.
2. If there are more modes, then the "toggle" button can cycle through them. However, I don't think such cycling should be implemented on Orchard side, I think having a `:view-mode` as a plain config value is sufficient at this level. CIDER or cider-nrepl can then tackle user interactions (cycling, dedicated switches, both).
3. I'm not set on the names of view modes (currently `:normal` and `:java`). Bikeshedding is welcome.