### PR TITLE
[print] Make orchard.print more consistent with CIDER printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#314](https://github.com/clojure-emacs/orchard/pull/314): Print: add special printing rules for records and allow meta :type overrides.
 * [#336](https://github.com/clojure-emacs/orchard/pull/336): Inspector: tune pretty-printing mode.
+* [#337](https://github.com/clojure-emacs/orchard/pull/337): Print: make orchard.print consistent with CIDER printing.
 
 ## 0.34.0 (2025-04-18)
 

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -168,7 +168,7 @@
               [:newline]
               "  " [:value ":name" pos?] " = " [:value "any-var" pos?]
               [:newline]
-              "  " [:value ":ns" pos?] " = " [:value "orchard.inspect-test" pos?]
+              "  " [:value ":ns" pos?] " = " [:value "#namespace[orchard.inspect-test]" pos?]
               [:newline]
               [:newline]]
              (section "Meta Information" rendered)))
@@ -1147,7 +1147,7 @@
         (is+ ["--- Refer from:"
               [:newline]
               "  "
-              [:value "clojure.core" pos?]
+              [:value "#namespace[clojure.core]" pos?]
               " = "
               [:value #=(str "[#'clojure.core/primitives-classnames #'clojure.core/+' #'clojure.core/decimal? "
                              "#'clojure.core/restart-agent #'clojure.core/sort-by ...]") pos?]

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -83,15 +83,21 @@
     "java.lang.Long[] {0, 1, 2, 3, 4}" (into-array Long (range 5))
     "java.lang.Long[] {}" (into-array Long [])
     "#<MyTestType test1>" (MyTestType. "test1")
-    "#Atom[1]" (atom 1)
-    "#Delay[<pending>]" (delay 1)
-    "#Delay[1]" (doto (delay 1) deref)
-    "#Delay[<failed>]" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
-    #"#Error\[clojure.lang.ExceptionInfo \"Boom\" \"orchard.print_test.+\"\]" (ex-info "Boom" {})
-    #"#Error\[clojure.lang.ExceptionInfo \"Boom\" \{:a 1\} \"orchard.print_test.+\"\]" (ex-info "Boom" {:a 1})
-    #"#Error\[java.lang.RuntimeException \"Runtime!\" \"orchard.print_test.+\"\]" (RuntimeException. "Runtime!")
-    #"#Error\[java.lang.RuntimeException \"Outer: Inner\" \"orchard.print_test.+\"\]" (RuntimeException. "Outer"
+    "#atom[1]" (atom 1)
+    "#delay[<pending>]" (delay 1)
+    "#delay[1]" (doto (delay 1) deref)
+    "#delay[<failed>]" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
+    "#promise[<pending>]" (promise)
+    "#promise[1]" (doto (promise) (deliver 1))
+    "#future[<pending>]" (future (Thread/sleep 10000))
+    "#future[1]" (doto (future 1) deref)
+    "#agent[1]" (agent 1)
+    #"#error\[clojure.lang.ExceptionInfo \"Boom\" \"orchard.print_test.+\"\]" (ex-info "Boom" {})
+    #"#error\[clojure.lang.ExceptionInfo \"Boom\" \{:a 1\} \"orchard.print_test.+\"\]" (ex-info "Boom" {:a 1})
+    #"#error\[java.lang.RuntimeException \"Runtime!\" \"orchard.print_test.+\"\]" (RuntimeException. "Runtime!")
+    #"#error\[java.lang.RuntimeException \"Outer: Inner\" \"orchard.print_test.+\"\]" (RuntimeException. "Outer"
                                                                                                          (RuntimeException. "Inner"))
+    #"multifn\[print .+\]" sut/print
     "#function[clojure.core/str]" str))
 
 (deftest print-writer-limits
@@ -134,10 +140,10 @@
 
   (are [result lvl] (= result (binding [*print-level* lvl]
                                 (sut/print-str (atom {:a (range 10)}))))
-    "#Atom[...]" 0
-    "#Atom[{...}]" 1
-    "#Atom[{:a (...)}]" 2
-    "#Atom[{:a (0 1 2 3 4 5 6 7 8 9)}]" 3))
+    "#atom[...]" 0
+    "#atom[{...}]" 1
+    "#atom[{:a (...)}]" 2
+    "#atom[{:a (0 1 2 3 4 5 6 7 8 9)}]" 3))
 
 (deftest print-non-iterable
   (is (= "#{1 2 3}" (sut/print-str (reify clojure.lang.IPersistentSet


### PR DESCRIPTION
I want to make the custom printing we do in inspector, debugger, and the customly inject print-methods in cider-nrepl more consistent with each other. This PR adds print handling for futures, promises, namespaces, multimethods (things that cider-nrepl already performs prettyfication of), downcases the custom printed representation names (again, like cider-nrepl does), and other minor things.

---

- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)