### PR TITLE
[src-files] Correctly resolve source files for non-base JDK classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
       files:
         description: Files to consider when creating the cache key
         type: string
-        default: "deps.edn project.clj"
+        default: "deps.edn project.clj download-jdk-sources.sh"
       cache_version:
         type: string
         description: "Key used to identify unique cache"

--- a/.circleci/download-jdk-sources.sh
+++ b/.circleci/download-jdk-sources.sh
@@ -9,5 +9,6 @@ wget "$URL" -O full-src.zip
 unzip -q full-src.zip
 cp -r jdk*/src/java.base/share/classes java.base
 cp -r jdk*/src/java.desktop/share/classes java.desktop
-zip -qr $DEST java.base java.desktop
-rm -rf java.base java.desktop jdk* full-src.zip
+cp -r jdk*/src/java.sql/share/classes java.sql
+zip -qr $DEST java.base java.desktop java.sql
+rm -rf java.base java.desktop java.sql jdk* full-src.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - [#353](https://github.com/clojure-emacs/orchard/pull/353): Stacktrace: flag Clojure functions as duplicate.
+- [#355](https://github.com/clojure-emacs/orchard/pull/355): Java: resolve source files for non-base JDK classes.
 
 ## 0.36.0 (2025-06-29)
 

--- a/src/orchard/java/compatibility.clj
+++ b/src/orchard/java/compatibility.clj
@@ -16,6 +16,18 @@
   [class-or-sym]
   (module-name-macro class-or-sym))
 
+(defmacro ^:private contains-in-boot-modules-macro [class]
+  ;; On JDK8, always return nil.
+  (when (>= misc/java-api-version 11)
+    `(let [^Class klass# ~class]
+       (when-some [module# (some-> klass# .getModule)]
+         (.contains (.modules (java.lang.ModuleLayer/boot)) module#)))))
+
+(defn is-in-boot-module?
+  "Return true if the class belongs to a module that is among boot modules."
+  [class]
+  (contains-in-boot-modules-macro class))
+
 (defmacro get-field-value-macro [field obj]
   (if (>= misc/java-api-version 11)
     `(try (if (or (.canAccess ~field ~obj)

--- a/test/orchard/java/source_files_test.clj
+++ b/test/orchard/java/source_files_test.clj
@@ -7,7 +7,8 @@
 (when util/jdk-sources-present?
   (deftest class->source-file-url-test
     (is (src-files/class->source-file-url mx.cider.orchard.LruMap)) ;; classpath
-    (is (src-files/class->source-file-url Thread))                  ;; JDK
+    (is (src-files/class->source-file-url Thread)) ;; JDK
+    (is (src-files/class->source-file-url java.sql.Connection)) ;; JDK other module
     (is (src-files/class->source-file-url clojure.lang.PersistentVector)) ;; Clojure
     (is (nil? (src-files/class->source-file-url clojure.core.Eduction))))) ;; record
 


### PR DESCRIPTION
Turns out I had wrong heuristic for figuring out if a class is a JDK one.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
