### PR TITLE
Revert clojure.string alias back to str

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -4,6 +4,5 @@
  :linters           {:unused-private-var {:level   :warning
                                           :exclude [orchard.query-test/a-private orchard.query-test/docd-fn]}
                      :unresolved-symbol  {:exclude [(clojure.test/is [match?])]}
-                     :consistent-alias   {:aliases {clojure.string string}}
                      ;; Enable this opt-in linter:
                      :unsorted-required-namespaces {:level :warning}}}

--- a/src/orchard/cljs/analysis.cljc
+++ b/src/orchard/cljs/analysis.cljc
@@ -4,7 +4,7 @@
    :added "0.5"}
   (:refer-clojure :exclude [all-ns find-ns find-var ns-aliases ns-resolve])
   (:require
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.misc :as misc]))
 
 (defn all-ns [{namespaces :cljs.analyzer/namespaces}]
@@ -210,7 +210,7 @@
   * a var that is alias-qualified e.g. `foo/bar`."
   [env ns sym]
   (let [[referred-var-ns referred-var-symbol :as referred]
-        (some-> env (referred-vars ns) (get sym) (str) (string/split #"/") (->> (map symbol)))]
+        (some-> env (referred-vars ns) (get sym) (str) (str/split #"/") (->> (map symbol)))]
     (if referred
       (find-symbol-meta env referred-var-ns referred-var-symbol)
       (let [sym-ns (some-> sym namespace symbol)

--- a/src/orchard/indent.clj
+++ b/src/orchard/indent.clj
@@ -2,7 +2,7 @@
   "`:style/indent` inference."
   (:require
    [clojure.set :as set]
-   [clojure.string :as string])
+   [clojure.string :as str])
   (:import
    (java.util List)))
 
@@ -115,7 +115,7 @@
                                                                            (find clojure-mode-indents-fuzzy macro-name)
                                                                            (->> clojure-mode-indents-fuzzy
                                                                                 (some (fn [[k _v :as entry]]
-                                                                                        (when (string/includes? macro-name k)
+                                                                                        (when (str/includes? macro-name k)
                                                                                           entry)))))
         one-arglist? (-> arglists count (= 1))
         def-like? (re-find #"^def" macro-name)

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -10,7 +10,7 @@
   Pretty wild, right?"
   (:require
    [clojure.core.protocols :refer [datafy nav]]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.print :as print])
   (:import
    (java.lang.reflect Constructor Field Method Modifier)
@@ -556,7 +556,7 @@
 (defn- render-indent-str-lines [inspector s]
   (reduce #(-> (render-indent %1 (str %2))
                (render-ln))
-          inspector (string/split-lines s)))
+          inspector (str/split-lines s)))
 
 (defmethod inspect :string [inspector ^java.lang.String obj]
   (-> (render-class-name inspector obj)
@@ -581,13 +581,13 @@
   ;; Ugly as hell, but easier than reimplementing all custom printing that
   ;; java.lang.reflect does.
   (as-> member-string s
-    (string/replace s #"[\w\.]+\.(\w+\()" "$1") ;; remove class from method name
-    (string/replace s #"[\w\.]+\.(\w+)$" "$1") ;; remove class from field name
+    (str/replace s #"[\w\.]+\.(\w+\()" "$1") ;; remove class from method name
+    (str/replace s #"[\w\.]+\.(\w+)$" "$1") ;; remove class from field name
     ;; Class might not have a canonical name, as per `.getCanonicalName` doc.
     (if-let [canonical (.getCanonicalName class)]
-      (string/replace s canonical (.getSimpleName class))
+      (str/replace s canonical (.getSimpleName class))
       s)
-    (string/replace s #"java.lang.([A-Z])" "$1")))
+    (str/replace s #"java.lang.([A-Z])" "$1")))
 
 (defmethod inspect :default [inspector obj]
   (let [class-chain (loop [c (class obj), res ()]
@@ -763,7 +763,7 @@
     (if (and (seq path) (not-any? #(= % '<unknown>) path))
       (-> (render-section-header inspector "Path")
           (indent)
-          (render-indent (string/join " " (:path inspector)))
+          (render-indent (str/join " " (:path inspector)))
           (unindent))
       inspector)))
 

--- a/src/orchard/java.clj
+++ b/src/orchard/java.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.java.javadoc :as javadoc]
    [clojure.reflect :as reflect]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.java.resource :as resource]
    [orchard.java.source-files :as src-files]
    [orchard.misc :as misc]
@@ -71,8 +71,8 @@
 (defn javadoc-url
   "Return the relative `.html` javadoc path and member fragment."
   ([class]
-   (let [url (str (-> (string/replace (str class) "." "/")
-                      (string/replace "$" "."))
+   (let [url (str (-> (str/replace (str class) "." "/")
+                      (str/replace "$" "."))
                   ".html")
          ;; As of Java 11, Javadoc URLs begin with the module name.
          module (module-name class)]
@@ -82,8 +82,8 @@
    (str (javadoc-url class) "#" member
         (when argtypes
           (if (< misc/java-api-version 11) ; argtypes were munged before Java 11
-            (str "-" (string/join "-" (map #(string/replace % #"\[\]" ":A") argtypes)) "-")
-            (str "(" (string/join "," argtypes) ")"))))))
+            (str "-" (str/join "-" (map #(str/replace % #"\[\]" ":A") argtypes)) "-")
+            (str "(" (str/join "," argtypes) ")"))))))
 
 ;;; ## Class Metadata Assembly
 ;;
@@ -105,7 +105,7 @@
   ;; make the format match with that of `parser-next`:
   (mapv #(some-> %
                  str
-                 (string/replace "$" ".")
+                 (str/replace "$" ".")
                  symbol
                  typesym)
         argtypes))
@@ -193,12 +193,12 @@
         sb (StringBuilder.)
         package-re (when package
                      (re-pattern (str "^"
-                                      (string/replace package "." "\\.")
+                                      (str/replace package "." "\\.")
                                       "\\.")))
         shorten (fn [s]
                   (cond-> s
-                    package (string/replace package-re "")
-                    true (string/replace #"^java\.lang\." "")))
+                    package (str/replace package-re "")
+                    true (str/replace #"^java\.lang\." "")))
         fill-arglist!
         (fn []
           (into []

--- a/src/orchard/java/parser_next.clj
+++ b/src/orchard/java/parser_next.clj
@@ -21,7 +21,7 @@
   {:added "0.15.0"}
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.java.modules :as modules]
    [orchard.java.source-files :as src-files]
    [orchard.misc :as misc])
@@ -126,12 +126,12 @@
   "Using parse tree info, return the type's name equivalently to the `typesym`
   function in `orchard.java`."
   ([n ^DocletEnvironment env]
-   (let [t (string/replace (str n) #"<.*>" "") ; drop generics
+   (let [t (str/replace (str n) #"<.*>" "") ; drop generics
          util (.getElementUtils env)]
      (if-let [c (.getTypeElement util t)]
        (let [pkg (str (.getPackageOf util c) ".")
-             cls (-> (string/replace-first t pkg "")
-                     (string/replace "." "$"))]
+             cls (-> (str/replace-first t pkg "")
+                     (str/replace "." "$"))]
          (symbol (str pkg cls))) ; classes
        (symbol t)))))            ; primitives
 
@@ -294,15 +294,15 @@
           xs))
 
 (defn remove-left-margin [s]
-  (->> (string/split s #"\r?\n" -1) ;; split-lines without losing trailing newlines
+  (->> (str/split s #"\r?\n" -1) ;; split-lines without losing trailing newlines
        (map-indexed (fn [i s]
                       (let [first? (zero? i)
-                            blank? (string/blank? s)]
+                            blank? (str/blank? s)]
                         (cond-> s
                           (and (not first?)
                                (not blank?))
-                          (string/replace #"^ +" "")))))
-       (string/join "\n")))
+                          (str/replace #"^ +" "")))))
+       (str/join "\n")))
 
 (defn cleanup-whitespace [fragments]
   (into []
@@ -311,13 +311,13 @@
                    :as x}]
                (let [text? (= content-type "text")]
                  (assoc x :content (-> content
-                                       (string/replace #"^  +" " ")
-                                       (string/replace #"  +$" " ")
-                                       (string/replace #"\s*\n+\s*\n+\s*" "\n\n")
-                                       (string/replace #"\n +$" "\n")
+                                       (str/replace #"^  +" " ")
+                                       (str/replace #"  +$" " ")
+                                       (str/replace #"\s*\n+\s*\n+\s*" "\n\n")
+                                       (str/replace #"\n +$" "\n")
                                        (cond-> text? remove-left-margin
-                                               text? (string/replace #"^ +\." ".")
-                                               text? (string/replace #"^ +," ",")))))))
+                                               text? (str/replace #"^ +\." ".")
+                                               text? (str/replace #"^ +," ",")))))))
         fragments))
 
 (defn docstring
@@ -345,7 +345,7 @@
                                                             :found-closing-tags-types
                                                             found-closing-tags-types))
                                 :result)]
-    {:doc (some-> env .getElementUtils (.getDocComment e) string/trim)
+    {:doc (some-> env .getElementUtils (.getDocComment e) str/trim)
      :doc-first-sentence-fragments (-> first-sentence coalesce cleanup-whitespace)
      :doc-fragments (-> full-body coalesce cleanup-whitespace)
      :doc-block-tags-fragments (-> block-tags coalesce cleanup-whitespace)}))
@@ -382,12 +382,12 @@
                                       (= kind TypeKind/TYPEVAR)
                                       (upper-bound type))
                                 str
-                                (string/replace #"<.*>" "") ;; Remove generics
+                                (str/replace #"<.*>" "") ;; Remove generics
                                 symbol)]
                (some-> (or best
                            (type->sym element))
                        str
-                       (string/replace "$" ".")
+                       (str/replace "$" ".")
                        symbol)))
            parameters)
      :argnames (mapv #(-> ^VariableElement % .getSimpleName str symbol) (.getParameters m))}))

--- a/src/orchard/java/source_files.clj
+++ b/src/orchard/java/source_files.clj
@@ -4,7 +4,7 @@
   {:author "Oleksandr Yakushev"
    :added "0.29"}
   (:require [clojure.java.io :as io]
-            [clojure.string :as string]
+            [clojure.string :as str]
             [orchard.misc :as misc])
   (:import (java.io File IOException)
            (java.net URL)))
@@ -44,14 +44,14 @@
   (let [module (when (>= misc/java-api-version 11)
                  ((requiring-resolve 'orchard.java.modules/module-name) klass))
         classfile-name (-> (.getName klass)
-                           (string/replace #"\$.*" "") ;; Drop internal class.
-                           (string/replace "." "/")
+                           (str/replace #"\$.*" "") ;; Drop internal class.
+                           (str/replace "." "/")
                            (str ".class"))]
     (cond->> classfile-name
       module (format "%s/%s" module))))
 
 (defn- classfile-path->sourcefile-path [classfile-name]
-  (string/replace classfile-name #"\.class$" ".java"))
+  (str/replace classfile-name #"\.class$" ".java"))
 
 (defn class->sourcefile-path
   "Infer a relative path to a source file of the given `klass`."
@@ -82,7 +82,7 @@
   ;; function that prefixes the URL with jar:. This is fine.
   (try
     (let [uri-str (str (.toURI archive))]
-      (when (string/starts-with? uri-str "file:")
+      (when (str/starts-with? uri-str "file:")
         (io/as-url (format "jar:%s!/%s" uri-str relative-filename))))
     ;; Exceptions might happen when creating an URL, protect users from them.
     (catch java.net.MalformedURLException _)))
@@ -169,7 +169,7 @@
                             (recur (cons name acc) parent)
                             acc)))]
       {:artifact artifact
-       :group    (string/join "." group-parts)
+       :group    (str/join "." group-parts)
        :version  version})))
 
 #_(infer-maven-coordinates-for-class clojure.lang.PersistentVector)
@@ -192,14 +192,14 @@
 #_(download-sources-using-invoke-tool (infer-maven-coordinates-for-class clojure.lang.PersistentVector))
 
 (defn- run-subprocess [args]
-  (println "[Orchard] Invoking subprocess:" (string/join " " args))
+  (println "[Orchard] Invoking subprocess:" (str/join " " args))
   (let [process (.start (ProcessBuilder. ^java.util.List args))]
     (.waitFor process)
     (let [out (slurp (.getInputStream process))
           err (slurp (.getErrorStream process))]
-      (when-not (string/blank? out)
+      (when-not (str/blank? out)
         (println out))
-      (when-not (string/blank? err)
+      (when-not (str/blank? err)
         (binding [*out* *err*] (println err))))
     (.exitValue process)))
 

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -3,7 +3,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [orchard.cljs.analysis :as cljs-ana]
    [orchard.clojuredocs :as cljdocs]
@@ -21,13 +21,13 @@
   (if (seq? description)
     (str "(" (->> description
                   (map #(with-out-str (pprint/pprint %)))
-                  string/join
-                  string/trim-newline)
+                  str/join
+                  str/trim-newline)
          ")")
     (->>  description
           pprint/pprint
           with-out-str
-          string/trim-newline)))
+          str/trim-newline)))
 
 (defn format-spec
   "Return sequence of [role spec-description] pairs."
@@ -52,7 +52,7 @@
   entry pointing to https://clojure.org/..."
   [info]
   (if-let [url (cond
-                 (not (string/blank? (:url info)))
+                 (not (str/blank? (:url info)))
                  (str "https://clojure.org/" (:url info))
 
                  (:special-form info)
@@ -128,10 +128,10 @@
   - some.ns$eval1234$closing_over_fn__12345.invoke"
   [sym]
   (let [demunged (-> (Compiler/demunge (str sym))
-                     (string/replace #"--\d+" ""))
+                     (str/replace #"--\d+" ""))
         [_ wo-method] (re-matches #"(.+?)(?:\.(?:invoke|invokeStatic|doInvoke))?"
                                   demunged)
-        [ns-str name-str] (->> (string/split wo-method #"/")
+        [ns-str name-str] (->> (str/split wo-method #"/")
                                (remove #(re-matches #"eval\d+" %)))
         ns (some-> ns-str symbol find-ns)
         resolved (when (and ns name-str)
@@ -297,10 +297,10 @@
        "(not documented)"))
   ([n v]
    (->> (-> (var-doc v)
-            (string/replace #"\s+" " ") ; normalize whitespace
-            (string/split #"(?<=\.) ")) ; split sentences
+            (str/replace #"\s+" " ") ; normalize whitespace
+            (str/split #"(?<=\.) ")) ; split sentences
         (take n)
-        (string/join " "))))
+        (str/join " "))))
 
 (defn var-code
   "Find the source of the var `v`.

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [update-keys update-vals])
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.util.io :as util.io])
   (:import
    (java.util.concurrent.locks ReentrantLock)))
@@ -105,7 +105,7 @@
   "Parse a Java version string according to JEP 223 and return the appropriate
   version."
   [java-ver]
-  (try (let [[major minor _] (string/split java-ver #"\.")
+  (try (let [[major minor _] (str/split java-ver #"\.")
              major (Integer/parseInt major)]
          (if (> major 1)
            major
@@ -129,7 +129,7 @@
   [sym]
   (some-> sym
           str
-          (string/replace #"\$macros" "")
+          (str/replace #"\$macros" "")
           symbol))
 
 (defn ns-obj?

--- a/src/orchard/namespace.clj
+++ b/src/orchard/namespace.clj
@@ -7,7 +7,7 @@
    :added "0.5"}
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.java.classpath :as cp]
    [orchard.misc :as misc])
   (:import
@@ -66,8 +66,8 @@
   according to the canonical naming convention, if present on the classpath."
   ^URL [ns]
   (let [path (-> (str ns)
-                 (string/replace "-" "_")
-                 (string/replace "." "/"))]
+                 (str/replace "-" "_")
+                 (str/replace "." "/"))]
     (or (io/resource (str path ".clj"))
         (io/resource (str path ".cljc"))
         (io/resource (str path ".cljs")))))
@@ -89,7 +89,7 @@
 (defn in-project?
   "Whether the URL is in the current project's directory."
   [url]
-  (let [path (if (misc/os-windows?) (comp string/lower-case str) str)]
+  (let [path (if (misc/os-windows?) (comp str/lower-case str) str)]
     (.startsWith ^String (path url) (path project-root))))
 
 (defn inlined-dependency?

--- a/src/orchard/spec.clj
+++ b/src/orchard/spec.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.pprint :as pp]
    [clojure.spec.alpha :as spec1]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [orchard.misc :as misc]))
 
@@ -135,7 +135,7 @@
   "Given a string like \"clojure.core/let\" or \":user/email\" returns
   the associated spec in the registry, if there is one."
   [s]
-  (let [[spec-ns spec-kw] (string/split s #"/")]
+  (let [[spec-ns spec-kw] (str/split s #"/")]
     (if (.startsWith ^String spec-ns ":")
       (get-spec (keyword (subs spec-ns 1) spec-kw))
       (get-spec (symbol s)))))

--- a/src/orchard/trace.clj
+++ b/src/orchard/trace.clj
@@ -1,7 +1,7 @@
 (ns orchard.trace
   "Faster and prettier reimplementation of `clojure.tools.trace` with unnecessary
   parts removed. Used for tracing function invocations and their results."
-  (:require [clojure.string :as string]
+  (:require [clojure.string :as str]
             [orchard.print :as print]))
 
 ;;;; Internals
@@ -35,7 +35,7 @@
 (def ^:private ^:dynamic *depth* 0)
 
 (defn- trace-indent []
-  (string/join (repeat *depth* "│ ")))
+  (str/join (repeat *depth* "│ ")))
 
 (defmacro ^:private limit-printing [& body]
   ;; Good defaults for orchard.print.

--- a/src/orchard/util/os.clj
+++ b/src/orchard/util/os.clj
@@ -5,14 +5,14 @@
   {:author "Masashi Iizuka"
    :added "0.5"}
   (:require [clojure.java.io :as io]
-            [clojure.string :as string])
+            [clojure.string :as str])
   (:import (java.io BufferedReader)))
 
 (def os-name
-  (string/lower-case (System/getProperty "os.name")))
+  (str/lower-case (System/getProperty "os.name")))
 
 (def os-type
-  (condp #(string/includes? %2 %1) os-name
+  (condp #(str/includes? %2 %1) os-name
     "linux" ::linux
     "mac" ::mac
     "windows" ::windows
@@ -53,7 +53,7 @@
                           "\\\"@"]
                          (map #(str "[Dir]::GetKnownFolderPath(\\\"" %  "\\\")") guids)
                          ["}"])]
-    (run-commands (count guids) ["powershell.exe" "-Command" (string/join "\n" commands)])))
+    (run-commands (count guids) ["powershell.exe" "-Command" (str/join "\n" commands)])))
 
 (defn cache-dir
   "Returns the path to the user's cache directory.
@@ -65,9 +65,9 @@
   []
   (case os-type
     ::mac
-    (string/join file-separator [(System/getProperty "user.home")
-                                 "Library"
-                                 "Caches"])
+    (str/join file-separator [(System/getProperty "user.home")
+                              "Library"
+                              "Caches"])
 
     ::windows
     (-> ["F1B32785-6FBA-4FCF-9D55-7B8E7F157091"]
@@ -75,6 +75,6 @@
         first)
 
     (let [cache-home (System/getenv "XDG_CACHE_HOME")]
-      (if (string/blank? cache-home)
+      (if (str/blank? cache-home)
         (str (System/getProperty "user.home") file-separator ".cache")
         cache-home))))

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -5,7 +5,7 @@
   (:require
    [clojure.repl :as repl]
    [clojure.set :as set]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [orchard.query :as q]))
 
 (defn- var->fn [var-ref]
@@ -74,7 +74,7 @@
           ;; prefixes names of lambdas with the name of its surrounding function class
           deps (into #{}
                      (comp (filter (fn [[k _v]]
-                                     (clojure.string/includes? k f-class-name)))
+                                     (str/includes? k f-class-name)))
                            (map (fn [[_k value]]
                                   (.get ^java.lang.ref.Reference value)))
                            (mapcat fn-deps-class))
@@ -155,7 +155,7 @@
 
   ;; returns all classes in this ns, even repl eval'd
   (let [f-class-name "orchard.xref" #_(-> orchard.xref/fn-deps .getClass .getName)
-        classes (into #{} (comp (filter (fn [[k _v]] (clojure.string/includes? k f-class-name)))
+        classes (into #{} (comp (filter (fn [[k _v]] (str/includes? k f-class-name)))
                                 (map (fn [[_k v]] (.get ^java.lang.ref.Reference v))))
                       class-cache)]
     classes)

--- a/test-resources/orchard/test_ns.cljc
+++ b/test-resources/orchard/test_ns.cljc
@@ -1,7 +1,7 @@
 (ns ^{:doc "A test namespace"} orchard.test-ns
   (:refer-clojure :exclude [replace unchecked-byte while])
   (:require
-   [clojure.string :as string :refer [replace]]
+   [clojure.string :as str :refer [replace]]
    [orchard.test-no-defs :as no-defs]
    [orchard.test-ns-dep :as test-dep :refer [foo-in-dep referred]])
   #?(:clj  (:require [orchard.test-macros :as test-macros :refer [my-add]])
@@ -37,7 +37,7 @@
   replace)
 
 (def indirect3
-  string/capitalize)
+  str/capitalize)
 
 (def indirect4
   clojure.string/includes?)

--- a/test-resources/orchard/test_ns_dep.cljc
+++ b/test-resources/orchard/test_ns_dep.cljc
@@ -1,6 +1,6 @@
 (ns ^{:doc "Dependency of test-ns namespace"} orchard.test-ns-dep
   (:require
-   [clojure.string :as string]))
+   [clojure.string :as str]))
 
 (defn foo-in-dep
   {:custom/meta 1}
@@ -9,4 +9,4 @@
 
 (def x ::dep-namespaced-keyword)
 
-(def referred string/trim)
+(def referred str/trim)

--- a/test/orchard/apropos_test.clj
+++ b/test/orchard/apropos_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.apropos-test
   (:require
    [clojure.repl :as repl]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [orchard.apropos :as sut :refer [find-symbols]]
    [orchard.meta :refer [var-name var-doc]]))
@@ -48,7 +48,7 @@
 
   (testing "Removal of namespaces with `exclude-regexps`"
     (is (not-any? #(some-> (namespace (symbol (:name %)))
-                           (string/includes? "orchard"))
+                           (str/includes? "orchard"))
                   (find-symbols {:var-query
                                  {:ns-query
                                   {:exclude-regexps
@@ -59,7 +59,7 @@
    (apropos-first v nil))
   ([v search-ns]
    (->> (find-symbols
-         (cond-> {:var-query {:search (re-pattern (string/escape v {\* "\\*"}))}}
+         (cond-> {:var-query {:search (re-pattern (str/escape v {\* "\\*"}))}}
            search-ns
            (assoc-in [:var-query :ns-query :exactly] [search-ns])))
         (filter #(= (:name %) (if search-ns (format "%s/%s" search-ns v) v)))

--- a/test/orchard/clojuredocs_test.clj
+++ b/test/orchard/clojuredocs_test.clj
@@ -13,7 +13,7 @@
   (-> (Instant/now) .getEpochSecond (* 1000)))
 
 (defn- create-dummy-cache-file [& [timestamp]]
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (.. cache-file
         getParentFile
         mkdirs)
@@ -22,7 +22,7 @@
       (cond-> timestamp (.setLastModified timestamp)))))
 
 (defn- clojuredocs-test-fixture [f]
-  (with-redefs [docs/cache-file-name "target/clojuredocs/export.edn"]
+  (with-redefs [docs/cache-file (io/file "target/clojuredocs/export.edn")]
     (docs/clean-cache!)
     (f)
     (docs/clean-cache!)))
@@ -30,7 +30,7 @@
 (use-fixtures :each clojuredocs-test-fixture)
 
 (deftest load-docs-if-not-loaded!-test
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (testing "bundled"
       (is (not (.exists cache-file)))
       (is (empty? @docs/cache))
@@ -66,7 +66,7 @@
       (docs/clean-cache!))))
 
 (deftest update-cache!-no-cache-file-test
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (testing "accessible to remote export.edn"
       (is (not (.exists cache-file)))
       (is (empty? @docs/cache))
@@ -86,7 +86,7 @@
       (is (empty? @docs/cache)))))
 
 (deftest update-cache!-non-existing-url-test
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (is (not (.exists cache-file)))
     (is (empty? @docs/cache))
     (is (thrown? Exception (docs/update-cache! "file:/not/existing/file.edn")))
@@ -94,7 +94,7 @@
     (is (empty? @docs/cache))))
 
 (deftest update-cache!-existing-cache-file-test
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (testing "no cached documentation"
       (create-dummy-cache-file now)
       (reset! docs/cache {})
@@ -119,7 +119,7 @@
 (deftest clean-cache!-test
   (create-dummy-cache-file)
   (reset! docs/cache {:dummy "not-empty-dummy-data"})
-  (let [cache-file (io/file docs/cache-file-name)]
+  (let [cache-file docs/cache-file]
     (is (.exists cache-file))
     (is (seq @docs/cache))
     (docs/clean-cache!)

--- a/test/orchard/info_test.clj
+++ b/test/orchard/info_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
-   [clojure.string :as string :refer [replace-first]]
+   [clojure.string :as str :refer [replace-first]]
    [clojure.test :refer [are deftest is testing use-fixtures]]
    [orchard.info :as info]
    [orchard.misc :as misc]
@@ -11,7 +11,7 @@
 
 (def cljs-available?
   (let [sym 'orchard.cljs.test-env
-        fname (-> sym str (string/replace "." "/") (string/replace "-" "_") (str ".cljc"))]
+        fname (-> sym str (str/replace "." "/") (str/replace "-" "_") (str ".cljc"))]
     (assert (some-> fname io/resource io/as-file .exists)
             (format "The %s file can be required to begin with" fname))
     (try
@@ -49,7 +49,7 @@
                    :tag function
                    :arglists nil}
                  (select-keys i [:ns :name :record :type :tag :arglists])))
-          (is (string/includes? (:file i) "test_ns"))))))
+          (is (str/includes? (:file i) "test_ns"))))))
 
   (testing "- :clj"
     (let [i (info/info 'orchard.test-ns 'TestType)]
@@ -73,7 +73,7 @@
                    :tag function
                    :arglists nil}
                  (select-keys i [:ns :name :record :type :tag :arglists])))
-          (is (string/includes? (:file i) "test_ns")))))
+          (is (str/includes? (:file i) "test_ns")))))
 
     (testing "- :clj"
       (let [i (info/info 'orchard.test-ns 'TestRecord)]
@@ -133,11 +133,11 @@
         (testing "- :cljs"
           (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:ns :name :arglists])))
-            (is (string/includes? (:file i) "test_ns_dep")))))
+            (is (str/includes? (:file i) "test_ns_dep")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :arglists])))
-          (is (string/includes? (:file i) "test_ns_dep")))
+          (is (str/includes? (:file i) "test_ns_dep")))
         (testing "`:var-meta-allowlist`"
           (is (= {:ns 'orchard.test-ns-dep
                   :custom/meta 1
@@ -242,7 +242,7 @@
                  :ns orchard.test-ns
                  :name issue-28}
                (select-keys i [:arglists :line :column :ns :name])))
-        (is (string/includes? (:file i) "orchard/test_ns"))))))
+        (is (str/includes? (:file i) "orchard/test_ns"))))))
 
 (deftest info-ns-as-sym-test
   (testing "Only namespace as qualified symbol"
@@ -255,11 +255,11 @@
         (testing "- :cljs"
           (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:line :doc :name :ns])))
-            (is (string/includes? (:file i) "orchard/test_ns")))))
+            (is (str/includes? (:file i) "orchard/test_ns")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
-          (is (string/includes? (:file i) "orchard/test_ns"))))
+          (is (str/includes? (:file i) "orchard/test_ns"))))
 
       (when cljs-available?
         ;; is how the info middleware sends it
@@ -271,7 +271,7 @@
                      :name orchard.test-ns
                      :line 1}
                    (select-keys i [:line :name :ns])))
-            (is (string/includes? (:file i) "orchard/test_ns"))))))))
+            (is (str/includes? (:file i) "orchard/test_ns"))))))))
 
 (deftest info-ns-dependency-as-sym-test
   (testing "Namespace dependency"
@@ -284,11 +284,11 @@
         (testing "- :cljs"
           (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:line :doc :name :ns])))
-            (is (string/includes? (:file i) "orchard/test_ns_dep")))))
+            (is (str/includes? (:file i) "orchard/test_ns_dep")))))
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:line :doc :name :ns])))
-          (is (string/includes? (:file i) "orchard/test_ns_dep"))))
+          (is (str/includes? (:file i) "orchard/test_ns_dep"))))
 
       ;; is how the info middleware sends it
       (when cljs-available?
@@ -301,7 +301,7 @@
                      :doc "Dependency of test-ns namespace"
                      :line 1}
                    (select-keys i [:line :name :doc :ns])))
-            (is (string/includes? (:file i) "orchard/test_ns_dep"))))))))
+            (is (str/includes? (:file i) "orchard/test_ns_dep"))))))))
 
 (deftest info-cljs-core-namespace-test
   (testing "Namespace itself but cljs.core"
@@ -323,12 +323,12 @@
         (testing "- :cljs"
           (let [i (info/info* (merge @*cljs-params* params))]
             (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
-            (is (string/includes? (:file i) "orchard/test_ns_dep")))))
+            (is (str/includes? (:file i) "orchard/test_ns_dep")))))
 
       (testing "- :clj"
         (let [i (info/info* params)]
           (is (= expected (select-keys i [:ns :name :doc :arglists :line])))
-          (is (string/includes? (:file i) "orchard/test_ns_dep")))))))
+          (is (str/includes? (:file i) "orchard/test_ns_dep")))))))
 
 (deftest info-namespace-macro-test
   (testing "Macro namespace"
@@ -613,13 +613,13 @@
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity()")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity()"]
-        (is (string/includes? url exp-suffix))))
+        (is (str/includes? url exp-suffix))))
 
     (testing "Javadoc 1.8 format"
       (let [reply      (info/javadoc-info "java/lang/StringBuilder.html#capacity--")
             url        (:javadoc reply)
             exp-suffix "/docs/api/java/lang/StringBuilder.html#capacity--"]
-        (is (string/includes? url exp-suffix)))))
+        (is (str/includes? url exp-suffix)))))
 
   (testing "Get general URL for a clojure javadoc"
     (let [reply    (info/javadoc-info "clojure/java/io.clj")
@@ -739,7 +739,7 @@
                                          info/info*
                                          (select-keys [:arglists :doc])
                                          (update :doc (fn [s]
-                                                        (some-> s string/split-lines first))))))
+                                                        (some-> s str/split-lines first))))))
                               true)
         'indirect1 '{:arglists ([] [a b c]), :doc "Docstring"}
         'indirect2 '{:arglists ([s match replacement]),

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1,6 +1,6 @@
 (ns orchard.inspect-test
   (:require
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [clojure.walk :as walk]
    [matcher-combinators.matchers :as matchers]
@@ -13,8 +13,8 @@
 
 (defn- demunge-str [s]
   (-> s
-      (string/replace #"(?i)\$([a-z-]+)__([0-9]+)(@[a-f0-9]+)?" "\\$$1")
-      (string/replace #"(?i)(fn|eval)--([0-9]+)" "$1")))
+      (str/replace #"(?i)\$([a-z-]+)__([0-9]+)(@[a-f0-9]+)?" "\\$$1")
+      (str/replace #"(?i)(fn|eval)--([0-9]+)" "$1")))
 
 (defn- demunge
   ([rendered]

--- a/test/orchard/java/classpath_test.clj
+++ b/test/orchard/java/classpath_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.set :as set]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [matcher-combinators.matchers :as m]
    [orchard.java]
@@ -20,7 +20,7 @@
   (let [s (if (instance? URL x)
             (.getPath ^URL x)
             x)]
-    (string/replace s #"/$" "")))
+    (str/replace s #"/$" "")))
 
 (deftest classpath-test
   (testing "Classpath"

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.java.parser-next-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [orchard.java :as java]
    [orchard.misc :as misc]
@@ -30,7 +30,7 @@
         (parse-java (io/resource "orchard/java/InvalidClass.java") nil)
         (assert false)
         (catch Exception e
-          (is (-> e ex-data :out (string/includes? "illegal start of expression"))))))))
+          (is (-> e ex-data :out (str/includes? "illegal start of expression"))))))))
 
 (when jdk11+?
   (deftest source-info-test
@@ -120,12 +120,12 @@ returning "}
                                  ['java.util.Locale 'java.lang.String (symbol "java.lang.Object[]")]
                                  :doc-fragments])
                         (->> (map :content)))
-          s (string/join fragments)]
+          s (str/join fragments)]
       (is (seq fragments))
       (testing "Flattens links, since they can't be clicked from most Orchard clients"
         (testing s
-          (is (not (string/includes? s "<a")))
-          (is (not (string/includes? s "<a href"))))))))
+          (is (not (str/includes? s "<a")))
+          (is (not (str/includes? s "<a href"))))))))
 
 (when (and jdk11+? util/jdk-sources-present?)
   (deftest smoke-test

--- a/test/orchard/java/resource_test.clj
+++ b/test/orchard/java/resource_test.clj
@@ -1,6 +1,6 @@
 (ns orchard.java.resource-test
   (:require
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [matcher-combinators.matchers :as m]
    [orchard.java.resource :as resource]))
@@ -13,7 +13,7 @@
 (deftest project-resources-test
   (testing "get the correct resources for the orchard project"
     (let [test-export (some (fn [{:keys [relpath] :as res}]
-                              (when (string/ends-with? relpath "test_export.edn")
+                              (when (str/ends-with? relpath "test_export.edn")
                                 res))
                             (resource/project-resources))]
       (is (match? {:relpath "clojuredocs/test_export.edn"

--- a/test/orchard/java_test.clj
+++ b/test/orchard/java_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.java.javadoc :as javadoc]
    [clojure.set :as set]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [orchard.java :as sut :refer [cache class-info class-info* javadoc-url member-info resolve-class resolve-javadoc-path resolve-member resolve-symbol source-info]]
    [orchard.misc :as misc]
@@ -138,12 +138,12 @@
                   (is (re-find #"^\[" s))
                   (is (re-find #"\^.*\[" s)))
                 ;; Assert that the format doesn't include past bugs:
-                (is (not (string/includes? s "<")))
-                (is (not (string/includes? s "^Object java.lang.Object")))
-                (is (not (string/includes? s "^Object Object")))
-                (is (not (string/includes? s "^function.Function java.util.function.Function")))
-                (is (not (string/includes? s "^java.util.function.Function java.util.function.Function")))
-                (is (not (string/includes? s "java.lang")))))))))))
+                (is (not (str/includes? s "<")))
+                (is (not (str/includes? s "^Object java.lang.Object")))
+                (is (not (str/includes? s "^Object Object")))
+                (is (not (str/includes? s "^function.Function java.util.function.Function")))
+                (is (not (str/includes? s "^java.util.function.Function java.util.function.Function")))
+                (is (not (str/includes? s "java.lang")))))))))))
 
 (when (and jdk11+? util/jdk-sources-present?)
   (deftest class-info-test
@@ -212,7 +212,7 @@
         (testing "implemented on ancestor superclass"
           (is (not= 'java.lang.Object (:class m7)))
           (testing (-> m6 :doc pr-str)
-            (is (-> m6 :doc (string/starts-with? "Called by the garbage collector on an object when garbage collection"))
+            (is (-> m6 :doc (str/starts-with? "Called by the garbage collector on an object when garbage collection"))
                 "Contains doc that is clearly defined in Object (the superclass)")))
         (when jdk11+?
           (testing "Doc fragments"
@@ -507,7 +507,7 @@
             (is (= arities-from-source arities-from-reflector))
             (doseq [arity arities-from-source]
               (doseq [s arity
-                      :let [s (-> s str (string/replace "[]" ""))]]
+                      :let [s (-> s str (str/replace "[]" ""))]]
                 (when-not (#{"byte" "short" "int" "long" "float" "double" "char" "boolean" "void"}
                            s)
                   (is (try

--- a/test/orchard/namespace_test.clj
+++ b/test/orchard/namespace_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.namespace-test
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [orchard.misc :as misc]
    [orchard.namespace :as sut]))
@@ -61,7 +61,7 @@
                   '(ns orchard.namespace-test
                      (:require
                       [clojure.java.io :as io]
-                      [clojure.string :as string]
+                      [clojure.string :as str]
                       [clojure.test :refer [are deftest is testing]]
                       [orchard.misc :as misc]
                       [orchard.namespace :as sut]))])))
@@ -72,7 +72,7 @@
     (doseq [s corpus]
       (is (symbol? s))
       ;; Exclude classes that are JDK-dependent.
-      (when-not (some #(string/starts-with? (name s) %)
+      (when-not (some #(str/starts-with? (name s) %)
                       ["com.sun.tools.javadoc."
                        "com.sun.javadoc."
                        "jdk.javadoc.doclet."
@@ -95,8 +95,8 @@
   tests that follows"
   [url]
   (let [string (str url)
-        upper (string/upper-case string)
-        lower (string/lower-case string)]
+        upper (str/upper-case string)
+        lower (str/lower-case string)]
     (io/as-url
      (if (= string lower) upper lower))))
 

--- a/test/orchard/test/util.clj
+++ b/test/orchard/test/util.clj
@@ -1,5 +1,5 @@
 (ns orchard.test.util
-  (:require clojure.string
+  (:require [clojure.string :as str]
             [orchard.java.source-files :as src-files]))
 
 (def jdk-sources-present?
@@ -14,4 +14,4 @@
   "Like `with-out-str`, but replaces Windows' CR+LF with LF."
   [& body]
   `(let [s# (with-out-str ~@body)]
-     (clojure.string/replace s# "\r\n" "\n")))
+     (str/replace s# "\r\n" "\n")))

--- a/test/orchard/util/os_test.clj
+++ b/test/orchard/util/os_test.clj
@@ -1,6 +1,6 @@
 (ns orchard.util.os-test
   (:require
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :as test :refer [deftest is testing]]
    [orchard.util.os :as os]))
 
@@ -8,15 +8,15 @@
   (deftest cache-dir-test
     (testing "BSD"
       (with-redefs [os/os-type ::os/bsd]
-        (is (string/ends-with? (os/cache-dir) "/.cache"))))
+        (is (str/ends-with? (os/cache-dir) "/.cache"))))
 
     (testing "Linux"
       (with-redefs [os/os-type ::os/linux]
-        (is (string/ends-with? (os/cache-dir) "/.cache"))))
+        (is (str/ends-with? (os/cache-dir) "/.cache"))))
 
     (testing "Mac"
       (with-redefs [os/os-type ::os/mac]
-        (is (string/ends-with? (os/cache-dir) "/Library/Caches"))))))
+        (is (str/ends-with? (os/cache-dir) "/Library/Caches"))))))
 
 (when (= os/os-type ::os/windows)
   (deftest cache-dir-windows-test


### PR DESCRIPTION
I know this may look petty, but I lost count how many times I've typed `(str/`, pressed complete, figured that the namespace probably doesn't have clojure.string required yet, going to the ns form only to discover it's `string` in this project. I'm not a fan of useless churn, but this is seriously annoying. Let's agree that `str/` is an "industry standard" and forget about this.
