### PR TITLE
Test parsers on all JDKs >=11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,16 +48,13 @@ commands:
     parameters:
       steps:
         type: steps
-      clojure_version:
-        description: Will be used as part of the cache key
-        type: string
       files:
         description: Files to consider when creating the cache key
         type: string
         default: "deps.edn project.clj"
       cache_version:
         type: string
-        description: "Change this value to force a cache update"
+        description: "Key used to identify unique cache"
         default: "1"
     steps:
       - run:
@@ -75,14 +72,17 @@ commands:
               find . -name $file -exec cat {} +
             done | sha256sum | awk '{print $1}' > /tmp/clojure_cache_seed
       - restore_cache:
-          key: cache-<< parameters.cache_version >>-<< parameters.clojure_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+          key: cache-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - ~/.m2
             - .cpcache
-            - base-src.zip
-          key: cache-<< parameters.cache_version >>-<< parameters.clojure_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
+            - base-src-jdk11.zip
+            - base-src-jdk17.zip
+            - base-src-jdk21.zip
+            - base-src-jdk23.zip
+          key: cache-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
 jobs:
 
@@ -100,8 +100,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: "lint_v1"
-          clojure_version: << parameters.clojure_version >>
+          cache_version: "lint_v1_<< parameters.clojure_version >>"
           steps:
             - run:
                 name: Running cljfmt
@@ -125,8 +124,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          clojure_version: << parameters.clojure_version >>
-          cache_version: "eastwood_v1"
+          cache_version: "eastwood_v1_<< parameters.clojure_version >>"
           steps:
             # Eastwood is run for every Clojure and JDK version because its
             # results are sensitive to the code in the runtime.
@@ -160,11 +158,11 @@ jobs:
     executor: << parameters.jdk_version >>
     environment:
       CLOJURE_VERSION: << parameters.clojure_version >>
+      JDK_SRC_VERSION: << parameters.jdk_version >>
     steps:
       - checkout
       - with_cache:
-          clojure_version: << parameters.clojure_version >>
-          cache_version: test_v1_<< parameters.command >>
+          cache_version: "test_v1_<< parameters.clojure_version >>_<< parameters.jdk_version >>_<< parameters.command >>"
           steps:
             - run:
                 name: Running tests (make << parameters.command >>)

--- a/download-jdk-sources.sh
+++ b/download-jdk-sources.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+URL="$1"
+QUALIFIER=$2
+DEST=$3
+
+# Download JDK sources from Github and repackage in the same fashion as src.zip
+# that is normally distributed with JDK.
+wget "$URL" -O full-src.zip
+unzip -q full-src.zip
+cp -r "$QUALIFIER"u-*/src/java.base/share/classes java.base
+cp -r "$QUALIFIER"u-*/src/java.desktop/share/classes java.desktop
+zip -qr $DEST java.base java.desktop
+rm -rf java.base java.desktop "$QUALIFIER"u- full-src.zip

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -8,8 +8,9 @@
   (:import
    (orchard.java DummyClass)))
 
-(when (System/getenv "CI")
-  (println "JDK sources present?" (pr-str util/jdk-sources-present?)))
+(when (and (System/getenv "CI") (>= misc/java-api-version 11))
+  (deftest sources-should-be-present-on-ci
+    (is util/jdk-sources-present?)))
 
 (def source-info
   (when (>= misc/java-api-version 9)
@@ -93,22 +94,16 @@
 
 (when (and @@java/parser-next-available? util/jdk-sources-present?)
   (deftest doc-fragments-test
-    (is (= [{:type "text", :content "Returns an estimate of the number of "}
-            {:type "html", :content "<pre>#isAlive()</pre> "}
-            {:type "text",
-             :content
-             "
-platform threads in the current thread's thread group and its subgroups.
-Virtual threads are not included in the estimate.
-
-The value returned is only an estimate because the number of
-threads may change dynamically while this method traverses internal
-data structures, and might be affected by the presence of certain
-system threads. This method is intended primarily for debugging
-and monitoring purposes."}]
-           (-> `Thread
+    (is (= [{:type "text", :content "Inserts the specified element at the tail of this queue if it is
+possible to do so immediately without exceeding the queue's capacity,
+returning "}
+            {:type "html", :content "<pre>true</pre> "}
+            {:type "text", :content " upon success and throwing an\n"}
+            {:type "html", :content "<pre>IllegalStateException</pre> "}
+            {:type "text", :content " if this queue is full."}]
+           (-> 'java.util.concurrent.ArrayBlockingQueue
                source-info
-               (get-in [:members 'activeCount [] :doc-fragments])))
+               (get-in [:members 'add '[java.lang.Object] :doc-fragments])))
         "Returns a data structure with carefully managed whitespace location")
 
     (is (some #{{:type "text", :content " permission as well as\n"}}

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -5,15 +5,11 @@
    [clojure.set :as set]
    [clojure.string :as string]
    [clojure.test :refer [are deftest is testing]]
-   [orchard.java :as sut :refer [cache class-info class-info* javadoc-url jdk-tools member-info resolve-class resolve-javadoc-path resolve-member resolve-symbol resolve-type source-info]]
+   [orchard.java :as sut :refer [cache class-info class-info* javadoc-url member-info resolve-class resolve-javadoc-path resolve-member resolve-symbol resolve-type source-info]]
    [orchard.misc :as misc]
    [orchard.test.util :as util])
   (:import
    (mx.cider.orchard LruMap)))
-
-(def modern-java? (>= misc/java-api-version 9))
-
-(def jdk-parser? (or modern-java? jdk-tools))
 
 (javadoc/add-remote-javadoc "com.amazonaws." "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/")
 (javadoc/add-remote-javadoc "org.apache.kafka." "https://kafka.apache.org/090/javadoc/")
@@ -166,7 +162,7 @@
           m5 (member-info 'java.lang.Class 'forName)
           m6 (member-info 'java.util.AbstractMap 'finalize)
           m7 (member-info 'java.util.HashMap 'finalize)
-          m8 (member-info `Thread 'resume)]
+          m8 (member-info `Thread 'isDaemon)]
       (testing "Member"
         (testing "source file"
           (is (string? (:file m1)))


### PR DESCRIPTION
Before merging the parser implementations, it is a good idea to restore the parser testing for all JDK versions (except for JDK8 for now). I've updated the relevant scripts to download and repackage JDK sources for all JDK targets we run tests for.
