### PR TITLE
[inspector] Show parent class hierarchy when inspecting a class

### DIFF
--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -296,6 +296,12 @@
          (update :counter inc)
          (update :rendered conj expr)))))
 
+(defn render-indented-value [inspector value & [value-opts]]
+  (-> inspector
+      (render-indent)
+      (render-value value value-opts)
+      (render-ln)))
+
 (defn render-labeled-value [inspector label value & [value-opts]]
   (-> inspector
       (render-indent (str label ": "))
@@ -373,9 +379,7 @@
   [{:keys [page-size] :as inspector} obj]
   (if (some-> (counted-length obj) (<= page-size))
     (render-items inspector obj (map? obj) 0 false)
-    (-> (render-indent inspector)
-        (render-value obj)
-        (render-ln))))
+    (render-indented-value inspector obj)))
 
 (defn- render-leading-page-ellipsis [{:keys [current-page] :as inspector}]
   (if (> current-page 0)
@@ -634,10 +638,7 @@
                               (comp sort-fn first)
                               second))
                    (reduce (fn [ins [elt printed]]
-                             (-> ins
-                                 (render-indent)
-                                 (render-value elt {:display-value printed})
-                                 (render-ln)))
+                             (render-indented-value ins elt {:display-value printed}))
                            (-> inspector
                                (render-section-header section)
                                (indent)))))))
@@ -692,10 +693,8 @@
       inspector
       (-> (render-section-header inspector "Imports")
           (indent)
-          (render-indent)
-          (render-value imports)
-          (unindent)
-          (render-ln)))))
+          (render-indented-value imports)
+          (unindent)))))
 
 (defn- render-ns-interns [inspector obj]
   (let [interns (ns-interns obj)]
@@ -703,10 +702,8 @@
       inspector
       (-> (render-section-header inspector "Interns")
           (indent)
-          (render-indent)
-          (render-value interns)
-          (unindent)
-          (render-ln)))))
+          (render-indented-value interns)
+          (unindent)))))
 
 (defmethod inspect :namespace [inspector ^clojure.lang.Namespace obj]
   (-> (render-class-name inspector obj)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -974,6 +974,11 @@
                (inspect/down 4)
                :path)))))
 
+(defn- rendered-hier [indents-and-classnames]
+  (mapcat (fn [[indent class]]
+            [indent (list :value class number?) '(:newline)])
+          (partition 2 indents-and-classnames)))
+
 (deftest inspect-class-test
   (testing "inspecting the java.lang.Object class"
     (let [rendered (-> Object inspect render)]
@@ -1025,11 +1030,27 @@
 
   (testing "inspecting the java.lang.Class class"
     (let [rendered (-> Class inspect render)]
-      (testing "renders the interfaces section"
-        (is (match? (matchers/embeds (list "--- Interfaces:"
+      (testing "renders the class hierarchy section"
+        (is (match? (matchers/embeds (list "--- Class hierarchy:"
                                            '(:newline)
-                                           "  " (list :value "java.io.Serializable" number?)))
-                    (section "Interfaces" rendered))))))
+                                           "  " (list :value "java.lang.Object" number?)
+                                           '(:newline)
+                                           "  " (list :value "java.io.Serializable" number?)
+                                           '(:newline)))
+                    (section "Class hierarchy" rendered))))))
+
+  (testing "inspecting the java.io.FileReader  class"
+    (let [rendered (-> java.io.FileReader inspect render)]
+      (testing "renders the class hierarchy section"
+        (is (match? (concat '("--- Class hierarchy:" (:newline))
+                            (rendered-hier ["  " "java.io.InputStreamReader"
+                                            "    " "java.io.Reader"
+                                            "      " "java.lang.Object"
+                                            "      " "java.io.Closeable"
+                                            "        " "java.lang.AutoCloseable"
+                                            "      " "java.lang.Readable"])
+                            '((:newline)))
+                    (section "Class hierarchy" rendered))))))
 
   (testing "inspecting the java.lang.ClassValue class"
     (let [rendered (-> java.lang.ClassValue inspect render)]


### PR DESCRIPTION
This PR has two implementations: a boring one and a fun one. Let's first decide which one to continue with, and then I'll take care of the tests.

1. The boring one simply adds the supersclass to the list of interfaces we currently show when inspecting the class. It will look like this (see APersistentVector):
<img width="348" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/a4fdc159-3611-4089-aea4-06238dff1088">

Care is taken to sort only the interfaces (like we currently do) but the superclass will always stay on top.

2. The fun one prints the whole hierarchy all at once. Everything is clickable, of course. Like with the boring one, the superclass is always first, then come the interfaces. Duplicate interfaces are never shown twice, each is shown only the first time it comes up. Examples:
<img width="427" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/c98cfcf1-6b98-4447-98ea-8df6dc9a8ee1">

<img width="346" alt="image" src="https://github.com/clojure-emacs/orchard/assets/468477/43482eb7-c44b-473f-8384-c790318e356d">

I like the fun one better because it gives much more information at a glance. You can discover with surprise that a certain class transitively implements an interface. You can immediately click the interface or class that you want. The only downside I see is that the tree steals a lot of space at the top of the inspector window, so if people primarily use class inspection to see fields/methods (which they usually do), it may be annoying having to scroll down to those sections now.