### PR TITLE
[inspect] Don't crash when inspecting internal classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#282](https://github.com/clojure-emacs/orchard/issues/282): Inspector: don't crash when inspecting internal classes.
+
 ## 0.26.2 (2024-07-19)
 
 * [#274](https://github.com/clojure-emacs/orchard/issues/274): Inspector: remove support for spacious printing.

--- a/project.clj
+++ b/project.clj
@@ -37,10 +37,8 @@
                                    [org.clojure/clojure "1.10.3" :classifier "sources"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.3"]
                                    [org.clojure/clojure "1.11.3" :classifier "sources"]]}
-             :1.12 {:repositories [["snapshots"
-                                    "https://oss.sonatype.org/content/repositories/snapshots"]]
-                    :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]
-                                   [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "LATEST"]
+                                   [org.clojure/clojure "LATEST" :classifier "sources"]]}
 
              ;; Needed to test how Orchard behaves with Clojurescript on classpath.
              :cljs {:dependencies [[org.clojure/clojurescript "1.11.132"]]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1074,7 +1074,14 @@
                              "public final void wait() throws InterruptedException"
                              "public final void wait(long,int) throws InterruptedException"]]
             (is (match? (matchers/embeds (list "  " (list :value assertion pos?)))
-                        methods))))))))
+                        methods)))))))
+
+  (testing "inspecting an internal class"
+    (is (match? `("--- Fields:"
+                  (:newline) "  "
+                  (:value "public volatile clojure.lang.MethodImplCache __methodImplCache" ~number?)
+                  (:newline) (:newline))
+                (section "Fields" (-> clojure.lang.AFunction$1 inspect render))))))
 
 (deftest inspect-method-test
   (testing "reflect.Method values aren't truncated"


### PR DESCRIPTION
- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)