### PR TITLE
Rewrite orchard.xref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#382](https://github.com/clojure-emacs/orchard/pull/382): Rewrite and optimize `orchard.xref`.
+
 ## 0.40.0 (2026-03-25)
 
 - Adopt the modern indent spec tuple format (`[[:block N]]`, `[[:inner D]]`) shared with clojure-mode and clojure-ts-mode. The inferred `:style/indent` values from the spec tables now use this format. Plain integer inference from arglists is unchanged.

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -3,10 +3,12 @@
   references."
   {:added "0.5"}
   (:require
-   [clojure.repl :as repl]
    [clojure.set :as set]
    [clojure.string :as str]
-   [orchard.query :as q]))
+   [orchard.query :as q])
+  (:import (java.lang.ref Reference)
+           (java.lang.reflect Modifier)
+           (java.util.function BiConsumer)))
 
 (defn- var->fn [var-ref]
   (let [{:keys [test]} (meta var-ref)]
@@ -22,33 +24,23 @@
     (symbol? thing) (var->fn (find-var thing))
     (fn? thing) thing))
 
-(defn- fn-name [^java.lang.Class f]
-  (-> f .getName repl/demunge symbol))
-
-(def eval-lock
-  "We don't want parallel evaluation - easily dangerous."
-  (Object.))
-
 (defn fn-deps-class
   "Returns a set with all the functions invoked by `v`.
   `v` can be a function class or a symbol."
   {:added "0.9"}
   [v]
-  (let [^java.lang.Class v (if (class? v)
-                             v
-                             (locking eval-lock
-                               (eval v)))]
-    (when (class? v) ;; maybe a non-class was evaled
+  (let [^Class v (cond (class? v) v
+                       (symbol? v) (resolve v))]
+    (when (class? v) ;; maybe a non-class was resolved
       (into #{} (keep (fn [^java.lang.reflect.Field f]
-                        (or (and (identical? clojure.lang.Var (.getType f))
-                                 (java.lang.reflect.Modifier/isPublic (.getModifiers f))
-                                 (java.lang.reflect.Modifier/isStatic (.getModifiers f))
-                                 (-> f .getName (.startsWith "const__"))
-                                 (.get f (fn-name v)))
-                            nil))
-                      (.getDeclaredFields v))))))
+                        (when (and (identical? clojure.lang.Var (.getType f))
+                                   (Modifier/isPublic (.getModifiers f))
+                                   (Modifier/isStatic (.getModifiers f))
+                                   (str/starts-with? (.getName f) "const__"))
+                          (.get f nil))))
+            (.getDeclaredFields v)))))
 
-(def ^:private class-cache
+(def ^:private ^java.util.concurrent.ConcurrentHashMap class-cache
   "Reference to Clojures class cache.
    This holds of classes compiled by the Clojure compiler,
    one class per function and one per repl eval.
@@ -70,27 +62,25 @@
   [v]
   (when-let [^clojure.lang.AFn v (to-fn v)]
     (let [f-class-name (-> v .getClass .getName)
-          ;; this uses the implementation detail that the clojure compiler always
-          ;; prefixes names of lambdas with the name of its surrounding function class
-          deps (into #{}
-                     (comp (filter (fn [[k _v]]
-                                     (str/includes? k f-class-name)))
-                           (map (fn [[_k value]]
-                                  (.get ^java.lang.ref.Reference value)))
-                           (mapcat fn-deps-class))
-                     class-cache)
-          result
+          ;; Uses the implementation detail that the compiler always prefixes
+          ;; names of lambdas with the name of its surrounding function class.
+          deps (volatile! #{})
+          _ (.forEach
+             class-cache
+             (reify BiConsumer
+               (accept [_ k v]
+                 (when (str/starts-with? k f-class-name)
+                   (vswap! deps into (fn-deps-class (.get ^Reference v)))))))
           ;; if there's no deps the class is most likely AoT compiled,
           ;; try to access it directly
-          (if (empty? deps)
-            (-> v .getClass fn-deps-class)
-            deps)]
-      (into #{}
-            (map resolve) ;; choose the freshest one
-            ;; group duplicates. This is important
-            ;; because there can be two seemingly equal #'foo.bar/baz var objects in the result.
-            ;; That can happen as one re-evaluates code and the old var hasn't been GC'd yet.
-            (keys (group-by symbol result))))))
+          result (if (empty? @deps)
+                   (fn-deps-class (.getClass v))
+                   @deps)]
+      ;; Re-resolve all vars to pick up the freshest. This is important because
+      ;; there can be two seemingly equal #'foo.bar/baz var objects in the
+      ;; result. That can happen as one re-evaluates code and the old var hasn't
+      ;; been GC'd yet.
+      (into #{} (map (comp resolve symbol)) result))))
 
 (defn fn-transitive-deps
   "Returns a set with all the functions invoked inside `v` or inside those functions.
@@ -126,41 +116,7 @@
   "Find all functions that refer `var`.
   `var` can be a function value, a var or a symbol."
   {:added "0.5"}
-  [v]
-  (let [var (as-var v)
-        all-vars (q/vars {:ns-query {:project? true} :private? true})
-        deps-map (zipmap all-vars (pmap fn-deps all-vars))]
-    (into []
-          (comp (filter (fn [[_k v]]
-                          (contains? v var)))
-                (map first))
-          deps-map)))
-
-(comment
-  ;; this can be used to blow up memory, which will clear the class cache of old references
-  (defn oom []
-    (try (let [memKiller (java.util.ArrayList.)]
-           (loop [free 10000000]
-             (.add memKiller (object-array free))
-             (.get memKiller 0)
-             (recur 100000 #_(if (< (Math/abs (.. Runtime (getRuntime) (freeMemory))) Integer/MAX_VALUE)
-                               (Math/abs (.. Runtime (getRuntime) (freeMemory)))
-                               Integer/MAX_VALUE))))
-         (catch OutOfMemoryError _
-           (println "freed"))))
-
-  (fn-deps #'fn-refs)
-  (fn-deps #'orchard.xref/fn-deps)
-  (fn-refs #'orchard.xref/fn->sym)
-
-  ;; returns all classes in this ns, even repl eval'd
-  (let [f-class-name "orchard.xref" #_(-> orchard.xref/fn-deps .getClass .getName)
-        classes (into #{} (comp (filter (fn [[k _v]] (str/includes? k f-class-name)))
-                                (map (fn [[_k v]] (.get ^java.lang.ref.Reference v))))
-                      class-cache)]
-    classes)
-
-  (oom)
-  (def vars (q/vars {:ns-query {:project? true} :private? true}))
-
-  (map fn-deps vars))
+  [var]
+  (let [var (as-var var)
+        all-vars (doall (q/vars {:ns-query {:project? true} :private? true}))]
+    (filterv (fn [v2] (contains? (fn-deps v2) var)) all-vars)))

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -21,14 +21,13 @@
       "Is garbage-safe (important, as it uses `eval` which can return anything)")
 
   (is (set/superset? (xref/fn-deps-class (.getClass ^Object xref/fn-deps-class))
-                     #{#'clojure.core/keep
+                     #{#'clojure.core/symbol?
+                       #'clojure.core/keep
                        #'clojure.core/into
-                       #'clojure.core/class?
-                       #'orchard.xref/eval-lock})))
+                       #'clojure.core/class?})))
 
 ;; Supports #'fn-deps-test
 (deftest sample-test
-  (is (some? xref/eval-lock))
   (is (some? (xref/fn-refs #'dummy-fn))))
 
 (deftest fn-deps-test
@@ -44,7 +43,6 @@
 
   (testing "with a var that backs a deftest"
     (is (= #{#'orchard.xref-test/dummy-fn
-             #'orchard.xref/eval-lock
              #'clojure.test/do-report
              #'clojure.core/cons
              #'clojure.core/some?


### PR DESCRIPTION
Big redoing of `orchard.xref` that includes:

- Improved performance.
- Getting rid of `eval` (yikes).
- Cleanup and compaction.

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
