### PR TITLE
Remove unused orchard.misc functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    - `orchard.namespace/read-namespace`, `orchard.namespace/ensure-namespace`
    - `orchard.meta/var-meta-whitelist`
    - `orchard.inspect/set-page-size`, `orchard.inspect/set-max-atom-length`, `orchard.inspect/set-max-value-length`, `orchard.inspect/set-max-coll-size`, `orchard.inspect/set-max-nested-depth`
+* [#318](https://github.com/clojure-emacs/orchard/pull/318): **BREAKING:** Remove no longer used functions: `orchard.misc/lazy-seq?`, `orchard.misc/safe-count`, `orchard.misc/normalize-subclass`, `orchard.misc/remove-type-param`.
 
 ## 0.30.1 (2025-02-24)
 

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -49,7 +49,7 @@
 (def ^:private parser-next-source-info
   (delay
     (when (>= misc/java-api-version 11)
-      (try (let [f (misc/require-and-resolve 'orchard.java.parser-next/source-info)]
+      (try (let [f (requiring-resolve 'orchard.java.parser-next/source-info)]
              ;; We try parsing LruMap.java as a litmus test for whether the
              ;; parser works. We can be sure that LruMap.java is on the
              ;; classpath because we pack it into the final Orchard jar.
@@ -87,7 +87,7 @@
   "On JDK11+, return module name from the class if present; otherwise return nil"
   [class-or-sym]
   (when (>= misc/java-api-version 11)
-    ((misc/require-and-resolve 'orchard.java.modules/module-name) class-or-sym)))
+    ((requiring-resolve 'orchard.java.modules/module-name) class-or-sym)))
 
 (defn javadoc-url
   "Return the relative `.html` javadoc path and member fragment."

--- a/src/orchard/java/parser_next.clj
+++ b/src/orchard/java/parser_next.clj
@@ -383,7 +383,7 @@
                                       (= kind TypeKind/TYPEVAR)
                                       (upper-bound type))
                                 str
-                                misc/remove-type-param
+                                (string/replace #"<.*>" "") ;; Remove generics
                                 symbol)]
                (some-> (or best
                            (type->sym element))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -158,20 +158,3 @@
     (fn [& args]
       (when resolved-fn
         (apply resolved-fn args)))))
-
-(defn lazy-seq?
-  "Return true if `x` is a lazy seq, otherwise false."
-  [x]
-  (and (seq? x) (not (counted? x))))
-
-(defn safe-count
-  "Call `clojure.core/count` on `x` if it is a collection, but not a lazy seq."
-  [x]
-  (when (and (coll? x) (not (lazy-seq? x)))
-    (count x)))
-
-(defn normalize-subclass [s]
-  (string/replace s "$" "."))
-
-(defn remove-type-param [s]
-  (string/replace s #"<.*>" ""))

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -137,14 +137,12 @@
   [ns]
   (instance? clojure.lang.Namespace ns))
 
-;; Drop this in favor of clojure.core/requiring-resolve at some point?
-
 (defn require-and-resolve
-  "Try to require the namespace and get a var for the symbol, return the var's
-  value if successful, nil if not."
+  "Like `clojure.core/requiring-resolve`, but doesn't throw exception if namespace
+  was not found or failed to load. Also, returns derefs the resolved var."
   {:added "0.5"}
   [sym]
-  (try (require (-> sym namespace symbol))
+  (try (some-> sym requiring-resolve var-get)
        (var-get (resolve sym))
        (catch Exception _)))
 

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -17,11 +17,11 @@
 
 (def source-info
   (when jdk11+?
-    (misc/require-and-resolve 'orchard.java.parser-next/source-info)))
+    (requiring-resolve 'orchard.java.parser-next/source-info)))
 
 (def parse-java
   (when jdk11+?
-    (misc/require-and-resolve 'orchard.java.parser-next/parse-java)))
+    (requiring-resolve 'orchard.java.parser-next/parse-java)))
 
 (when jdk11+?
   (deftest parse-java-test

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -70,14 +70,3 @@
     (is (= 1 (f 1))))
   (let [f (misc/call-when-resolved 'com.example/unknown)]
     (is (nil? (f 1)))))
-
-(deftest lazy-seq?
-  (is (misc/lazy-seq? (repeat 1)))
-  (is (not (misc/lazy-seq? nil)))
-  (is (not (misc/lazy-seq? [1 2 3])))
-  (is (not (misc/lazy-seq? :not-a-seq))))
-
-(deftest safe-count
-  (is (= 3 (misc/safe-count [1 2 3])))
-  (is (nil? (misc/safe-count (repeat 1))))
-  (is (nil? (misc/safe-count :not-a-seq))))


### PR DESCRIPTION
Further cleanup of stuff we no longer need. Most of these were necessary when we supported pre-1.10, but they are not used anymore.

I don't fret making breaking changes here since I don't think that relying on a misc namespace of a 3rd-party library is such a good idea anyway.

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)