### PR TITLE
More permissive orchard.info parsing of stacktrace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    - `orchard.meta/var-meta-whitelist`
    - `orchard.inspect/set-page-size`, `orchard.inspect/set-max-atom-length`, `orchard.inspect/set-max-value-length`, `orchard.inspect/set-max-coll-size`, `orchard.inspect/set-max-nested-depth`
 * [#318](https://github.com/clojure-emacs/orchard/pull/318): **BREAKING:** Remove no longer used functions: `orchard.misc/lazy-seq?`, `orchard.misc/safe-count`, `orchard.misc/normalize-subclass`, `orchard.misc/remove-type-param`.
+* [#320](https://github.com/clojure-emacs/orchard/pull/320): Info: recognize printed Java classes/methods and munged Clojure functions in stacktrace outputs.
 
 ## 0.30.1 (2025-02-24)
 

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -63,10 +63,8 @@
      (m/special-sym-meta sym)
      ;; it's a var
      (some-> ns (m/resolve-var sym) (m/var-meta var-meta-allowlist))
-     ;; it's a Java constructor/static member symbol
+     ;; it's a Java class/constructor/member symbol
      (some-> ns (java/resolve-symbol sym))
-     ;; it's a Java class/record type symbol
-     (some-> ns (java/resolve-type unqualified-sym))
      ;; it's an alias for another ns
      (some-> ns (m/resolve-aliases) (get sym) (m/ns-meta))
      ;; We use :unqualified-sym *exclusively* here because because our :ns is
@@ -147,11 +145,10 @@
    only applies to `:clj` since for `:cljs` there's no allowlisting)."
   [params]
   (let [params  (normalize-params params)
-        dialect (:dialect params)
-        meta    (cond
-                  (= dialect :clj)  (clj-meta params)
-                  (= dialect :cljs) (cljs-meta params))]
-    meta))
+        dialect (:dialect params)]
+    (cond
+      (= dialect :clj)  (clj-meta params)
+      (= dialect :cljs) (cljs-meta params))))
 
 (defn info
   "Provide the info map for the input ns and sym.

--- a/src/orchard/info.clj
+++ b/src/orchard/info.clj
@@ -63,6 +63,8 @@
      (m/special-sym-meta sym)
      ;; it's a var
      (some-> ns (m/resolve-var sym) (m/var-meta var-meta-allowlist))
+     ;; it's a munged printed var or .invoke method of a Clojure function
+     (some-> (m/resolve-munged-printed-var sym) (m/var-meta var-meta-allowlist))
      ;; it's a Java class/constructor/member symbol
      (some-> ns (java/resolve-symbol sym))
      ;; it's an alias for another ns

--- a/src/orchard/java/parser_next.clj
+++ b/src/orchard/java/parser_next.clj
@@ -405,9 +405,7 @@
                    (mapv #(parse-info % env))
                    ;; Index by name, argtypes. Args for fields are nil.
                    (group-by :name)
-                   (reduce (fn [ret [n ms]]
-                             (assoc ret n (zipmap (mapv :non-generic-argtypes ms) ms)))
-                           {}))})
+                   (misc/update-vals #(zipmap (mapv :non-generic-argtypes %) %)))})
 
   ExecutableElement ;; => method, constructor
   (parse-info* [o env]

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -191,6 +191,24 @@
                             (select-keys [:ns :name :arglists :doc])
                             (update :ns ns-name))))))))
 
+(let [a 1]
+  (defn- closed-over [] a))
+(closed-over)
+
+(deftest info-munged-printed-var-test
+  (is (= 'str
+         (:name (info/info 'orchard.test-ns 'clojure.core$str))))
+  (is (= 'str
+         (:name (info/info 'orchard.test-ns 'clojure.core$str.invoke))))
+  (is (= 'str
+         (:name (info/info 'orchard.test-ns 'clojure.core$str$fn__12.doInvoke))))
+  (is (= 'str
+         (:name (info/info 'orchard.test-ns (symbol "clojure.core/str/fn--12")))))
+  (is (= 'closed-over
+         (:name (info/info 'orchard.test-ns 'orchard.info_test$eval17939$closed_over__17940.invokeStatic))))
+  (is (= 'closed-over
+         (:name (info/info 'orchard.test-ns (symbol "orchard.info-test/eval17939/closed_over--17940"))))))
+
 (deftest info-unqualified-sym-and-namespace-test
   (testing "Resolution from current namespace"
     (when cljs-available?
@@ -410,13 +428,13 @@
 
       (when cljs-available?
         (testing "- :cljs"
-          (is (= (take 3 (repeat expected))
+          (is (= (repeat 3 expected)
                  (->> params
                       (map #(info/info* (merge @*cljs-params* %)))
                       (map #(select-keys % [:ns :name :arglists :macro :file])))))))
 
       (testing "- :clj"
-        (is (= [{}, expected, {}]
+        (is (= (repeat 3 expected)
                (->> params
                     (map #(info/info* %))
                     (map #(select-keys % [:ns :name :arglists :macro :file])))))))))


### PR DESCRIPTION
This is part 1 of simplifying Haystack usecases. I think this PR is self-sufficient enough to be reviewed individually.

The proposed changes relax the requirements for Java classes/members and Clojure vars to be inferred using `orchard.info/info`. Now it can recognize all printed stacktrace formats. The examples are in the tests. This influences:
- Better jump to definition (can jump directly from the REPL output without no extra prep)
- Better cider-doc support
- Even eldoc (this looks a bit funny, consider yourself if we should restrict this somehow).

<img width="441" alt="image" src="https://github.com/user-attachments/assets/8e8fd635-20f3-4bb6-b7e0-87329ad1ac55" />

<img width="287" alt="image" src="https://github.com/user-attachments/assets/9a221613-356a-4888-9060-891f39e01f66" />

<img width="399" alt="image" src="https://github.com/user-attachments/assets/3fa24ef7-7430-497a-8ec8-4e2d807676b8" />

<img width="582" alt="image" src="https://github.com/user-attachments/assets/c3840b4b-8222-43af-ab11-53d929705ee5" />

<img width="629" alt="image" src="https://github.com/user-attachments/assets/c23d8892-3b6f-457d-ba8d-2f019648379c" />

<img width="497" alt="image" src="https://github.com/user-attachments/assets/90d750d8-048d-47ab-ab66-c6495686eb2e" />

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)