### PR TITLE
[java] Return actual paths as :file in class-info*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#309](https://github.com/clojure-emacs/orchard/pull/309): **BREAKING:** Remove deprecated functions from orchard.java (`jdk-find`, `jdk-sources`, `jdk-tools`, `ensure-jdk-sources`).
 * [#309](https://github.com/clojure-emacs/orchard/pull/309): **BREAKING:** Remove `orchard.java/cache-initializer`.
 * [#311](https://github.com/clojure-emacs/orchard/pull/311): Trace: fix the printing inside the wrapped function to be truncated.
+* [#313](https://github.com/clojure-emacs/orchard/pull/313): Java: make `class-info*` return absolute paths in `:file` key.
 
 ## 0.29.1 (2025-01-03)
 

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -81,16 +81,16 @@
 (defn update-vals
   "Update the values of map `m` via the function `f`."
   [f m]
-  (reduce (fn [acc [k v]]
-            (assoc acc k (f v)))
-          {} m))
+  (reduce-kv (fn [acc k v]
+               (assoc acc k (f v)))
+             {} m))
 
 (defn update-keys
   "Update the keys of map `m` via the function `f`."
   [f m]
-  (reduce (fn [acc [k v]]
-            (assoc acc (f k) v))
-          {} m))
+  (reduce-kv (fn [acc k v]
+               (assoc acc (f k) v))
+             {} m))
 
 (defn deep-merge
   "Merge maps recursively. When vals are not maps, last value wins."

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -1,6 +1,5 @@
 (ns orchard.java-test
   (:require
-   [clojure.java.io :as io]
    [clojure.java.javadoc :as javadoc]
    [clojure.set :as set]
    [clojure.string :as string]
@@ -154,11 +153,9 @@
           thread-class-info (class-info `Thread)]
       (testing "Class"
         (testing "source file"
-          (is (string? (:file c1)))
-          (is (io/resource (:file c1))))
+          (is (misc/url? (:file c1))))
         (testing "source file for nested class"
-          (is (string? (:file c2)))
-          (is (io/resource (:file c2))))
+          (is (misc/url? (:file c2))))
         (testing "member info"
           (is (map? (:members c1)))
           (is (every? map? (vals (:members c1))))
@@ -193,8 +190,7 @@
           m8 (member-info `Thread 'isDaemon)]
       (testing "Member"
         (testing "source file"
-          (is (string? (:file m1)))
-          (is (io/resource (:file m1))))
+          (is (misc/url? (:file m1))))
         (testing "line number"
           (is (number? (:line m1))))
         (testing "arglists"


### PR DESCRIPTION
Context here: https://clojurians.slack.com/archives/CBE668G4R/p1735807627304719

Cider-nrepl's `info` doc says that `:file` key contains either an absolute URL or a relative path to the file – but still a filesystem path. The current class-info* implementation returns `:file` as a path on the classpath. Sometimes, it is a valid as a file path – if the class is local to the project, but more often the class is external, and the resource path doesn't work as the file path.

This PR fixes that.

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)