### PR TITLE
[print] Protect printing from broken eductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#359](https://github.com/clojure-emacs/orchard/pull/359): Print: protect printing from broken eductions.
+
 ## 0.37.0 (2025-09-19)
 
 - [#353](https://github.com/clojure-emacs/orchard/pull/353): Stacktrace: flag Clojure functions as duplicate.

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -13,9 +13,9 @@
    (clojure.core Eduction)
    (clojure.lang AFunction Compiler IDeref IPending IPersistentMap MultiFn
                  IPersistentSet IPersistentVector IRecord Keyword Namespace
-                 Symbol TaggedLiteral Var)
+                 RT Symbol TaggedLiteral Var)
    (java.io Writer)
-   (java.util List Map Map$Entry)
+   (java.util Iterator List Map Map$Entry)
    (mx.cider.orchard TruncatingStringWriter
                      TruncatingStringWriter$TotalLimitExceeded)))
 
@@ -78,8 +78,11 @@
      (when-not (nil? level)
        (set! *print-level* (dec level)))
      (try
-       (let [^Iterable iterable (if (instance? Iterable x) x (seq x))
-             it (.iterator iterable)]
+       (let [^Iterator it (try (RT/iter (if (instance? Iterable x) x (seq x)))
+                               ;; In some cases, calling .iterator may throw
+                               ;; (e.g. incomplete CollReduce implementations).
+                               (catch Exception ex
+                                 (RT/iter [(format "<<%s>>" ex)])))]
          (if (.hasNext it)
            (do (.write w prefix)
                (if (or (nil? level) (pos? level))

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -1,7 +1,8 @@
 (ns orchard.print-test
   (:require
    [clojure.test :as t :refer [is are deftest testing]]
-   [orchard.print :as sut])
+   [orchard.print :as sut]
+   [orchard.test.util :refer [is+]])
   (:import
    (mx.cider.orchard TruncatingStringWriter
                      TruncatingStringWriter$TotalLimitExceeded)))
@@ -182,3 +183,13 @@
       (are [kw repr] (= repr (sut/print-str kw))
         ::foo    ":orchard.print-test/foo"
         ::t/foo          ":clojure.test/foo"))))
+
+(deftest broken-eduction-test
+  (testing "shouldn't throw if printing an eduction that lacks Seq impl"
+    (is+ #"\(\"<<java.lang.IllegalArgumentException: Don't know how to create ISeq from:"
+         (sut/print-str (eduction (map identity)
+                                  (reify clojure.core.protocols.CollReduce
+                                    (coll-reduce [_ f]
+                                      (reduce f (range 10)))
+                                    (coll-reduce [_ f init]
+                                      (reduce f init (range 10)))))))))


### PR DESCRIPTION
---

- [x] You've added tests to cover your change(s)
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
