### PR TITLE
Fix fn-transitive-deps to skip already-visited vars

### DIFF
--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -91,13 +91,13 @@
     (loop [checked #{}
            to-check (into [] deps)
            deps deps]
-      (cond
-        (empty? to-check) deps
-        :else (let [[current & remaining] to-check
-                    new-deps (fn-deps current)]
-                (recur (conj checked current)
-                       (concat remaining (filter #(contains? deps %) new-deps))
-                       (set/union deps new-deps)))))))
+      (if (empty? to-check)
+        deps
+        (let [[current & remaining] to-check
+              new-deps (fn-deps current)]
+          (recur (conj checked current)
+                 (into (vec remaining) (remove checked new-deps))
+                 (set/union deps new-deps)))))))
 
 (defn- fn->sym
   "Convert a function value `f` to symbol."


### PR DESCRIPTION
The `checked` set in `fn-transitive-deps` was accumulated but never used for filtering - new deps were filtered against `deps` instead. This meant the same var could be expanded by `fn-deps` multiple times in graphs with shared dependencies. Now filters against `checked` to avoid redundant work.