### PR TITLE
Inspector analytics improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#339](https://github.com/clojure-emacs/orchard/pull/339): Inspector: support analytics for all maps and arrays.
+
 ## 0.34.1 (2025-04-23)
 
 * [#314](https://github.com/clojure-emacs/orchard/pull/314): Print: add special printing rules for records and allow meta :type overrides.

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -427,9 +427,9 @@
 (defn supports-table-view-mode?
   "Return whether the inspected object can be rendered in :table view-mode."
   [{:keys [chunk value] :as _inspector}]
-  (let [val (or chunk value)]
-    (and (#{:list :array} (object-type val))
-         (#{:list :array :map} (object-type (first val))))))
+  (let [chunk (or chunk value)]
+    (and (#{:list :array} (object-type value))
+         (#{:list :array :map} (object-type (first chunk))))))
 
 (defn- render-chunk-as-table [inspector chunk idx-starts-from]
   (let [m-i map-indexed

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -688,6 +688,7 @@
   (-> (render-class-name inspector obj)
       (render-counted-length obj)
       (render-labeled-value "Component Type" (.getComponentType (class obj)))
+      (render-analytics)
       (render-section-header "Contents")
       (indent)
       (render-collection-paged)

--- a/src/orchard/inspect/analytics.clj
+++ b/src/orchard/inspect/analytics.clj
@@ -17,12 +17,11 @@
        (into {})))
 
 (defn- *frequencies [coll]
-  (->> coll
-       (eduction (take *size-cutoff*))
-       frequencies
-       (sort-by second >)
-       (apply concat)
-       (apply array-map)))
+  (let [freqs (->> coll
+                   (eduction (take *size-cutoff*))
+                   frequencies)]
+    ;; Turn the result in a map that is sorted by descending value.
+    (into (sorted-map-by #(- (compare (freqs %1) (freqs %2)))) freqs)))
 
 (definline ^:private inc-if [val condition]
   `(cond-> ~val ~condition inc))

--- a/src/orchard/inspect/analytics.clj
+++ b/src/orchard/inspect/analytics.clj
@@ -165,13 +165,18 @@
   - lists of arbitrary collections
   - arbitrary key-value maps"
   [object]
-  (or (tuples-stats object)
-      (records-stats object)
-      (keyvals-stats object)
-      (basic-list-stats object true)))
+  (let [object (if (some-> (class object) (.isArray))
+                 ;; Convert arrays into vectors to simplify analytics for them.
+                 (vec object)
+                 object)]
+    (or (tuples-stats object)
+        (records-stats object)
+        (keyvals-stats object)
+        (basic-list-stats object true))))
 
 (defn can-analyze?
   "Simple heuristic: we currently only analyze collections (but most of them)."
   [object]
   (or (instance? List object)
-      (instance? Map object)))
+      (instance? Map object)
+      (some-> (class object) (.isArray))))

--- a/src/orchard/inspect/analytics.clj
+++ b/src/orchard/inspect/analytics.clj
@@ -123,12 +123,11 @@
 (defn- keyvals-stats [coll]
   (when (instance? Map coll)
     (let [cnt (bounded-count *size-cutoff* coll)]
-      (when (> cnt 10)
-        (non-nil-hmap
-         :cutoff? (when (>= cnt *size-cutoff*) true)
-         :count cnt
-         :keys (basic-list-stats (vec (keys coll)) false)
-         :values (basic-list-stats (vec (vals coll)) false))))))
+      (non-nil-hmap
+       :cutoff? (when (>= cnt *size-cutoff*) true)
+       :count cnt
+       :keys (basic-list-stats (vec (keys coll)) false)
+       :values (basic-list-stats (vec (vals coll)) false)))))
 
 (defn- tuples-stats [^Iterable coll]
   (when (list-of-tuples? coll)
@@ -174,4 +173,5 @@
 (defn can-analyze?
   "Simple heuristic: we currently only analyze collections (but most of them)."
   [object]
-  (instance? java.util.Collection object))
+  (or (instance? List object)
+      (instance? Map object)))

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1566,7 +1566,13 @@
             "  | " [:value "7" pos?] " | " [:value "7" pos?] " | " [:value "7" pos?] " | " [:newline]
             "  | " [:value "8" pos?] " | " [:value "8" pos?] " | " [:value "8" pos?] " | " [:newline]
             [:newline]]
-           (section "Contents" rendered)))))
+           (section "Contents" rendered))))
+
+  (testing "map is not reported as table-viewable when paged"
+    (is (not (-> (zipmap (range 100) (range))
+                 (inspect/start)
+                 (set-page-size 30)
+                 (inspect/supports-table-view-mode?))))))
 
 (deftest pretty-print-map-test
   (testing "in :pretty view-mode are pretty printed"


### PR DESCRIPTION
First part is pretty minor – allow analytics for all maps and for arrays.

~The second part is a bit more involved. Sometimes, it is beneficial to display a map as map after you order it somehow – sort by keys or values or anyhow else. However, turning that sorted list of MapEntries back into an array-map just so that inspector or printer displays it properly without messing up the entry order is inefficient. Thus, I've added a meta flag that is interpreted by inspector, printer, and pretty-printer as "show this sequence of mapentries as a map".~

~This is currently only used for displaying frequencies computed by inspector analytics. We have tests for that functionality, so no new tests are necessary.~

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)