### PR TITLE
[inspect] Show count for HashMap and other maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## master (unreleased)
 
+* [#293](https://github.com/clojure-emacs/orchard/issues/293): Inspector: show HashMap size in the header.
+
 ## 0.27.2 (2024-08-28)
 
-* [#292](https://github.com/clojure-emacs/orchard/issues/290): Inspector/debugger: fix map entries being spliced in non-map collections when printed.
+* [#292](https://github.com/clojure-emacs/orchard/issues/292): Inspector/debugger: fix map entries being spliced in non-map collections when printed.
 
 ## 0.27.1 (2024-08-27)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -72,6 +72,7 @@
 
 (defn- counted-length [obj]
   (cond (instance? clojure.lang.Counted obj) (count obj)
+        (instance? Map obj) (.size ^Map obj)
         (array? obj) (java.lang.reflect.Array/getLength obj)))
 
 (defn- pagination-info

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1409,6 +1409,14 @@
                     "Component Type: " (:value "byte" 1)
                     (:newline)
                     (:newline))
+                  (header rendered))))
+    (let [rendered (-> (java.util.HashMap.) inspect render)]
+      (is (match? '("Class: "
+                    (:value "java.util.HashMap" 0)
+                    (:newline)
+                    "Count: " "0"
+                    (:newline)
+                    (:newline))
                   (header rendered))))))
 
 (deftest object-view-mode-test


### PR DESCRIPTION
HashMap size was not shown in the inspector because it's not an instance of `Counted`. This PR fixes that.