### PR TITLE
[inspect] Introduce analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#328](https://github.com/clojure-emacs/orchard/pull/328): Inspector: display identity hashcode for Java objects.
+* [#329](https://github.com/clojure-emacs/orchard/pull/329): Inspector: add analytics.
 
 ## 0.31.1 (2025-03-19)
 

--- a/src/orchard/inspect/analytics.clj
+++ b/src/orchard/inspect/analytics.clj
@@ -1,0 +1,177 @@
+(ns orchard.inspect.analytics
+  "Submodule of Orchard Inspector for getting quick insights about the inspected
+  data. A \"Metabase\" for Orchard/CIDER Inspector."
+  (:refer-clojure :exclude [bounded-count])
+  (:require
+   [clojure.string :as str])
+  (:import
+   (java.util List Map)))
+
+;; To keep execution time under control, only calculate analytics for the first
+;; 100k elements.
+(def ^:dynamic *size-cutoff* 100000)
+
+(defn- non-nil-hmap [& keyvals]
+  (->> (partition 2 keyvals)
+       (keep #(when (some? (second %)) (vec %)))
+       (into {})))
+
+(defn- *frequencies [coll]
+  (->> coll
+       (eduction (take *size-cutoff*))
+       frequencies
+       (sort-by second >)
+       (apply concat)
+       (apply array-map)))
+
+(definline ^:private inc-if [val condition]
+  `(cond-> ~val ~condition inc))
+
+(defn- count-pred [pred limit ^Iterable coll]
+  (let [it (.iterator ^Iterable coll)]
+    (loop [i 0, n 0]
+      (if (and (< i limit) (.hasNext it))
+        (let [x (.next it)]
+          (recur (inc i) (inc-if n (pred x))))
+        [n (/ n i)]))))
+
+(defn- bounded-count [limit coll]
+  (first (count-pred (constantly true) limit coll)))
+
+(defn- list-of-tuples?
+  "Heuristic-based: an sequence is a list of tuples if at least 20 items of the
+  first 100, or at least 30% of it, are maps with < 20 values."
+  [coll]
+  (and (instance? List coll)
+       (let [[n ratio] (count-pred #(and (vector? %) (< (count %) 20)) 100 coll)]
+         (or (> n 20) (> ratio 0.3)))))
+
+(defn- list-of-records?
+  "Heuristic-based: a sequence is a list of 'records' if at least 20 items of the
+  first 100, or at least 30% of it, are vectors with size < 20."
+  [coll]
+  (and (instance? List coll)
+       (let [[n ratio] (count-pred #(and (map? %) (< (count %) 20)) 100 coll)]
+         (or (> n 20) (> ratio 0.3)))))
+
+(defn- numbers-stats [^Iterable coll]
+  (let [it (.iterator coll)]
+    (loop [i 0, hi nil, lo nil, zeros 0, n 0, sum 0]
+      (if (and (< i *size-cutoff*) (.hasNext it))
+        (let [x (.next it)]
+          (if (number? x)
+            (recur (inc i)
+                   (if (nil? hi) x (max hi x))
+                   (if (nil? lo) x (min lo x))
+                   (inc-if zeros (zero? x))
+                   (inc n)
+                   (+ sum x))
+            (recur (inc i) hi lo zeros n sum)))
+        (when (> n 0)
+          {:n n, :zeros zeros, :max hi, :min lo, :mean (float (/ sum n))})))))
+
+(def ^:private ^java.nio.charset.CharsetEncoder ascii-enc
+  (.newEncoder (java.nio.charset.Charset/forName "US-ASCII")))
+
+(defn- strings-stats [^Iterable coll]
+  (let [it (.iterator coll)]
+    (loop [i 0, n 0, blank 0, ascii 0, hi nil, lo nil, sum 0]
+      (if (and (< i *size-cutoff*) (.hasNext it))
+        (let [x (.next it)]
+          (if (string? x)
+            (let [len (count x)]
+              (recur (inc i)
+                     (inc n)
+                     (inc-if blank (str/blank? x))
+                     (inc-if ascii (.canEncode ascii-enc ^String x))
+                     (if (nil? hi) len (max hi len))
+                     (if (nil? lo) len (min lo len))
+                     (+ sum len)))
+            (recur (inc i) n blank ascii hi lo sum)))
+        (when (> n 0)
+          {:n n, :blank blank, :ascii ascii, :max-len hi, :min-len lo, :avg-len (float (/ sum n))})))))
+
+(defn- colls-stats [^Iterable coll]
+  (let [it (.iterator coll)]
+    (loop [i 0, n 0, empty 0, hi nil, lo nil, sum 0]
+      (if (and (< i *size-cutoff*) (.hasNext it))
+        (let [x (.next it)]
+          (if (instance? java.util.Collection x)
+            (let [size (count x)]
+              (recur (inc i)
+                     (inc n)
+                     (inc-if empty (empty? x))
+                     (if (nil? hi) size (max hi size))
+                     (if (nil? lo) size (min lo size))
+                     (+ sum size)))
+            (recur (inc i) n empty hi lo sum)))
+        (when (> n 0)
+          {:n n, :empty empty, :max-size hi, :min-size lo, :avg-size (float (/ sum n))})))))
+
+(defn- basic-list-stats [coll show-count?]
+  (when (instance? List coll)
+    (let [cnt (bounded-count *size-cutoff* coll)]
+      (non-nil-hmap
+       :cutoff? (when (and show-count? (>= cnt *size-cutoff*)) true)
+       :count (when show-count? cnt)
+       :types (*frequencies (map type coll))
+       :frequencies (*frequencies coll)
+       :numbers (numbers-stats coll)
+       :strings (strings-stats coll)
+       :collections (colls-stats coll)))))
+
+(defn- keyvals-stats [coll]
+  (when (instance? Map coll)
+    (let [cnt (bounded-count *size-cutoff* coll)]
+      (when (> cnt 10)
+        (non-nil-hmap
+         :cutoff? (when (>= cnt *size-cutoff*) true)
+         :count cnt
+         :keys (basic-list-stats (vec (keys coll)) false)
+         :values (basic-list-stats (vec (vals coll)) false))))))
+
+(defn- tuples-stats [^Iterable coll]
+  (when (list-of-tuples? coll)
+    (let [cnt (bounded-count *size-cutoff* coll)
+          all (into [] (take *size-cutoff*) coll)
+          longest (min 20 (apply max (map count all)))]
+      (non-nil-hmap
+       :cutoff? (when (>= cnt *size-cutoff*) true)
+       :count cnt
+       :tuples (mapv (fn [i]
+                       (basic-list-stats
+                        (mapv #(when (vector? %) (nth % i nil)) all)
+                        false))
+                     (range longest))))))
+
+(defn- records-stats [^Iterable coll]
+  (when (list-of-records? coll)
+    (let [cnt (bounded-count *size-cutoff* coll)
+          ks (set (mapcat keys coll))]
+      (non-nil-hmap
+       :cutoff? (when (>= cnt *size-cutoff*) true)
+       :count cnt
+       :by-key (into {}
+                     (for [k ks]
+                       (let [kcoll (mapv #(get % k) coll)]
+                         [k (basic-list-stats kcoll false)])))))))
+
+(defn analytics
+  "Return various analytical data about `object`. Supports the following data
+  types with different amount of insights:
+  - lists of numbers
+  - lists of strings
+  - lists of tuples
+  - lists of 'records' (maps with same keys)
+  - lists of arbitrary collections
+  - arbitrary key-value maps"
+  [object]
+  (or (tuples-stats object)
+      (records-stats object)
+      (keyvals-stats object)
+      (basic-list-stats object true)))
+
+(defn can-analyze?
+  "Simple heuristic: we currently only analyze collections (but most of them)."
+  [object]
+  (instance? java.util.Collection object))

--- a/test/orchard/inspect/analytics_test.clj
+++ b/test/orchard/inspect/analytics_test.clj
@@ -1,0 +1,128 @@
+(ns orchard.inspect.analytics-test
+  (:require
+   [clojure.test :refer [deftest testing]]
+   [matcher-combinators.matchers :as mc]
+   [orchard.inspect.analytics :refer [analytics]]
+   [orchard.test.util :refer [is+]]))
+
+(defn- approx [val] (mc/within-delta 0.01 val))
+
+(deftest numbers-test
+  (is+ {:count 1000
+        :types {java.lang.Long 1000}
+        :frequencies map?
+        :numbers {:n 1000, :zeros 1, :max 999, :min 0, :mean 499.5}}
+       (analytics (range 1000)))
+
+  (is+ {:count 100
+        :types {java.lang.Integer 50, java.lang.Long 50}
+        :frequencies {0 50, 1 50}
+        :numbers {:n 100, :zeros 50, :max 1, :min 0, :mean 0.5}}
+       (analytics (concat (map int (repeat 50 0)) (repeat 50 1))))
+
+  (is+ {:count 6
+        :types {java.lang.Long 3, nil 3}
+        :frequencies {nil 3, 0 1, 1 1, 2 1}
+        :numbers {:n 3, :zeros 1, :max 2, :min 0, :mean 1.0}}
+       (analytics [0 nil 1 nil 2 nil])))
+
+(deftest strings-test
+  (is+ {:count 100
+        :types {java.lang.String 100}
+        :frequencies map?
+        :strings {:n 100, :blank 0, :ascii 100, :max-len 2, :min-len 1, :avg-len (approx 1.9)}}
+       (analytics (map str (range 100))))
+
+  (is+ {:count 6,
+        :types {java.lang.String 5, nil 1}
+        :frequencies map?
+        :strings {:n 5, :blank 3, :ascii 4, :max-len 6, :min-len 0, :avg-len (approx 2.8)}}
+       (analytics [nil "" " " "  " "hello" "привіт"])))
+
+(deftest colls-stats
+  (is+ {:count 20
+        :types {clojure.lang.LongRange 19, clojure.lang.PersistentList$EmptyList 1}
+        :frequencies map?
+        :collections {:n 20, :empty 1, :max-size 19, :min-size 0, :avg-size 9.5}}
+       (analytics (map range (range 20)))))
+
+(deftest heterogeneous-list-stats
+  (is+ {:count 90,
+        :types {java.lang.Long 20, java.lang.Integer 20, java.lang.String 20, clojure.lang.PersistentVector 20, nil 10}
+        :frequencies {nil 10, [42] 10, [] 10 ;; and others
+                      }
+        :numbers {:n 40, :zeros 2, :max 19, :min 0, :mean 9.5}
+        :strings {:n 20, :blank 0, :ascii 20, :max-len 2, :min-len 1, :avg-len 1.5}
+        :collections {:n 20, :empty 10, :max-size 1, :min-size 0, :avg-size 0.5}}
+       (analytics (shuffle (concat (range 20)
+                                   (map int (range 20))
+                                   (map str (range 20))
+                                   (repeat 10 [])
+                                   (repeat 10 [42])
+                                   (repeat 10 nil))))))
+
+(deftest keyvals-test
+  (is+ {:count 100
+        :keys {:types {java.lang.Long 100}
+               :frequencies map?
+               :numbers {:n 100, :zeros 1, :max 99, :min 0, :mean 49.5}}
+        :values {:types {java.lang.String 100}
+                 :frequencies map?
+                 :strings {:n 100, :blank 0, :ascii 100, :max-len 2, :min-len 1, :avg-len (approx 1.9)}}}
+       (analytics (zipmap (range 100) (map str (range 100))))))
+
+(deftest list-of-tuples-test
+  (is+ {:count 100
+        :tuples [{:types {java.lang.Long 100}
+                  :numbers {:n 100, :zeros 1, :max 99, :min 0, :mean 49.5}}
+                 {:types {java.lang.String 100}
+                  :strings {:n 100, :blank 0, :ascii 100, :max-len 2, :min-len 1, :avg-len (approx 1.9)}}
+                 {:types {nil 50, java.lang.Long 50}
+                  :frequencies {nil 50, 42 50}
+                  :numbers {:n 50, :zeros 0, :max 42, :min 42, :mean 42.0}}]}
+       (analytics (map #(cond-> [% (str %)]
+                          (odd? %) (conj 42))
+                       (range 100)))))
+
+(deftest list-of-records-test
+  (testing "analytics on a list of records analyzes values for each unique key individually"
+    (is+ {:count 100
+          :by-key {:s {:types {java.lang.String 100}
+                       :frequencies map?
+                       :strings {:n 100, :blank 0, :ascii 50, :max-len 7, :min-len 5, :avg-len (approx 6.4)}}
+                   :kw {:types {nil 66, clojure.lang.Keyword 34}, :frequencies {nil 66, :occasional 34}}
+                   :i {:types {java.lang.Long 100}
+                       :numbers {:n 100, :zeros 1, :max 99, :min 0, :mean 49.5}}}}
+         (analytics (map #(cond-> {:i %
+                                   :s (str "test" % (when (even? %) "ї"))}
+                            (zero? (mod % 3)) (assoc :kw :occasional))
+                         (range 100))))))
+
+(deftest cutoff-test
+  (testing "when the collection size is within cutoff, :cutoff? field is not returned"
+    (is+ {:cutoff? mc/absent} (analytics (range 100))))
+
+  (testing "when above cutoff, :cutoff? true is returned, and only #cutoff items are analyzed"
+    (is+ {:cutoff? true
+          :count 100
+          :numbers {:max 99}}
+         (binding [orchard.inspect.analytics/*size-cutoff* 100]
+           (analytics (range 200))))
+    (is+ {:cutoff? true
+          :count 100}
+         (binding [orchard.inspect.analytics/*size-cutoff* 100]
+           (analytics (repeat 101 "test"))))
+    (is+ {:cutoff? true
+          :count 100}
+         (binding [orchard.inspect.analytics/*size-cutoff* 100]
+           (analytics (repeat 100 {:foo 1 :bar 2}))))
+    (is+ {:cutoff? true
+          :count 100}
+         (binding [orchard.inspect.analytics/*size-cutoff* 100]
+           (analytics (repeat 100 [1 "test"]))))
+    (is+ {:cutoff? true
+          :count 100
+          :keys {:types {java.lang.Long 100}}
+          :values {:types {java.lang.Long 100}}}
+         (binding [orchard.inspect.analytics/*size-cutoff* 100]
+           (analytics (zipmap (range 200) (range 200)))))))


### PR DESCRIPTION
Now this is a feature I had on my mind for quite some time, and one I'm very excited about. The idea is to have all kinds of analytics that the inspector can automatically (on demand) compute when the user inspects a large collection of data. It happens very often to me that I inspect something big and can't really grasp some characteristics of that data just by looking at it visually at the inspector, and I start running all the things on it like `frequencies`, `(map type coll)`, etc. Having the inspector do it without leaving the inspector window is crazily convenient.

Bonus: we can present the analytics data **using the inspector itself**. I'm almost crying as I'm writing this. It is a thing of beauty; Father McCarthy smiles upon us from heaven.

Some screenshots how it would look like in the end:

<img width="612" alt="image" src="https://github.com/user-attachments/assets/4e71507a-73d1-47d5-bd99-33a156a320de" />

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/2995e214-ffaf-4e9b-9ab5-63a3dc3b1058" />

Things it can do so far:
- For any list: frequencies of values, frequencies of value types
- Basic numerical stats on lists with numbers (min, max, mean, number of zeros)
- Very basic string stats on lists with strings (number of blanks, min, max, avg length)
- Same but on lists of lists
- For keyvalues (maps k->v): separate list analysis of keys and of values
- For lists of tuples: separate list analysis of each "vertical slice" (treat all first values as list 1, all second values as list 2, etc.)
- For lists of "records" (maps of the same structure): separate list analysis on values under each key.

Extras:
- Configurable cutoff limit (100,000 by default). Only that many values from the head of the list will be analyzed.
- A hint about this feature that is displayed to the user until they trigger analytics for the first time. Will serve the discoverability function.

I have a dream that as people start using it, we together can come up with more ideas what to compute and make this feature even awesomer.

---

- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)