### PR TITLE
[java] Don't crash if none of the parsers can be initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## master (unreleased)
 
 * [#285](https://github.com/clojure-emacs/orchard/issues/285): **BREAKING:** Remove special handling of Boot classpath.
-* [#287](https://github.com/clojure-emacs/orchard/issues/287): Inspector: ton't crash when field contains non-equiv()able value.
+* [#287](https://github.com/clojure-emacs/orchard/issues/287): Inspector: don't crash when field contains non-equiv()able value.
+* [#288](https://github.com/clojure-emacs/orchard/issues/288): Java: don't crash when loading if none of the parsers could be correctly initialized.
 
 ## 0.26.3 (2024-08-14)
 

--- a/project.clj
+++ b/project.clj
@@ -110,7 +110,8 @@
                          :eastwood {:ignored-faults {:unused-ret-vals-in-try {orchard.java {:line 84}
                                                                               orchard.java.parser-next-test true}}
                                     :exclude-namespaces ~(if jdk8?
-                                                           '[orchard.java.parser
+                                                           '[orchard.java.modules
+                                                             orchard.java.parser
                                                              orchard.java.parser-test
                                                              orchard.java.parser-utils
                                                              orchard.java.parser-next

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -31,13 +31,13 @@
 ;; project's dev dependencies. The core Java API classes are the exception to
 ;; this, since these are external to lein/maven dependency management. For
 ;; these, `enrich-classpath` searches the JDK directory and add the source classpath entry
-;; manually, if available. Prior to JDK9, parsing source files also requires
+;; manually, if available. On JDK8, parsing source files also requires
 ;; having `tools.jar` on the classpath.
 
 (defn ^:deprecated jdk-find
   "Search common JDK path configurations for a specified file name and return a
   URL if found. This accommodates `java.home` being set to either the JDK root
-  (JDK9+) or a JRE directory within this (JDK 8), and searches both the home and
+  (JDK11+) or a JRE directory within this (JDK 8), and searches both the home and
   `lib` directories."
   [_]
   nil)
@@ -69,7 +69,7 @@
 
 ;;; ## Source Analysis
 ;;
-;; Java parser support is available for JDK9+ and JDK8 and below via separate
+;; Java parser support is available for JDK11+ and JDK8 via separate
 ;; namespaces, `java.parser` and `java.legacy-parser`. The former uses only
 ;; external JDK APIs and supports modular (Jigsaw) sources. The latter uses
 ;; internal APIs out of necessity. Once this project discontinues support for

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -139,13 +139,11 @@
   (source-info* class))
 
 ;; As of Java 11, Javadoc URLs begin with the module name.
-(def module-name
-  "On JDK9+, return module name from the class if present; otherwise return nil"
-  ;; NOTE This function exists in the parser namespace for conditional
-  ;; loading on JDK9+; it does not require parsing.
-  (if (>= misc/java-api-version 9)
-    (misc/require-and-resolve 'orchard.java.parser-utils/module-name)
-    (constantly nil)))
+(defn module-name
+  "On JDK11+, return module name from the class if present; otherwise return nil"
+  [klass]
+  (when (>= misc/java-api-version 9)
+    ((misc/require-and-resolve 'orchard.java.modules/module-name) klass)))
 
 (defn javadoc-url
   "Return the relative `.html` javadoc path and member fragment."

--- a/src/orchard/java/legacy_parser.clj
+++ b/src/orchard/java/legacy_parser.clj
@@ -23,7 +23,7 @@
 
 ;;; ## JDK Compatibility
 ;; This namespace is compatible with JDK8 and below. It requires that
-;; `tools.jar` be on the classpath. A newer parser compatible with JDK9+ exists
+;; `tools.jar` be on the classpath. A newer parser compatible with JDK11+ exists
 ;; as a separate namespace.
 
 ;;; ## Java Source Analysis

--- a/src/orchard/java/modules.clj
+++ b/src/orchard/java/modules.clj
@@ -1,0 +1,7 @@
+(ns orchard.java.modules
+  "Utilities for accessing module information. Requires JDK11 and onward.")
+
+(defn module-name
+  "Return the module name for the class if it can be resolved."
+  [klass]
+  (some-> klass ^Class resolve .getModule .getName))

--- a/src/orchard/java/parser.clj
+++ b/src/orchard/java/parser.clj
@@ -19,7 +19,7 @@
 
 ;;; ## JDK Compatibility
 ;;
-;; This namespace requires JDK9+.
+;; This namespace requires JDK11+.
 
 ;;; ## Java Source Analysis
 ;;

--- a/src/orchard/java/parser_utils.clj
+++ b/src/orchard/java/parser_utils.clj
@@ -3,7 +3,8 @@
   {:added "0.15.0"}
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string])
+   [clojure.string :as string]
+   [orchard.java.modules :as modules])
   (:import
    (java.io StringWriter)
    (javax.lang.model.element VariableElement)
@@ -87,10 +88,12 @@
   {:name (-> f .getSimpleName str symbol)
    :type (-> f .asType (typesym env))})
 
+;; Left for backward compatibility, callers are free to invoke
+;; `orchard.java.modules/module-name` directly.
 (defn module-name
   "Return the module name, or nil if modular"
   [klass]
-  (some-> klass ^Class resolve .getModule .getName))
+  (modules/module-name klass))
 
 (defn source-path
   "Return the relative `.java` source path for the top-level class."


### PR DESCRIPTION
Context here: https://clojurians.slack.com/archives/C17JYSA3H/p1724172844138059

On the JRE, loading CIDER (and hence Orchard) produces an exception like this:

```
error in process sentinel: Could not start nREPL server: Downloading: cider/cider-nrepl/0.45.0/cider-nrepl-0.45.0.pom from clojars
Downloading: cider/orchard/0.22.0/orchard-0.22.0.pom from clojars
Downloading: mx/cider/logjam/0.2.0/logjam-0.2.0.pom from clojars
Downloading: cider/orchard/0.22.0/orchard-0.22.0.jar from clojars
Downloading: mx/cider/logjam/0.2.0/logjam-0.2.0.jar from clojars
Downloading: cider/cider-nrepl/0.45.0/cider-nrepl-0.45.0.jar from clojars
Execution error (IllegalArgumentException) at orchard.misc/require-and-resolve (misc.clj:161).
No such namespace: orchard.java.parser-utils
```

---

- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) 