### PR TITLE
Throw on invalid input to stacktrace/analyze

### DIFF
--- a/src/orchard/stacktrace.clj
+++ b/src/orchard/stacktrace.clj
@@ -313,4 +313,7 @@
   (cond (instance? Throwable exception)
         (analyze-causes (Throwable->map-with-traces exception))
         (and (map? exception) (:trace exception))
-        (analyze-causes exception)))
+        (analyze-causes exception)
+        :else
+        (throw (ex-info "Expected a Throwable or a map with a :trace key"
+                        {:exception exception}))))


### PR DESCRIPTION
The `cond` in `analyze` would silently return nil when passed anything other than a Throwable or a map with a `:trace` key. This could mask bugs at call sites. Now throws an `ex-info` with a clear message instead.