### PR TITLE
Remove deprecated functions and refactor some tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+* [#317](https://github.com/clojure-emacs/orchard/pull/317): **BREAKING:** Remove deprecated functions:
+   - `orchard.namespace/read-namespace`, `orchard.namespace/ensure-namespace`
+   - `orchard.meta/var-meta-whitelist`
+   - `orchard.inspect/set-page-size`, `orchard.inspect/set-max-atom-length`, `orchard.inspect/set-max-value-length`, `orchard.inspect/set-max-coll-size`, `orchard.inspect/set-max-nested-depth`
+
 ## 0.30.1 (2025-02-24)
 
 * [#316](https://github.com/clojure-emacs/orchard/pull/316): Java: properly convert file path that contains spaces or backslashes to URI.

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -817,31 +817,6 @@
   []
   (start nil))
 
-(defn ^:deprecated set-page-size
-  "Use `refresh` instead."
-  [inspector new-page-size]
-  (refresh inspector {:page-size new-page-size}))
-
-(defn ^:deprecated set-max-atom-length
-  "Use `refresh` instead."
-  [inspector max-atom-length]
-  (refresh inspector {:max-atom-length max-atom-length}))
-
-(defn ^:deprecated set-max-value-length
-  "Use `refresh` instead."
-  [inspector max-value-length]
-  (refresh inspector {:max-value-length max-value-length}))
-
-(defn ^:deprecated set-max-coll-size
-  "Use `refresh` instead."
-  [inspector max-coll-size]
-  (refresh inspector {:max-coll-size max-coll-size}))
-
-(defn ^:deprecated set-max-nested-depth
-  "Use `refresh` instead."
-  [inspector max-nested-depth]
-  (refresh inspector {:max-nested-depth max-nested-depth}))
-
 (defn inspect-print
   "Get a human readable printout of rendered sequence."
   [x]

--- a/src/orchard/java/classpath.clj
+++ b/src/orchard/java/classpath.clj
@@ -26,10 +26,6 @@
   ([]
    (classloaders (context-classloader))))
 
-(defn ^:deprecated modifiable-classloader
-  ([_])
-  ([]))
-
 (defn set-classloader!
   "Sets the current classloader for the current thread."
   [^ClassLoader loader]
@@ -60,12 +56,6 @@
         (distinct)))
   ([]
    (classpath (context-classloader))))
-
-(defn ^:deprecated add-classpath!
-  "Adds the URL to the classpath and returns it if successful, or nil otherwise,
-  ensuring that a modifiable classloader is available."
-  [_]
-  nil)
 
 ;;; Classpath resources
 

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -236,9 +236,6 @@
   [:ns :name :doc :file :arglists :forms :macro :special-form
    :protocol :line :column :static :added :deprecated :resource :style/indent :indent])
 
-(def ^:deprecated var-meta-whitelist
-  var-meta-allowlist)
-
 ;; TODO: Split the responsibility of finding meta and normalizing the meta map.
 (defn var-meta
   "Return a map of metadata for var v.

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -55,12 +55,6 @@
            (every-pred ns-form? ns-form->ns-name)
            ns-form->ns-name))
 
-(defn read-namespace
-  "Returns the namespace name from the first top-level `ns` form in the file."
-  {:deprecated "0.19"}
-  [url]
-  (read-ns-name url))
-
 (defn read-ns-form
   "Returns the first top-level `ns` form in the file."
   {:added "0.19"}
@@ -86,11 +80,6 @@
   [ns]
   (try (doto (symbol ns) require)
        (catch Exception _)))
-
-(defn ^:deprecated ensure-namespace
-  "Renamed - please use `#'ensure-namespace!` instead."
-  [ns]
-  (ensure-namespace! ns))
 
 ;;; Filters
 


### PR DESCRIPTION
This PR removes most of the older deprecated functions. cider-nrepl no longer uses them, and I doubt anybody else does.

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)