### PR TITLE
[java] Don't delay loading parser-next namespace, move exception handling

### DIFF
--- a/src/orchard/java/parser_next.clj
+++ b/src/orchard/java/parser_next.clj
@@ -97,15 +97,14 @@
                           (getSupportedOptions [_this]
                             #{})))
         out      (StringWriter.)        ; discard compiler messages
-        opts     (apply conj ["--show-members" "private"
-                              "--show-types" "private"
-                              "--show-packages" "all"
-                              "--show-module-contents" "all"
-                              "-quiet"]
-                        (when module
-                          ["--patch-module" (str module "=" tmpdir)]))
-        slurped (slurp url)
-        _ (spit tmpfile slurped)
+        opts     (concat ["--show-members" "private"
+                          "--show-types" "private"
+                          "--show-packages" "all"
+                          "--show-module-contents" "all"
+                          "-quiet"]
+                         (when module
+                           ["--patch-module" (str module "=" tmpdir)]))
+        _ (spit tmpfile (slurp url))
         task (.getTask compiler out nil nil doclet opts sources)]
     (try
       (if (false? (.call ^DocumentationTool$DocumentationTask task))
@@ -428,7 +427,7 @@
   ([class-sym]
    ;; This arity is left for backward compatibility.
    (let [klass (resolve class-sym)
-         src-url (src-files/class->source-file-url klass)]
+         src-url (some-> klass src-files/class->source-file-url)]
      (when src-url
        (source-info klass src-url))))
   ([^Class klass, source-url]

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -5,12 +5,9 @@
    [clojure.string :as string :refer [replace-first]]
    [clojure.test :refer [are deftest is testing use-fixtures]]
    [orchard.info :as info]
-   [orchard.java :as java]
    [orchard.misc :as misc]
    [orchard.test-ns]
    [orchard.test.util :as util]))
-
-(java/source-info 'mx.cider.orchard.LruMap) ;; make tests more deterministic
 
 (def cljs-available?
   (let [sym 'orchard.cljs.test-env


### PR DESCRIPTION
Now that we have a single parser that can be loaded pretty reliably (we don't depend on --add-opens), we can avoid stuffing it in a delay. Besides, that delay is touched very early on in cider-nrepl anyway.