### PR TITLE
[inspect] Hexdump view mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#342](https://github.com/clojure-emacs/orchard/pull/342): Inspector: add hexdump view mode.
+
 ## 0.34.3 (2025-04-28)
 
 - Inspector: fix multiple frequencies not shown for the same value in analytics.

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1561,6 +1561,49 @@
                  (set-page-size 30)
                  (inspect/supports-table-view-mode?))))))
 
+(deftest hex-view-mode-test
+  (testing "in :hex view-mode byte arrays are rendered as hexdump tables"
+    (let [rendered (-> (byte-array (range 100))
+                       inspect
+                       (inspect/set-view-mode :hex)
+                       render)]
+      (is+ ["--- Contents:" [:newline]
+            "  0x00000000 │ 00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f │ ················" [:newline]
+            "  0x00000010 │ 10 11 12 13 14 15 16 17  18 19 1a 1b 1c 1d 1e 1f │ ················" [:newline]
+            "  0x00000020 │ 20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f │  !\"#$%&'()*+,-./" [:newline]
+            "  0x00000030 │ 30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f │ 0123456789:;<=>?" [:newline]
+            "  0x00000040 │ 40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f │ @ABCDEFGHIJKLMNO" [:newline]
+            "  0x00000050 │ 50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f │ PQRSTUVWXYZ[\\]^_" [:newline]
+            "  0x00000060 │ 60 61 62 63                                      │ `abc" [:newline] [:newline]]
+           (contents-section rendered))
+      (is+ ["--- View mode:" [:newline] "  :hex"]
+           (section rendered "View mode"))))
+
+  (testing "works with paging"
+    (is+ ["--- Contents:" [:newline]
+          "  0x00000000 │ 00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f │ ················" [:newline]
+          "  0x00000010 │ 10 11 12 13 14 15 16 17  18 19 1a 1b 1c 1d 1e 1f │ ················" [:newline]
+          "  ..." [:newline] [:newline]]
+         (-> (byte-array (range 100))
+             inspect
+             (inspect/set-view-mode :hex)
+             (set-page-size 2)
+             render
+             contents-section))
+
+    (is+ ["--- Contents:" [:newline]
+          "  ..." [:newline]
+          "  0x00000020 │ 20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f │  !\"#$%&'()*+,-./" [:newline]
+          "  0x00000030 │ 30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f │ 0123456789:;<=>?" [:newline]
+          "  ..." [:newline] [:newline]]
+         (-> (byte-array (range 100))
+             inspect
+             (inspect/set-view-mode :hex)
+             (set-page-size 2)
+             inspect/next-page
+             render
+             contents-section))))
+
 (deftest pretty-print-map-test
   (testing "in :pretty view-mode are pretty printed"
     (let [rendered (-> {:a 0


### PR DESCRIPTION
Here is how it looks:

<img width="764" alt="image" src="https://github.com/user-attachments/assets/79001e73-3f81-4f61-be26-dfebd978fec2" />

- Inspired by `hexdump` tool.
- Supports paging (renders 16*page-size of bytes).
- Currently only works for byte arrays. I may add support for ByteBuffers in the future, based on the feedback.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)