### PR TITLE
Remove special handling of Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#285](https://github.com/clojure-emacs/orchard/issues/285): **BREAKING:** Remove special handling of Boot classpath.
+
 ## 0.26.3 (2024-08-14)
 
 * [#282](https://github.com/clojure-emacs/orchard/issues/282): Inspector: don't crash when inspecting internal classes.

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -5,7 +5,6 @@
    [orchard.cljs.analysis :as cljs-ana]
    [orchard.cljs.meta :as cljs-meta]
    [orchard.java :as java]
-   [orchard.java.classpath :as cp]
    [orchard.java.resource :as resource]
    [orchard.meta :as m]
    [orchard.misc :as misc]))
@@ -158,8 +157,7 @@
      meta
 
      (merge (when-let [file-path (:file meta)]
-              {:file (cond-> file-path
-                       (misc/boot-project?) cp/classpath-file-relative-path)})))))
+              {:file file-path})))))
 
 (defn info
   "Provide the info map for the input ns and sym.

--- a/src/orchard/java/resource.clj
+++ b/src/orchard/java/resource.clj
@@ -37,10 +37,10 @@
                     :url (io/as-url file)})))
           (remove #(.startsWith ^String (:relpath %) "META-INF/"))
           (remove #(re-matches #".*\.(clj[cs]?|java|class)" (:relpath %)))))
-   (filter (memfn ^File isDirectory) (map io/as-file (cp/classpath (cp/boot-aware-classloader))))))
+   (filter (memfn ^File isDirectory) (map io/as-file (cp/classpath (cp/context-classloader))))))
 
 (defn resource-full-path ^URL [relative-path]
-  (io/resource relative-path (cp/boot-aware-classloader)))
+  (io/resource relative-path (cp/context-classloader)))
 
 (defn resource-path-tuple
   "If it's a resource, return a tuple of the relative path and the full

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -9,20 +9,6 @@
 (defn os-windows? []
   (.startsWith (System/getProperty "os.name") "Windows"))
 
-(defn boot-fake-classpath
-  "Retrieve Boot's fake classpath.
-  When using Boot, fake.class.path contains the original directories with source
-  files, which makes it way more useful than the real classpath.
-  See https://github.com/boot-clj/boot/issues/249 for details."
-  []
-  (System/getProperty "fake.class.path"))
-
-(defn boot-project?
-  "Check whether we're dealing with a Boot project.
-  We figure this by checking for the presence of Boot's fake classpath."
-  []
-  (not (nil? (boot-fake-classpath))))
-
 (defn url?
   "Check whether the argument is an url"
   [u]

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -454,17 +454,10 @@
                      :doc "catch-clause => (catch classname name expr*)\n  finally-clause => (finally expr*)\n\n  Catches and handles Java exceptions.",
                      :name finally,
                      :special-form true,
-                     :url "https://clojure.org/special_forms#finally"}]
-      (testing "- boot project"
-        (with-redefs [orchard.misc/boot-project? (constantly true)]
-          (let [i (info/info* params)]
-            (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
-            (is (nil? (:file i))))))
-
-      (testing "- no boot project"
-        (let [i (info/info* params)]
-          (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
-          (is (nil? (:file i))))))))
+                     :url "https://clojure.org/special_forms#finally"}
+          i (info/info* params)]
+      (is (= expected (select-keys i [:ns :name :doc :forms :special-form :url])))
+      (is (nil? (:file i))))))
 
 (deftest file-resolution-no-defs-issue-75-test
   (testing "File resolves, issue #75"
@@ -720,20 +713,6 @@
            (-> '{:ns orchard.info}
                (info/normalize-params)
                (select-keys [:ns :unqualified-sym]))))))
-
-(deftest boot-file-resolution-test
-  ;; this checks the files on the classpath soo you need the test-resources
-  ;; and specifically test-resources/orchard/test_ns.cljc
-  ;;
-  ;; Note that :file in :meta is left untouched
-  (when cljs-available?
-    (with-redefs [orchard.misc/boot-project? (constantly true)]
-      (is (= '{:ns orchard.test-ns
-               :name x
-               :file "orchard/test_ns.cljc"}
-             (-> (merge @*cljs-params* '{:ns orchard.test-ns :sym x})
-                 (info/info*)
-                 (select-keys [:ns :name :file])))))))
 
 (deftest indirect-vars-cljs
   (when cljs-available?


### PR DESCRIPTION
This PR removes handling of Boot's classpath magic. This would not make CIDER "broken" with Boot, the REPL will still start and work (if somebody manages to run Boot, that is), but the "jump to source" functionality will become wobbly.

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)