### PR TITLE
[java] Parse LruMap.java as indicator of a working parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#290](https://github.com/clojure-emacs/orchard/issues/290): Java: initialize parsers if JDK classes aren't present.
+
 ## 0.27.0 (2024-08-21)
 
 * [#285](https://github.com/clojure-emacs/orchard/issues/285): **BREAKING:** Remove special handling of Boot classpath.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Set bash instead of sh for the @if [[ conditions,
 # and use the usual safety flags:
-SHELL = /bin/bash -Eeu
+SHELL = /bin/bash -Ee
 
 HOME=$(shell echo $$HOME)
 CLOJURE_VERSION ?= 1.11

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   {:dependencies '[[org.clojure/java.classpath "1.1.0"]
                    [nubank/matcher-combinators "3.9.1"
                     :exclusions [org.clojure/clojure]]]
-   :source-paths (cond-> ["test-java"]
+   :source-paths (cond-> ["test-java" "java"]
                    ;; We only include sources with JDK21 because we only
                    ;; repackage sources for that JDK. Sources from one JDK are
                    ;; not compatible with other JDK for our test purposes.

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -82,7 +82,7 @@
 (def parser-next-available?
   (delay ;; avoid the side-effects at compile-time
     (atom ;; make the result mutable - this is helpful in case the detection below wasn't sufficient
-     (and (>= misc/java-api-version 9)
+     (and (>= misc/java-api-version 17) ;; parser-next doesn't work correctly on JDK11
           (try
             ;; indicates that the classes are available
             ;; however it does not indicate if necessary `add-opens=...` JVM flag is in place:

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -92,7 +92,7 @@
              (do
                ;; require the whole namespace in case there's some other source of problems (e.g. some other missing `opens`)
                (require 'orchard.java.parser-next)
-               ((resolve 'orchard.java.parser-next/source-info) `String :throw))
+               ((resolve 'orchard.java.parser-next/source-info) `LruMap :throw))
              true)
             (catch Throwable e
               (reset! parser-available-exception e)
@@ -106,7 +106,7 @@
   (delay
     (when (>= misc/java-api-version 9)
       (try (let [f (misc/require-and-resolve 'orchard.java.parser/source-info)]
-             (when (f `String)
+             (when (f `LruMap)
                f))
            (catch Throwable e
              (reset! parser-available-exception e)
@@ -116,7 +116,7 @@
   (delay
     (when jdk-tools
       (try (let [f (misc/require-and-resolve 'orchard.java.legacy-parser/source-info)]
-             (when (f `String)
+             (when (f `LruMap)
                f))
            (catch Throwable e
              (reset! parser-available-exception e)


### PR DESCRIPTION
This allows parsers to correctly initialize even if JDK sources aren't present.
