### PR TITLE
[ci] Refactor linter and other CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,13 +88,10 @@ jobs:
 
   lint:
     parameters:
-      jdk_version:
-        type: string
-        default: jdk21
       clojure_version:
         type: string
-        default: "1.11"
-    executor: << parameters.jdk_version >>
+        default: "1.12"
+    executor: jdk21
     environment:
       CLOJURE_VERSION: << parameters.clojure_version >>
     steps:
@@ -117,6 +114,7 @@ jobs:
         type: string
       clojure_version:
         type: string
+        default: "1.12"
     executor: << parameters.jdk_version >>
     environment:
       CLOJURE_VERSION: << parameters.clojure_version >>
@@ -184,22 +182,10 @@ workflows:
   ci-test-matrix:
     jobs:
       - test:
-          # Regular tests for all Clojure and JDK versions (except JDK21, see
-          # below). This matrix doesn't perform parser tests because we don't
-          # have JDK sources here.
           matrix:
             alias: "test"
             parameters:
-              jdk_version: [jdk8, jdk11, jdk17, jdk23]
-              clojure_version: ["1.10", "1.11", "1.12"]
-          <<: *run_always
-      - test:
-          # We have source for JDK21, so with this JDK version we also perform
-          # Java parser tests.
-          matrix:
-            alias: "test_with_sources"
-            parameters:
-              jdk_version: [jdk21]
+              jdk_version: [jdk8, jdk11, jdk17, jdk21, jdk23]
               clojure_version: ["1.10", "1.11", "1.12"]
           <<: *run_always
       - test:
@@ -212,21 +198,19 @@ workflows:
               clojure_version: ["1.12"]
               command: ["test-no-extra-deps"]
           <<: *run_always
-      # Eastwood output partly depends on Clojure and JDK version it is run on,
+      # Eastwood output partly depends on JDK version it is run on,
       # so selectively test with several versions of those.
       - eastwood:
           matrix:
             alias: "eastwood"
             parameters:
               jdk_version: [jdk8, jdk23]
-              clojure_version: ["1.11", "1.12"]
           <<: *run_always
       - lint:
           <<: *run_always
       - deploy:
           requires:
             - test
-            - test_with_sources
             - test_no_extra_deps
             - eastwood
             - lint

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
 {:output            {:progress      true
-                     :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj" "base-src.zip"]}
+                     :exclude-files ["analysis.cljc" "meta.cljc" "inspect_test.clj" "print_test.clj"]}
  :config-in-comment {:linters {:unused-value         {:level :off}
                                :unresolved-namespace {:level :off}}}
  :linters           {:unused-private-var {:level   :warning

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: submodules test quick-test docs eastwood cljfmt kondo install deploy clean lein-repl repl lint
+.PHONY: submodules test docs eastwood cljfmt kondo install deploy clean lein-repl repl lint
 .DEFAULT_GOAL := install
 
 # Set bash instead of sh for the @if [[ conditions,
@@ -53,19 +53,13 @@ test: base-src-$(JDK_SRC_VERSION).zip submodules clean
 test-no-extra-deps: base-src-$(JDK_SRC_VERSION).zip
 	lein with-profile -user,-dev,+test,+$(CLOJURE_VERSION) test
 
-quick-test: test
-
 eastwood:
 	lein with-profile $(TEST_PROFILES),+$(CLOJURE_VERSION),+eastwood eastwood
 
 cljfmt:
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+cljfmt cljfmt check
 
-# Note that -dev is necessary for not hitting OOM errors in CircleCI
-.make_kondo_prep: project.clj .clj-kondo/config.edn
-	lein with-profile -dev,+test,+clj-kondo clj-kondo --copy-configs --dependencies --parallel --lint '$$classpath' > $@
-
-kondo: .make_kondo_prep clean
+kondo: clean
 	lein with-profile -dev,+test,+clj-kondo clj-kondo
 
 lint: kondo cljfmt eastwood

--- a/project.clj
+++ b/project.clj
@@ -93,9 +93,9 @@
              :cljfmt {:plugins [[lein-cljfmt "0.9.2"]]
                       :cljfmt {:indents {merge-meta [[:inner 0]]}}}
 
-             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2023.07.13"]]}
+             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "2024.11.14"]]}
 
-             :eastwood  {:plugins  [[jonase/eastwood "1.4.0"]]
+             :eastwood  {:plugins  [[jonase/eastwood "1.4.3"]]
                          :eastwood {:ignored-faults {:unused-ret-vals-in-try {orchard.java {:line 84}
                                                                               orchard.java.parser-next-test true}}
                                     :exclude-namespaces ~(when jdk8?


### PR DESCRIPTION
- Update linter versions.
- Reduce the matrix for Eastwood.
- Merge back test matrices since we now only have one parser and we download sources for all JDK versions.