### PR TITLE
[stacktrace] Stop sending compile-like flag

### DIFF
--- a/src/orchard/stacktrace.clj
+++ b/src/orchard/stacktrace.clj
@@ -253,16 +253,6 @@
         (flag-duplicates)
         (flag-tooling))))
 
-(defn- compile-like-exception?
-  "'Compile-like' exceptions are those that happen at runtime (and therefore never
-  include a `:phase`) which however, represent code that cannot possibly work,
-  and thus are a compile-like exception (i.e. a linter could have caught them)."
-  [{:keys [phase type message]}]
-  (boolean
-   (and (nil? phase)
-        (= type 'java.lang.IllegalArgumentException)
-        (some->> message (re-find #"^No matching (field|method)")))))
-
 (defn- analyze-cause
   "Analyze the `cause-data` of an exception, in `Throwable->map` format."
   [cause-data print-fn]
@@ -272,7 +262,6 @@
         phase (-> cause-data :data :clojure.error/phase)
         m {:class (name (:type cause-data))
            :phase phase
-           :compile-like (str (compile-like-exception? cause-data))
            :message (:message cause-data)
            :stacktrace (analyze-stacktrace-data
                         (cond (seq (:trace cause-data)) (:trace cause-data)

--- a/test/orchard/stacktrace_test.clj
+++ b/test/orchard/stacktrace_test.clj
@@ -256,24 +256,7 @@
 
   (testing "Does not include `:phase` for vanilla runtime exceptions"
     (is (match? [{:phase nil}]
-                (catch-and-analyze (throw (ex-info "" {}))))))
-
-  (testing "`:compile-like`"
-    (testing "For non-existing fields"
-      (is (match? [{:compile-like "true"}]
-                  (catch-and-analyze (eval '(.-foo ""))))))
-    (testing "For non-existing methods"
-      (is (match? [{:compile-like "true"}]
-                  (catch-and-analyze (eval '(-> "" (.foo 1 2)))))))
-    (testing "For vanilla exceptions"
-      (is (match? [{:compile-like "false"}]
-                  (catch-and-analyze (throw (ex-info "." {}))))))
-    (testing "For vanilla `IllegalArgumentException`s"
-      (is (match? [{:compile-like "false"}]
-                  (catch-and-analyze (throw (IllegalArgumentException. "foo"))))))
-    (testing "For exceptions with a `:phase`"
-      (is (match? [{:compile-like "false"} {:compile-like "false"}]
-                  (catch-and-analyze (eval '(let [1]))))))))
+                (catch-and-analyze (throw (ex-info "" {})))))))
 
 (deftest tooling-frame-name?
   (are [frame-name] (true? (#'sut/tooling-frame-name? frame-name))


### PR DESCRIPTION
I found this confusing while I was redoing the the exception handling subsystem. This flag gives an impression that such exceptions (with "compile-like" being true) are handled differently by CIDER, e.g. they don't pop up cider-error buffer and only displayed inline with overlays. That's not true – this flag is not used anywhere in CIDER, cider-nrepl, or Calva. And I don't think it is a good idea to do that either – reflection errors are not compile-time errors and it's misleading to present them so.

To avoid the confusion, I propose to remove this unused flag. Changelog update does not feel necessary since `orchard.stacktrace` is still new.