### PR TITLE
[inspect] Add :table view-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#328](https://github.com/clojure-emacs/orchard/pull/328): Inspector: display identity hashcode for Java objects.
 * [#329](https://github.com/clojure-emacs/orchard/pull/329): Inspector: add analytics.
+* [#331](https://github.com/clojure-emacs/orchard/pull/331): Inspector: add table view mode.
 
 ## 0.31.1 (2025-03-19)
 


### PR DESCRIPTION
Another big feature for the inspector that has been requested before and will make some people's lives better.

We already have the concept of a "view mode" that currently switches between :normal and :object (force-showing Java object fields instead of custom rendering).

A new view-mode called `:table` can also be cycled through using the same `v` keybinding. 

- Table view mode works for sequences of maps or tuples.
- Supports paging.
- All elements inside the table are clickable/navigable!
- There are some minor lackings, like path is not recorded if you navigate through the table, but it can be fixed later.

Here's how the end result looks:

<img width="463" alt="image" src="https://github.com/user-attachments/assets/60490ab4-3886-4070-92ce-3cd3080e19b5" />

<img width="486" alt="image" src="https://github.com/user-attachments/assets/16fbb0b5-b6a1-4d08-a7e8-410c0d79ccec" />

<img width="459" alt="image" src="https://github.com/user-attachments/assets/0d234080-f1ab-44e5-88d7-4fc0b4ddb579" />

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)