### PR TITLE
[inspect] Count small lazy collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#293](https://github.com/clojure-emacs/orchard/issues/293): Inspector: show HashMap size in the header.
+* [#294](https://github.com/clojure-emacs/orchard/issues/294): Inspector: count small lazy collections.
 
 ## 0.27.2 (2024-08-28)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -73,7 +73,11 @@
 (defn- counted-length [obj]
   (cond (instance? clojure.lang.Counted obj) (count obj)
         (instance? Map obj) (.size ^Map obj)
-        (array? obj) (java.lang.reflect.Array/getLength obj)))
+        (array? obj) (java.lang.reflect.Array/getLength obj)
+        ;; Count small lazy collections <= 10 elements (arbitrary).
+        (sequential? obj) (let [bc (bounded-count 11 obj)]
+                            (when (<= bc 10)
+                              bc))))
 
 (defn- pagination-info
   "Calculate if the object should be paginated given the page size. Return a map

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1417,6 +1417,14 @@
                     "Count: " "0"
                     (:newline)
                     (:newline))
+                  (header rendered))))
+    (let [rendered (-> (cons 1 (cons 2 nil)) inspect render)]
+      (is (match? '("Class: "
+                    (:value "clojure.lang.Cons" 0)
+                    (:newline)
+                    "Count: " "2"
+                    (:newline)
+                    (:newline))
                   (header rendered))))))
 
 (deftest object-view-mode-test


### PR DESCRIPTION
Addresses #268.

This influences both the `Count` indicator in the header for types like `Cons` or small lazy seqs, but also displays such collections as lists when they are inside containers like atoms, delays, etc.
