### PR TITLE
[inspect] Don't crash when field contains non-equiv()able value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#285](https://github.com/clojure-emacs/orchard/issues/285): **BREAKING:** Remove special handling of Boot classpath.
+* [#287](https://github.com/clojure-emacs/orchard/issues/287): Inspector: ton't crash when field contains non-equiv()able value.
 
 ## 0.26.3 (2024-08-14)
 


### PR DESCRIPTION
Happens when the object declares but doesn't implement all the necessary methods. Such object is not correct, but we should still be aware.