### PR TITLE
[inspect] Tune pretty-printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#314](https://github.com/clojure-emacs/orchard/pull/314): Print: add special printing rules for records and allow meta :type overrides.
+* [#336](https://github.com/clojure-emacs/orchard/pull/336): Inspector: tune pretty-printing mode.
 
 ## 0.34.0 (2025-04-18)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -973,12 +973,17 @@
       inspector)))
 
 (defn render-view-mode [inspector]
-  (let [view-mode (:view-mode inspector)]
-    (if (= view-mode :normal)
+  (let [{:keys [view-mode pretty-print]} inspector
+        view-mode-str (->> [(when-not (= view-mode :normal)
+                              (str view-mode))
+                            (when pretty-print ":pretty")]
+                           (remove nil?)
+                           (str/join " "))]
+    (if (str/blank? view-mode-str)
       inspector
       (-> (render-section-header inspector "View mode")
           (indent)
-          (render-indent (str view-mode))
+          (render-indent view-mode-str)
           (unindent)))))
 
 (defn inspect-render

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -378,7 +378,7 @@
   "Returns true of `s` is a long string, more than 20 character or
   containing newlines."
   [^String s]
-  (or (.contains s "\n") (> (count s) 20)))
+  (or (.contains s "\n") (> (count s) 50)))
 
 (defn- render-map-separator
   "Render the map separator according to `rendered-key`. If

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -770,7 +770,11 @@
                   (shorten-member-string (str obj) (.getDeclaringClass ^Method obj))
 
                   (instance? Field obj)
-                  (shorten-member-string (str obj) (.getDeclaringClass ^Field obj)))]
+                  (shorten-member-string (str obj) (.getDeclaringClass ^Field obj))
+
+                  ;; Using print-str and not pprint intentionally, so that the
+                  ;; `Value:` remains on a single line.
+                  :else (print/print-str obj))]
     (letfn [(render-fields [inspector section-name field-values]
               (if (seq field-values)
                 (-> inspector

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -208,9 +208,13 @@
   "Pretty print the object `x` with `orchard.pp/pprint` and return it as
   a string. The `:indentation` option is the number of spaces used for
   indentation."
-  [x & [{:keys [indentation]}]]
-  (let [writer (TruncatingStringWriter. *max-atom-length* *max-total-length*)
-        indentation-str (apply str (repeat (or indentation 0) " "))]
-    (try (pp/pprint writer x {:indentation indentation-str})
-         (catch TruncatingStringWriter$TotalLimitExceeded _))
-    (str/trimr (.toString writer))))
+  ([x]
+   (pprint-str x {}))
+  ([x options]
+   (let [{:keys [indentation] :or {indentation 0}} options
+         writer (TruncatingStringWriter. *max-atom-length* *max-total-length*)
+         indentation-str (apply str (repeat indentation " "))]
+     (try (pp/pprint writer x {:indentation indentation-str
+                               :max-width (+ indentation 80)})
+          (catch TruncatingStringWriter$TotalLimitExceeded _))
+     (str/trimr (.toString writer)))))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1590,9 +1590,10 @@
             [:value (str "[{:a 0, :bb \"000\", :ccc [[]]}\n"
                          "        {:a -1, :bb \"111\", :ccc [1]}\n"
                          "        {:a 2, :bb \"222\", :ccc [1 2]}]") 8]
-            [:newline]]
+            [:newline] [:newline]]
            (section "Contents" rendered))
-      (is (nil? (section "View mode" rendered))))))
+      (is+ ["--- View mode:" [:newline] "  :pretty"]
+           (section "View mode" rendered)))))
 
 (deftest pretty-print-map-in-object-view-test
   (testing "in :object view mode + :pretty, Value: is printed regularly"
@@ -1639,9 +1640,10 @@
                          "\"222\", :ccc (2 1)}\n       {:a -3, :bb \"333\", "
                          ":ccc (3 2 1)}\n       {:a -4, :bb \"444\", "
                          ":ccc (4 3 2 1)})}") 2]
-            [:newline]]
+            [:newline] [:newline]]
            (section "Contents" rendered))
-      (is (nil? (section "View mode" rendered))))))
+      (is+ ["--- View mode:" [:newline] "  :pretty"]
+           (section "View mode" rendered)))))
 
 (deftest pretty-print-map-as-key-test
   (testing "in :pretty view-mode maps that contain maps as a keys are pretty printed"
@@ -1677,9 +1679,10 @@
                          ":bb \"222\", :ccc [2 1]}\n    {:a -3, :bb "
                          "\"333\", :ccc [3 2 1]}\n    {:a -4, :bb "
                          "\"444\", :ccc [4 3 2 1]}]}") 2]
-            [:newline] [:newline]]
+            [:newline] [:newline] [:newline]]
            (section "Contents" rendered))
-      (is (nil? (section "View mode" rendered))))))
+      (is+ ["--- View mode:" [:newline] "  :pretty"]
+           (section "View mode" rendered)))))
 
 (deftest pretty-print-seq-of-map-as-key-test
   (testing "in :pretty view-mode maps that contain seq of maps as a keys are pretty printed"
@@ -1707,9 +1710,10 @@
                          "[{:a 0, :bb \"000\", :ccc [[]]}\n    {:a -1, "
                          ":bb \"111\", :ccc [1]}\n    {:a 2, :bb \"222\", "
                          ":ccc [1 2]}]}") 2]
-            [:newline] [:newline]]
+            [:newline] [:newline] [:newline]]
            (section "Contents" rendered))
-      (is (nil? (section "View mode" rendered))))))
+      (is+ ["--- View mode:" [:newline] "  :pretty"]
+           (section "View mode" rendered)))))
 
 (deftest tap-test
   (testing "tap-current-value"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1595,7 +1595,7 @@
       (is (nil? (section "View mode" rendered))))))
 
 (deftest pretty-print-map-in-object-view-test
-  (testing "in :pretty view-mode are pretty printed"
+  (testing "in :object view mode + :pretty, Value: is printed regularly"
     (let [rendered (-> {:a 0
                         :bb "000"
                         :ccc []
@@ -1607,16 +1607,8 @@
                        (set-pretty-print true)
                        render)]
       (is+ ["Value: "
-            [:value (str "{:a 0,\n"
-                         "        :bb \"000\",\n"
-                         "        :ccc [],\n"
-                         "        :d\n"
-                         "        [{:a 0, :bb \"000\", :ccc [[]]}\n"
-                         "         {:a -1, :bb \"111\", :ccc [1]}\n"
-                         "         {:a 2, :bb \"222\", :ccc [1 2]}]}") 1]]
-           (labeled-value "Value" rendered))
-      (is+ ["--- View mode:" [:newline] "  :object"]
-           (section "View mode" rendered)))))
+            [:value "{:a 0, :bb \"000\", :ccc [], :d [{:a 0, :bb \"000\", :ccc [[]]} {:a -1, :bb \"111\", :ccc [1]} {:a 2, :bb \"222\", :ccc [1 2]}]}" 1]]
+           (labeled-value "Value" rendered)))))
 
 (deftest pretty-print-seq-of-maps-test
   (testing "in :pretty view-mode maps seqs of maps are pretty printed"


### PR DESCRIPTION
I've started using the pretty inspector view and I'm willing to change a couple of things:

- Make the threshold for long key wrap larger. Let's start with 50, this should reduce spurious line-wraps.
- Allocate 80 characters of width to the printer regardless of indentation. Currently, if the map key is long, this squeezes the available space for the pretty-printed a lot, making it very thin and unreadable.
- Show `:pretty` in View mode section when it's enabled.
- Don't pretty print `Value:` in object mode (or in normal mode for unknown objects) to keep this a single line. 

What do you think, @r0man?

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)