### PR TITLE
[java] Rework Java sources discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /checkouts
 /classes
 .javac
-.enrich-classpath-lein-repl
 /gh-pages
 /unzipped-jdk-source
 /target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-* [#278](https://github.com/clojure-emacs/orchard/pull/301): **BREAKING:** Drop support for Java sources parsing on JDK8.
+* [#301](https://github.com/clojure-emacs/orchard/pull/301): **BREAKING:** Drop support for Java sources parsing on JDK8.
+* [#303](https://github.com/clojure-emacs/orchard/pull/303): Rework Java sources discovery.
 
 ## 0.28.0 (2024-10-31)
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,30 @@ Just add `orchard` as a dependency and start hacking.
 Consult the [API documentation](https://cljdoc.org/d/cider/orchard/CURRENT) to get a better idea about the
 functionality that's provided.
 
-#### Using `enrich-classpath` for best results
+## Dealing with Java sources
 
-There are features that Orchard intends to provide (especially, those related to Java interaction) which need to assume a pre-existing initial classpath that already has various desirable items, such as the JDK sources, third-party sources, special jars such as `tools` (for JDK8), a given project's own Java sources... all that is a domain in itself, which is why our [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath) project does it.
+Orchard interacts with Java source files (`.java` files) in several ways:
 
-For getting the most out of Orchard, it is therefore recommended/necessary to use `enrich-classpath`. Please refer to its installation/usage instructions.
+- Locates the Java source files to enable the "jump to definition" functionality.
+  - Also enables "jump to file:line" from the printed stacktrace (a CIDER feature).
+- Parses Java sources to extract additional information about Java interop
+  targets (constructors, methods).
+  - Allows jumping directly to method definition in the Java source file.
+  - Extends the documentation for interop targets with Javadoc comments, exact
+    method argument names.
+
+Currently, Orchard is able to find Java source files in the following places:
+
+- On the classpath.
+- In the `src.zip` archive that comes together with most JDK distributions.
+- For clases that come from Maven-downloaded dependencies — in the special
+  `-sources.jar` artifact that resides next to the main artifact in the `~/.m2`
+  directory. The sources artifact has to be downloaded ahead of time, for
+  example, by [enrich-classpath](https://github.com/clojure-emacs/enrich-classpath).
+
+If the source file can be located, this is usually enough for basic "jump to
+source" functionality. For a more precise "jump to definition" and for
+Javadoc-based documentation, Orcard will attempt to parse the source file.
 
 #### `xref/fn-deps` and `xref/fn-refs` limitations
 
@@ -151,14 +170,10 @@ clients can make of use of the general functionality contained in
 
 ### Development
 
-`enrich-classpath` is important for development of Java-related features in Orchard, since it makes the Java sources available. Certain features parse those Java sources as a source of information.
-
-You can fire up a REPL (and nREPL server) that uses `cider-nrepl` and `enrich-classpath` like so:
-
-```bash
-# or `make lein-repl`
-make repl
-```
+Having JDK sources archive (`$JAVA_HOME/lib/src.zip`) is important for
+development of Java-related features in Orchard. Certain features parse those
+Java sources as a source of information. The archive doesn't need to be on the
+classpath, it just need to exist in the distribution.
 
 You can install Orchard locally like this:
 

--- a/project.clj
+++ b/project.clj
@@ -3,29 +3,11 @@
     (if (.contains v ".") 8 (Integer/parseInt v))))
 (def jdk8? (= jdk-version 8))
 
-;; Needed to be added onto classpath to test Java parser functionality.
-(def jdk-sources-archive
-  (delay
-    (when (>= jdk-version 11)
-      (when-let [requested-src-version (System/getenv "JDK_SRC_VERSION")]
-        (let [zip-path (format "base-src-%s.zip" requested-src-version)
-              src-zip (clojure.java.io/file zip-path)]
-          (if (.exists src-zip)
-            (do (println "Found JDK sources:" src-zip)
-                [src-zip])
-            (do (println (format "%s not found. Run `make %s` to properly run all the tests."
-                                 zip-path zip-path))
-                nil)))))))
-
 (def dev-test-common-profile
   {:dependencies '[[org.clojure/java.classpath "1.1.0"]
                    [nubank/matcher-combinators "3.9.1"
                     :exclusions [org.clojure/clojure]]]
-   :source-paths (cond-> ["test-java" "java"]
-                   ;; We only include sources with JDK21 because we only
-                   ;; repackage sources for that JDK. Sources from one JDK are
-                   ;; not compatible with other JDK for our test purposes.
-                   (>= jdk-version 11) (into @jdk-sources-archive))
+   :source-paths ["test-java" "java"]
    :resource-paths ["test-resources"]
    :test-paths ["test"]
    :java-source-paths ["test-java"]})

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -151,13 +151,7 @@
         meta    (cond
                   (= dialect :clj)  (clj-meta params)
                   (= dialect :cljs) (cljs-meta params))]
-
-    ;; TODO: Split the responsibility of finding meta and normalizing the meta map.
-    (some->
-     meta
-
-     (merge (when-let [file-path (:file meta)]
-              {:file file-path})))))
+    meta))
 
 (defn info
   "Provide the info map for the input ns and sym.

--- a/src/orchard/java/modules.clj
+++ b/src/orchard/java/modules.clj
@@ -2,6 +2,9 @@
   "Utilities for accessing module information. Requires JDK11 and onward.")
 
 (defn module-name
-  "Return the module name for the class if it can be resolved."
-  [klass]
-  (some-> klass ^Class resolve .getModule .getName))
+  "Return the module name for the class."
+  [class-or-sym]
+  (let [^Class klass (if (symbol? class-or-sym)
+                       (resolve class-or-sym)
+                       class-or-sym)]
+    (some-> klass .getModule .getName)))

--- a/src/orchard/java/source_files.clj
+++ b/src/orchard/java/source_files.clj
@@ -1,0 +1,127 @@
+(ns orchard.java.source-files
+  "Contains functions for discovering Java source files that are already available
+  on the REPL and for downloading sources from Maven."
+  {:author "Oleksandr Yakushev"
+   :added "0.29"}
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [orchard.misc :as misc])
+  (:import (java.io File IOException)
+           (java.net URL)))
+
+(defn- readable-file [^File f]
+  (when (.canRead f) f))
+
+(defn- jdk-find
+  "Search common JDK path configurations for a specified file name and return a
+  URL if found. This accommodates `java.home` being set to either the JDK root
+  (JDK11+) or a JRE directory within this (JDK 8), and searches both the home
+  and `lib` directories."
+  [f]
+  (let [home (io/file (System/getProperty "java.home"))
+        parent (.getParentFile home)]
+    (->> [(io/file home f)
+          (io/file home "lib" f)
+          (io/file parent f)
+          (io/file parent "lib" f)]
+         (some readable-file))))
+
+(def ^:private jdk-sources
+  "The JDK sources path. If found on the existing classpath, this is the
+  corresponding classpath entry. Otherwise, the JDK directory is searched for
+  the file `src.zip`."
+  (delay (jdk-find "src.zip")))
+
+(defn- class->classfile-path
+  "Infer a relative path to the classfile of the given `klass`."
+  [^Class klass]
+  (let [module (when (>= misc/java-api-version 11)
+                 ((requiring-resolve 'orchard.java.modules/module-name) klass))
+        classfile-name (-> (.getName klass)
+                           (string/replace #"\$.*" "") ;; Drop internal class.
+                           (string/replace "." "/")
+                           (str ".class"))]
+    (cond->> classfile-name
+      module (format "%s/%s" module))))
+
+(defn- classfile-path->sourcefile-path [classfile-name]
+  (string/replace classfile-name #"\.class$" ".java"))
+
+(defn class->sourcefile-path
+  "Infer a relative path to a source file of the given `klass`."
+  [^Class klass]
+  (-> klass class->classfile-path classfile-path->sourcefile-path))
+
+#_(class->sourcefile-path Thread)
+#_(class->sourcefile-path clojure.lang.PersistentVector)
+
+(defn- verify-url-readable
+  "Try to open `url` for reading. If it is readable, return `url`, otherwise nil."
+  [^URL url]
+  (when url
+    (try (.getContent ^URL url)
+         url
+         (catch IOException _))))
+
+(defn- locate-source-url-on-classpath ^URL [klass]
+  (-> klass
+      class->sourcefile-path
+      io/resource
+      verify-url-readable))
+
+#_(locate-source-url-on-classpath mx.cider.orchard.LruMap)
+
+(defn- combine-archive-url ^URL [^File archive, relative-filename]
+  ;; Even though the JDK stores sources in a zip archive, we still use this
+  ;; function that prefixes the URL with jar:. This is fine.
+  (io/as-url (format "jar:file:%s!/%s" archive relative-filename)))
+
+(defn- locate-source-url-in-jdk-sources
+  "Try to find the source file for `klass` in sources included with JDK."
+  ^URL [^Class klass]
+  ;; Heuristic: JDK classes have `nil` classloader.
+  (when (and @jdk-sources (nil? (.getClassLoader klass)))
+    (let [source-file (class->sourcefile-path klass)]
+      (-> (combine-archive-url @jdk-sources source-file)
+          verify-url-readable))))
+
+#_(locate-source-url-in-jdk-sources Thread)
+
+(defn- parse-jar-path-from-url [^URL url]
+  (when-let [[_ path] (some->> url .getFile (re-matches #"file:(.+\.jar)!.*"))]
+    (readable-file (io/file path))))
+
+(defn- infer-sources-jar-file [^File jar-file]
+  (let [parent (.getParent jar-file)
+        [_ fname] (re-matches #"(.+)\.jar" (.getName jar-file))
+        sources-jar (io/file parent (str fname "-sources.jar"))]
+    (readable-file sources-jar)))
+
+(defn- locate-source-url-near-class-jar
+  "If `klass` comes from a third-party JAR that presumedly resides in `.m2`
+  directory, try to look for a sources JAR near the class JAR and return it
+  together with the implied source filename."
+  [^Class klass]
+  (when-let [cl (some-> klass .getClassLoader)]
+    ;; Get the classloader that loaded the `klass` and locate the resource that
+    ;; the the class was loaded from. If that resource is a JAR file, search for
+    ;; a sources JAR near it.
+    (let [class-file (class->classfile-path klass)
+          res (.getResource cl class-file)
+          sources-jar-file (some-> res parse-jar-path-from-url infer-sources-jar-file)
+          source-filename (classfile-path->sourcefile-path class-file)]
+      (when sources-jar-file
+        (-> (combine-archive-url sources-jar-file source-filename)
+            verify-url-readable)))))
+
+#_(locate-source-url-near-class-jar clojure.lang.PersistentVector)
+
+(defn class->source-file-url ^URL [klass]
+  (or (locate-source-url-on-classpath klass)
+      (locate-source-url-in-jdk-sources klass)
+      (locate-source-url-near-class-jar klass)))
+
+#_(class->source-file-url mx.cider.orchard.LruMap)
+#_(class->source-file-url java.lang.Thread)
+#_(class->source-file-url clojure.lang.PersistentVector)
+#_(class->source-file-url clojure.core.Eduction)

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -535,7 +535,7 @@
 (deftest info-java-test
   (is (info/info-java 'clojure.lang.Atom 'swap)))
 
-(when util/jdk-sources-present?
+(when (and (>= misc/java-api-version 11) util/jdk-sources-present?)
   (deftest info-java-member-precedence-test
     (testing "Integer/max - issue #86"
       (let [i (info/info* {:ns 'user :sym 'Integer/max})]
@@ -544,9 +544,8 @@
                  :member max
                  :modifiers #{:public :static}
                  :class java.lang.Integer
-                 :arglists ([a b])
                  :returns int}
-               (select-keys i [:class :member :modifiers :throws :argtypes :arglists :returns])))
+               (select-keys i [:class :member :modifiers :throws :argtypes :returns])))
         (is (re-find #"Returns the greater of two" (:doc i)))))))
 
 (def some-var nil)

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -1,5 +1,6 @@
 (ns orchard.java.parser-next-test
   (:require
+   [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.test :refer [deftest is testing]]
    [orchard.java :as java]
@@ -26,7 +27,7 @@
   (deftest parse-java-test
     (testing "Throws an informative exception on invalid code"
       (try
-        (parse-java "orchard/java/InvalidClass.java" nil)
+        (parse-java (io/resource "orchard/java/InvalidClass.java") nil)
         (assert false)
         (catch Exception e
           (is (-> e ex-data :out (string/includes? "illegal start of expression"))))))))
@@ -36,8 +37,7 @@
     (is (class? DummyClass))
 
     (testing "file on the filesystem"
-      (is (= '{:file "orchard/java/DummyClass.java",
-               :doc-first-sentence-fragments
+      (is (= '{:doc-first-sentence-fragments
                [{:type "text", :content "Class level docstring."}],
                :column 1,
                :line 12,
@@ -85,14 +85,7 @@
                "Class level docstring.\n\n <pre>\n   DummyClass dc = new DummyClass();\n </pre>\n\n @author Arne Brasseur"}
              (dissoc (source-info 'orchard.java.DummyClass)
                      :path
-                     :resource-url))))
-
-    (testing "java file in a jar"
-      (let [rt-info (source-info 'clojure.lang.RT)]
-        (is (= {:file "clojure/lang/RT.java"}
-               (select-keys rt-info [:file])))
-        (is (re-find #"jar:file:/.*/.m2/repository/org/clojure/clojure/.*/clojure-.*-sources.jar!/clojure/lang/RT.java"
-                     (str (:resource-url rt-info))))))))
+                     :resource-url))))))
 
 (when (and jdk11+? util/jdk-sources-present?)
   (deftest doc-fragments-test

--- a/test/orchard/java/source_files_test.clj
+++ b/test/orchard/java/source_files_test.clj
@@ -1,0 +1,9 @@
+(ns orchard.java.source-files-test
+  (:require [clojure.test :refer [deftest is]]
+            [orchard.java.source-files :as src-files]))
+
+(deftest class->source-file-url-test
+  (is (src-files/class->source-file-url mx.cider.orchard.LruMap)) ;; classpath
+  (is (src-files/class->source-file-url Thread)) ;; JDK
+  (is (src-files/class->source-file-url clojure.lang.PersistentVector)) ;; Clojure
+  (is (nil? (src-files/class->source-file-url clojure.core.Eduction)))) ;; record

--- a/test/orchard/test/util.clj
+++ b/test/orchard/test/util.clj
@@ -1,9 +1,8 @@
 (ns orchard.test.util
-  (:require [clojure.java.io :as io]))
+  (:require [orchard.java.source-files :as src-files]))
 
 (def jdk-sources-present?
-  (boolean (or (io/resource "java/lang/Thread.java")
-               (io/resource "java.base/java/lang/Thread.java"))))
+  (boolean (src-files/class->source-file-url Thread)))
 
 (defn imported-classes [ns-sym]
   {:post [(seq %)]}


### PR DESCRIPTION
This is the first step – and a big one – in redoing Orchard's interaction with Java sources. It's kinda difficult to split it into smaller chunks, so I'm going to explain the changes below.

1. The main idea is this – the user may have some downloaded Java sources on the disk. We used to look for those sources on classpath, but it's not obligatory. In fact, there is no reason to put the sources themselves on the classpath, we can read them of the disk just the same, just have to discover them.
2. The biggest obvious place where we can find Java sources is the Java home directory. We know where it is, we know how to find the source archive in it, thus we can parse sources and enable jump-to-definition for those without having them on the classpath.
3. Another possible source of sources (heh) are the `-sources.jar` JARs that can be downloaded from Maven. Getting them from Maven is kind of complicated – that's why `enrich-classpath` exists. But once they are downloaded, we can again locate them on the disk without having to bring them onto the classpath.
4. A new namespace `orchard.java.source-files` currently contains code that sources for those source archives and JARs. It replaces the current approach of only calling `io/resource` to search for Java source files. In the future, this namespace might also enable the downloading of JARs somehow (e.g., by calling an external process), but it already brings certain value as is.
5. Jumping to the source file doesn't have to obligate parsing that source file first. Sure, if we parse it, then we have the exact line number, but even without that simply opening the Java source file is already beneficial. So, this PR separates the logic of locating the source file and parsing it, so the latter is not required for the former.
6. I've also updated other functions to play well with these changes. 

I'm going to test-drive these changes for a while.

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md).