### PR TITLE
Fix dead code in require-and-resolve

### DIFF
--- a/src/orchard/misc.clj
+++ b/src/orchard/misc.clj
@@ -143,12 +143,11 @@
   (instance? clojure.lang.Namespace ns))
 
 (defn require-and-resolve
-  "Like `clojure.core/requiring-resolve`, but doesn't throw exception if namespace
-  was not found or failed to load. Also, returns derefs the resolved var."
+  "Like `clojure.core/requiring-resolve`, but doesn't throw if the namespace
+  was not found or failed to load. Returns the var's value, not the var itself."
   {:added "0.5"}
   [sym]
   (try (some-> sym requiring-resolve var-get)
-       (var-get (resolve sym))
        (catch Exception _)))
 
 (defn call-when-resolved


### PR DESCRIPTION
The `try` body in `require-and-resolve` had two expressions, but only the last one's return value matters in Clojure. The `requiring-resolve` + `var-get` on the first line was computed and discarded. The second expression `(var-get (resolve sym))` would also silently NPE when `resolve` returned nil.

Removed the dead second expression so the function works as its docstring describes. Also fixed a small grammar issue in the docstring.