### PR TITLE
[pp] Reuse orchard.print in orchard.pp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## master (unreleased)
 
 * [#314](https://github.com/clojure-emacs/orchard/pull/314): Print: add special printing rules for records and allow meta :type overrides.
-* [#336](https://github.com/clojure-emacs/orchard/pull/336): Inspector: tune pretty-printing mode.
 * [#337](https://github.com/clojure-emacs/orchard/pull/337): Print: make orchard.print consistent with CIDER printing.
+* [#338](https://github.com/clojure-emacs/orchard/pull/337): Print: reuse orchard.print in orchard.pp.
+* [#336](https://github.com/clojure-emacs/orchard/pull/336): Inspector: tune pretty-printing mode.
 
 ## 0.34.0 (2025-04-18)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -12,6 +12,7 @@
    [clojure.core.protocols :refer [datafy nav]]
    [clojure.string :as str]
    [orchard.inspect.analytics :as analytics]
+   [orchard.pp :as pp]
    [orchard.print :as print])
   (:import
    (java.lang.reflect Constructor Field Method Modifier)
@@ -57,7 +58,7 @@
   of the inspector."
   [{:keys [indentation pretty-print]} value]
   (if pretty-print
-    (print/pprint-str value {:indentation (or indentation 0)})
+    (pp/pprint-str value {:indentation (or indentation 0)})
     (print/print-str value)))
 
 (defn- array? [obj]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1420,7 +1420,7 @@
             ["--- Instance fields:"
              [:newline]
              "  " [:value "_meta" pos?] " = " [:value "nil" pos?] [:newline]
-             "  " [:value "state" pos?] " = " [:value "foo" pos?] [:newline]
+             "  " [:value "state" pos?] " = " [:value #"#object\[java.util.concurrent.atomic.AtomicReference" pos?] [:newline]
              "  " [:value "validator" pos?] " = " [:value "nil" pos?] [:newline]
              "  " [:value "watches" pos?] " = " [:value "{}" pos?] [:newline]
              [:newline]])

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -64,6 +64,7 @@
     ":foo" :foo
     ":abc/def" :abc/def
     "sym" 'sym
+    "\\space" \space
     "(:a :b :c)" '(:a :b :c)
     "[1 2 3]" [1 2 3]
     "{:a 1, :b 2}" {:a 1 :b 2}
@@ -86,7 +87,7 @@
     "#atom[1]" (atom 1)
     "#delay[<pending>]" (delay 1)
     "#delay[1]" (doto (delay 1) deref)
-    "#delay[<failed>]" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
+    #"#delay\[<failed> #error\[java.lang.ArithmeticException \"Divide by zero\"" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
     "#promise[<pending>]" (promise)
     "#promise[1]" (doto (promise) (deliver 1))
     "#future[<pending>]" (future (Thread/sleep 10000))
@@ -155,60 +156,3 @@
 (deftest print-custom-print-method
   (is (= "hello"
          (sut/print-str (with-meta (->TestRecord 1 2 3 4) {:type ::custom-rec})))))
-
-(deftest pprint-no-limits
-  (are [result form] (match? result (sut/pprint-str form))
-    "1" 1
-    "\"2\"" "2"
-    "\"special \\\" \\\\ symbols\"" "special \" \\ symbols"
-    ":foo" :foo
-    ":abc/def" :abc/def
-    "sym" 'sym
-    "(:a :b :c)" '(:a :b :c)
-    "[1 2 3]" [1 2 3]
-    "{:a 1, :b 2}" {:a 1 :b 2}
-    "[:a 1]" (first {:a 1 :b 2})
-    "([:a 1] [:b 2])" (seq {:a 1 :b 2})
-    "[[:a 1] [:b 2]]" (vec {:a 1 :b 2})
-    "{}" {}
-    "{}" (java.util.HashMap.)
-    "#{:a}" #{:a}
-    "(1 2 3)" (lazy-seq '(1 2 3))
-    "[1 1 1 1 1]" (java.util.ArrayList. ^java.util.Collection (repeat 5 1))
-    "{:a 1, :b 2}" (let [^java.util.Map x {:a 1 :b 2}]
-                     (java.util.HashMap. x))
-    "#orchard.print_test.TestRecord{:a 1, :b 2, :c 3, :d 4}" (->TestRecord 1 2 3 4)
-    "[1 2 3 4]" (long-array [1 2 3 4])
-    "[]" (long-array [])
-    "[0 1 2 3 4]" (into-array Long (range 5))
-    "[]" (into-array Long [])
-    ;; The following tests print differently in the REPL vs in Leiningen due to some overrides in cider-nrepl
-    ;; #"#object\[orchard.print_test.MyTestType 0x.+ \"orchard.print_test.MyTestType@.+\"\]" (MyTestType. "test1")
-    ;; #"#atom\[1 0x.+\]" (atom 1)
-    ;; #"#delay\[\{:status :pending, :val nil\} 0x.+\]" (delay 1)
-    ;; #"#delay\[\{:status :ready, :val 1\} 0x.+\]" (doto (delay 1) deref)
-    ;; #"(?ms)#delay\[\{:status :failed, :val #error .*\}\]" (let [d (delay (/ 1 0))] (try @d (catch Exception _)) d)
-    ;; #"(?ms)#error \{.*\}" (ex-info "Boom" {})
-    ;; "#function[clojure.core/str]" str
-    ))
-
-(deftest pprint-limits
-  (testing "global writer limits will stop the printing when reached"
-    (are [result form] (= result (binding [sut/*max-atom-length* 10
-                                           sut/*max-total-length* 30
-                                           *print-length* 5
-                                           *print-level* 10]
-                                   (sut/pprint-str form)))
-      "\"aaaaaaaaa..." (apply str (repeat 300 "a"))
-      "[\"aaaaaaaaa...\n \"aaaaaaaaa...]..." [(apply str (repeat 300 "a")) (apply str (repeat 300 "a"))]
-      "(1 1 1 1 1 ...)" (repeat 1)
-      "[(1 1 1 1 1 ...)]" [(repeat 1)]
-      "{:a {(0 1 2 3 4 ...) 1, 2 3, 4..." {:a {(range 10) 1, 2 3, 4 5, 6 7, 8 9, 10 11}}
-      "[1 1 1 1 1..." (java.util.ArrayList. ^java.util.Collection (repeat 100 1))
-      "[0 1 2 3 4 ...]" (into-array Long (range 10))
-      "{:m\n {:m\n  {:m\n   {:m {:m 1234..." (nasty 5)
-      "{:b {:a {:..." graph-with-loop))
-
-  (testing "writer won't go much over total-length"
-    (is (= 2003 (count (binding [sut/*max-total-length* 2000]
-                         (sut/print-str infinite-map)))))))


### PR DESCRIPTION
This achieves better displayed consistency between orchard.print and orchard.pp. It also cuts down some code from orchard.pp that's already implemented in orchard.print.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)