### PR TITLE
[inspector] Inspectable exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#318](https://github.com/clojure-emacs/orchard/pull/318): **BREAKING:** Remove no longer used functions: `orchard.misc/lazy-seq?`, `orchard.misc/safe-count`, `orchard.misc/normalize-subclass`, `orchard.misc/remove-type-param`.
 * [#320](https://github.com/clojure-emacs/orchard/pull/320): Info: recognize printed Java classes/methods and munged Clojure functions in stacktrace outputs.
 * [#322](https://github.com/clojure-emacs/orchard/pull/322): Stacktrace: bring back `orchard.stacktrace` for stacktrace analysis (copied from `haystack.analyzer` and improved).
+* [#324](https://github.com/clojure-emacs/orchard/pull/324): Add dedicated renderers for exceptions to `orchard.print` and `orchard.inspect`.
 
 ## 0.30.1 (2025-02-24)
 

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -163,8 +163,20 @@
 (defmethod print TaggedLiteral [x w]
   (print-method x w))
 
-(defmethod print Throwable [x w]
-  (print-method x w))
+(defmethod print Throwable [^Throwable x, ^TruncatingStringWriter w]
+  (.write w "#Error[")
+  (.write w (str (.getName (class x)) " "))
+  (loop [cause x, msg nil]
+    (if cause
+      (recur (.getCause cause) (str msg (when msg ": ") (.getMessage cause)))
+      (print msg w)))
+  (when-let [data (not-empty (ex-data x))]
+    (.write w " ")
+    (print data w))
+  (when-let [first-frame (first (.getStackTrace x))]
+    (.write w " ")
+    (print (str first-frame) w))
+  (.write w "]"))
 
 (defmethod print :default [^Object x, ^TruncatingStringWriter w]
   (.write w (.toString x)))

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -87,6 +87,11 @@
     "#Delay[<pending>]" (delay 1)
     "#Delay[1]" (doto (delay 1) deref)
     "#Delay[<failed>]" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
+    #"#Error\[clojure.lang.ExceptionInfo \"Boom\" \"orchard.print_test.+\"\]" (ex-info "Boom" {})
+    #"#Error\[clojure.lang.ExceptionInfo \"Boom\" \{:a 1\} \"orchard.print_test.+\"\]" (ex-info "Boom" {:a 1})
+    #"#Error\[java.lang.RuntimeException \"Runtime!\" \"orchard.print_test.+\"\]" (RuntimeException. "Runtime!")
+    #"#Error\[java.lang.RuntimeException \"Outer: Inner\" \"orchard.print_test.+\"\]" (RuntimeException. "Outer"
+                                                                                                         (RuntimeException. "Inner"))
     "#function[clojure.core/str]" str))
 
 (deftest print-writer-limits


### PR DESCRIPTION
Two things here.

### 1
I've replaced the default printer for throwables that is used by the inspector (when a value is rendered inline) and the debugger to a custom one. The default printer used `print-method` implementation for throwables which in turn uses `print-throwable` – the default data-like representation of throwables. See below:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/af912b14-bd89-47e7-8a00-3344425d94f8" />
<img width="923" alt="image" src="https://github.com/user-attachments/assets/9fdf5538-c707-4229-82b3-2004675fd088" />

The multi-line pseudo pretty-printing that `print-throwable` performs here really doesn't vibe with the inline display nature of inspector and debugger. In the inspector, the multi-line value makes it harder to find the next value in the map/list. in the debugger, you might argue that seeing those few stackframes (before they are truncated) is useful, but it looks messy nonetheless. So, here's the new inlined rendering for throwables:

<img width="1185" alt="image" src="https://github.com/user-attachments/assets/10f76657-424b-44d7-a1d7-e1abf9b30c06" />
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/90a96b5b-4c51-4cb9-af17-514ce496a34b" />

It still spans multiple lines if there is data in the exception (like in this CompilerException example), but without data it is much more compact.

### 2

New dedicated inspector rendering for throwables. Looks like this:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/c443fab9-3a4b-4690-b94e-c0335c3d28ac" />

Most stuff that looks like data is clickable/navigable. I haven't settled on the final view. Maybe, it makes sense to reverse the order of causes, like `*cider-error*` does it. Anyway, it is a new thing, and it can be changed later, no big deal.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)