### PR TITLE
[print] Fix bug when a printed collection is not Iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#280](https://github.com/clojure-emacs/orchard/issues/279): Printer: fix a bug when the printed collection is not Iterable.
+
 ## 0.26.1 (2024-06-02)
 
 * [#275](https://github.com/clojure-emacs/orchard/issues/275): Inspector: re-implement :view-mode as a transient stack-remembered option.

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -49,9 +49,8 @@
     (when-not (nil? level)
       (set! *print-level* (dec level)))
     (try
-      (let [it (if (instance? Iterable x)
-                 (.iterator ^Iterable x)
-                 (.iterator (seq x)))]
+      (let [^Iterable iterable (if (instance? Iterable x) x (seq x))
+            it (.iterator iterable)]
         (if (.hasNext it)
           (do (.write w prefix)
               (if (or (nil? level) (pos? level))

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -130,3 +130,8 @@
     "#Atom[{...}]" 1
     "#Atom[{:a (...)}]" 2
     "#Atom[{:a (0 1 2 3 4 5 6 7 8 9)}]" 3))
+
+(deftest print-non-iterable
+  (is (= "#{1 2 3}" (sut/print-str (reify clojure.lang.IPersistentSet
+                                     (equiv [t o] (.equals t o))
+                                     (seq [_] (seq [1 2 3])))))))


### PR DESCRIPTION
This is a fix for the issue raised on Slack: https://clojurians.slack.com/archives/C0617A8PQ/p1721356711913299

I've been blindly calling `.iterator` on any Clojure collection in the printer, but not everything that implements IPersistentVector or IPersistentSet is `Iterable`.

In another commit, I rewrite `TruncatingStringWriter`, which used by the printer, to throw an error when the limit is riched, in the same manner as nREPL's `QuotaBoundPrinter` works. This simplifies the implementation of `print-coll`.
