### PR TITLE
[inspect] Rework view-mode toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - [#342](https://github.com/clojure-emacs/orchard/pull/342): Inspector: add hexdump view mode.
+- [#343](https://github.com/clojure-emacs/orchard/pull/343): Inspector: rework view-mode toggling.
 
 ## 0.34.3 (2025-04-28)
 


### PR DESCRIPTION
Because there are more view modes now, and they all work conditionally, and also to facilitate discovery, I've reworked how they are displayed and changed. Orchard now has its own "toggle view mode" functionality (previously it was in cider-nrepl).

All view modes that are available for the currently inspected objects are displayed, and the enabled one is marked with a special symbol.

<img width="537" alt="image" src="https://github.com/user-attachments/assets/ee927be4-6bd2-44cd-b7b5-35052c51dc27" />

---
- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)

