### PR TITLE
[inspect] Add support for printing compact qualified keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#353](https://github.com/clojure-emacs/orchard/pull/353): Stacktrace: flag Clojure functions as duplicate.
 - [#355](https://github.com/clojure-emacs/orchard/pull/355): Java: resolve source files for non-base JDK classes.
+- [#354](https://github.com/clojure-emacs/orchard/pull/354): Inspector: add support for printing compact qualified keywords.
 
 ## 0.36.0 (2025-06-29)
 

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -49,7 +49,8 @@
    :analytics-size-cutoff  100000
    :sort-maps false
    :only-diff false
-   :pretty-print false})
+   :pretty-print false
+   :pov-ns nil})
 
 (defn- reset-render-state [inspector]
   (-> inspector
@@ -1134,11 +1135,12 @@
 
 (defn inspect-render
   ([{:keys [max-atom-length max-value-length max-coll-size max-nested-depth value
-            pretty-print only-diff]
+            pretty-print only-diff pov-ns]
      :as inspector}]
    (binding [print/*max-atom-length*  max-atom-length
              print/*max-total-length* max-value-length
              print/*coll-show-only-diff* (boolean only-diff)
+             print/*pov-ns*           (some-> pov-ns find-ns)
              *print-length*           max-coll-size
              *print-level*            (cond-> max-nested-depth
                                         ;; In pretty mode a higher *print-level*

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1777,6 +1777,18 @@
              render
              contents-section))))
 
+(deftest compact-keywords-test
+  (testing "when :pov-ns is passed, use it to compact qualified keywords"
+    (is+ ["--- Contents:" [:newline]
+          "  " [:value "::foo" pos?] " = " [:value "1" pos?] [:newline]
+          "  " [:value "::str/bar" pos?] " = " [:value "2" pos?] [:newline]
+          "  " [:value "::walk/baz" pos?] " = " [:value "3" pos?]]
+         (-> {::foo 1
+              ::str/bar 2
+              :clojure.walk/baz 3}
+             (inspect {:pov-ns 'orchard.inspect-test})
+             render contents-section))))
+
 (deftest tap-test
   (testing "tap-current-value"
     (let [proof (atom [])


### PR DESCRIPTION
This is an idea to address https://github.com/clojure-emacs/cider/issues/3841. I think most of the time when people use long qualified keywords, it happens when using shortened syntax `::foo` or `::alias/foo`. The proposed feature tries to reconstruct the shortened syntax by providing a config paramter `:pov-ns` (Point-of-View namespace) from where the inspection is initiated. Example, inspecting this

<img width="246" height="87" alt="Screenshot 2025-09-11 at 21 16 08" src="https://github.com/user-attachments/assets/cf885dc6-897b-4f40-b3c4-780c6da06be8" />

Yields this:

<img width="357" height="147" alt="Screenshot 2025-09-11 at 21 16 20" src="https://github.com/user-attachments/assets/dd6ae082-cefa-415f-9c4a-a7d5ecb6a5cf" />

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
