### PR TITLE
[inspect] Rename default view mode for unknown objects to :object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#386](https://github.com/clojure-emacs/orchard/pull/386): Inspector: rename default view mode for unknown objects to `:object`.
+
 ## 0.41.0 (2026-04-13)
 
 - [#382](https://github.com/clojure-emacs/orchard/pull/382): Rewrite and optimize `orchard.xref`.

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -25,7 +25,7 @@
 ;; Navigating Inspector State
 ;;
 
-(declare inspect-render supported-view-modes)
+(declare inspect inspect-render supported-view-modes)
 
 (defn push-item-to-path
   "Takes `path` and the role and key of the value to be navigated to, and returns
@@ -308,13 +308,12 @@
 
 (defmulti view-mode-supported? (fn [_inspector view-mode] view-mode))
 
-(defmethod view-mode-supported? :normal [_ _] true)
+(defmethod view-mode-supported? :normal [{:keys [value]} _]
+  ;; "Normal" mode is supported when an object has a non-fallthrough renderer.
+  (not (identical? (get-method inspect (object-type value))
+                   (get-method inspect :default))))
 
-(defmethod view-mode-supported? :object [{:keys [value]} _]
-  ;; A hack - for all "known" types `object-type` returns a keyword. If it's not
-  ;; a keyword, it means we render it using object renderer, so :object
-  ;; view-mode is redundant for it.
-  (keyword? (object-type value)))
+(defmethod view-mode-supported? :object [_ _] true)
 
 (defmethod view-mode-supported? :table [{:keys [chunk value]} _]
   (let [chunk (or chunk value)]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -756,23 +756,20 @@
 (deftest inspect-java-object-test
   (testing "inspecting any Java object prints its fields"
     (is+ (matchers/prefix
-          ["Class: "
-           [:value "clojure.lang.TaggedLiteral" 0]
+          ["Class: " [:value "clojure.lang.TaggedLiteral" 0] [:newline]
+           "Value: " [:value "#foo ()" 1] [:newline]
+           #"Identity hash code: " [:newline]
            [:newline]
-           "Value: " [:value "#foo ()" 1]
+           "--- Instance fields:" [:newline]
+           "  " [:value "form" 2] " = " [:value "()" 3] [:newline]
+           "  " [:value "tag" 4] " = " [:value "foo" 5] [:newline]
            [:newline]
-           #"Identity hash code: "
+           "--- Static fields:" [:newline]
+           "  " [:value "FORM_KW" 6] " = " [:value ":form" 7] [:newline]
+           "  " [:value "TAG_KW" 8] " = " [:value ":tag" 9] [:newline]
            [:newline]
-           [:newline]
-           "--- Instance fields:"
-           [:newline] "  " [:value "form" 2] " = " [:value "()" 3]
-           [:newline] "  " [:value "tag" 4] " = " [:value "foo" 5]
-           [:newline]
-           [:newline]
-           "--- Static fields:"
-           [:newline] "  " [:value "FORM_KW" 6] " = " [:value ":form" 7]
-           [:newline] "  " [:value "TAG_KW" 8] " = " [:value ":tag" 9]
-           [:newline]])
+           #"View mode" [:newline]
+           "  ●object pretty sort-maps"])
          (render (inspect (clojure.lang.TaggedLiteral/create 'foo ()))))))
 
 (deftest inspect-path
@@ -1761,7 +1758,7 @@
          "  3. " [:value "#±[3 ~~ 4]" pos?]]
 
         "View mode"
-        ["  ●normal pretty sort-maps only-diff"]}
+        ["  ●normal object pretty sort-maps only-diff"]}
        (-> (inspect/diff data1 data2)
            inspect
            render
@@ -1805,7 +1802,7 @@
            "  3. " [:value "#±[3 ~~ 4]" pos?]]
 
           "View mode"
-          ["  ●normal pretty sort-maps ●only-diff"]}
+          ["  ●normal object pretty sort-maps ●only-diff"]}
          (-> (inspect/diff data1 data2)
              (inspect {:only-diff true})
              render


### PR DESCRIPTION
This is minor. 

It used to be that all objects had `:normal` view mode, and known objects also had `:object` view mode. Unknown objects could only be inspected in object mode but we still called it `:normal` mode for them.

Now, `:object` view mode is called that for any object. But unknown objects no longer support `:normal` mode which name we only reserve to objects that have explicit renderers.

---

- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
