### PR TITLE
[stacktrace] Flag Clojure functions as duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#353](https://github.com/clojure-emacs/orchard/pull/353): Stacktrace: flag Clojure functions as duplicate.
+
 ## 0.36.0 (2025-06-29)
 
 - [#346](https://github.com/clojure-emacs/orchard/pull/346): Inspector: only show those datafied collection items that have unique datafy represantation.

--- a/src/orchard/stacktrace.clj
+++ b/src/orchard/stacktrace.clj
@@ -143,6 +143,9 @@
        (partition 2 1)
        (map (fn [[frame parent]]
               (if (or (= (:name frame) (:name parent))
+                      ;; Deduplicate demunged function names
+                      (and (:fn frame)
+                           (= (:fn frame) (:fn parent)))
                       (and (= (:file frame) (:file parent))
                            (= (:line frame) (:line parent))))
                 (flag-frame parent :dup)


### PR DESCRIPTION
I'm not sure if this happened during moving haystack code to Orchard, or if it was always like that (unlikely) but the duplicates flagging functionality doesn't work properly right now. This PR fixes this by comparing demunged function names, not just raw Java class/method names, so that `user$foo.invoke` and `user$foo.invokeStatic` are deduped.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
