### PR TITLE
[stacktrace] Add ex-str-formatted message to analyzed causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#325](https://github.com/clojure-emacs/orchard/pull/325): Add `ex-str`-formatted message to analyzed causes.
+
 ## 0.31.0 (2025-03-14)
 
 * [#317](https://github.com/clojure-emacs/orchard/pull/317): **BREAKING:** Remove deprecated functions:

--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -101,6 +101,11 @@
               (last xs)))]
     (apply f (filter identity xs))))
 
+(defn assoc-some
+  "Assoc key-value to the map `m` if `v` is non-nil."
+  [m k v]
+  (if (nil? v) m (assoc m k v)))
+
 (defn parse-java-version
   "Parse a Java version string according to JEP 223 and return the appropriate
   version."

--- a/src/orchard/stacktrace.clj
+++ b/src/orchard/stacktrace.clj
@@ -12,7 +12,7 @@
    [clojure.string :as str]
    [orchard.info :as info]
    [orchard.java.resource :as resource]
-   [orchard.misc :refer [assoc-some]])
+   [orchard.misc :as misc :refer [assoc-some]])
   (:import
    (java.io StringWriter)
    (java.net URL)
@@ -252,7 +252,7 @@
   "Return the stacktrace as a sequence of maps, each describing a stack frame."
   [trace]
   (when (seq trace)
-    (-> (pmap analyze-frame trace)
+    (-> (misc/pmap analyze-frame trace)
         (flag-duplicates)
         (flag-tooling))))
 

--- a/test/orchard/stacktrace_test.clj
+++ b/test/orchard/stacktrace_test.clj
@@ -1,6 +1,7 @@
 (ns orchard.stacktrace-test
   (:require
    [clojure.spec.alpha :as s]
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [matcher-combinators.matchers :as matchers]
    [orchard.stacktrace :as sut]))
@@ -179,6 +180,11 @@
               :clojure.error/phase :macroexpand
               :clojure.error/symbol 'clojure.core/let}
              (:location cause))))))
+
+(deftest ex-triage-test
+  (testing "compilation errors that can be triaged contain :triage message"
+    (is (= "[a] - failed: even-number-of-forms? in: [0] at: [:bindings] spec: :clojure.core.specs.alpha/bindings"
+           (str/trim (:triage (first (catch-and-analyze (eval '(let [a]))))))))))
 
 (deftest test-analyze-throwable
   (testing "shape of analyzed throwable"


### PR DESCRIPTION
To accommodate for changes I'm making in https://github.com/clojure-emacs/cider/pull/3789, we need the triaged compiler exception string to be available within the analyzed exception itself, not just the stderr output. The solution is clunky, and I would do it differently if we didn't already have this cruft of sending one message per cause, but it's cheaper from the compatibility perspective to add it here.

The second commit is a minor addition. The new pmap in orchard.misc is more efficient and doesn't yank the Futures pool.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md)