### PR TITLE
Standardize test naming to use -test suffix

### DIFF
--- a/test/orchard/eldoc_test.clj
+++ b/test/orchard/eldoc_test.clj
@@ -6,7 +6,7 @@
    [orchard.info :as info]
    [orchard.test.util :refer [is+]]))
 
-(deftest test-eldoc
+(deftest eldoc-test
   (testing "arglist extraction"
     (is+ {:eldoc '(["x"] ["x" "y"])}
          (eldoc/eldoc {:arglists '([x] [x y])}))

--- a/test/orchard/inspect/analytics_test.clj
+++ b/test/orchard/inspect/analytics_test.clj
@@ -46,7 +46,7 @@
         :strings {:n 5, :blank 3, :ascii 4, :max-len 6, :min-len 0, :avg-len (approx 2.8)}}
        (analytics [nil "" " " "  " "hello" "привіт"])))
 
-(deftest colls-stats
+(deftest colls-stats-test
   (is+ {:count 20
         :types {clojure.lang.LongRange 19, clojure.lang.PersistentList$EmptyList 1}
         :collections {:n 20, :empty 1, :max-size 19, :min-size 0, :avg-size 9.5}}

--- a/test/orchard/java/source_files_test.clj
+++ b/test/orchard/java/source_files_test.clj
@@ -14,7 +14,7 @@
 
 ;; Download sources testing
 
-(deftest test-infer-maven-coordinates
+(deftest infer-maven-coordinates-test
   (is (= (src-files/infer-maven-coordinates-for-class clojure.lang.Ref)
          {:artifact "clojure", :group "org.clojure", :version (clojure-version)}))
 
@@ -30,7 +30,7 @@
 ;; TODO: doesn't currently pass on Windows because it can't find "lein".
 ;; Probably a CI setup problem.
 (when-not (= os/os-type ::os/windows)
-  (deftest test-download-sources-jar-using-lein
+  (deftest download-sources-jar-using-lein-test
     (let [f (sources-jar-file clojure.lang.Ref)]
       (.delete f)
       (is (not (.exists f))))
@@ -45,7 +45,7 @@
              200)))))
 
 (when-not (= os/os-type ::os/windows)
-  (deftest test-download-sources-jar
+  (deftest download-sources-jar-test
     (let [f (sources-jar-file clojure.lang.Ref)]
       (.delete f)
       (is (not (.exists f))))

--- a/test/orchard/misc_test.clj
+++ b/test/orchard/misc_test.clj
@@ -36,7 +36,7 @@
   (is (= (misc/parse-java-version "11") 11))
   (is (= (misc/parse-java-version "14") 14)))
 
-(deftest macros-suffix-add-remove
+(deftest macros-suffix-add-remove-test
   (testing "add-ns-macros"
     (is (nil? (misc/add-ns-macros nil)))
     (is (= 'mount.tools.macro$macros (misc/add-ns-macros 'mount.tools.macro))))
@@ -47,25 +47,25 @@
     (is (= 'cljs.core.async/go (misc/remove-macros 'cljs.core.async$macros/go)) "it should remove $macros from a namespaced var")
     (is (= 'mount.tools.macro (misc/remove-macros 'mount.tools.macro$macros)) "it should remove $macros from a namespace")))
 
-(deftest name-sym
+(deftest name-sym-test
   (is (nil? (misc/name-sym nil)))
   (is (= 'unqualified (misc/name-sym 'unqualified)))
   (is (= 'sym (misc/name-sym 'qualified/sym))))
 
-(deftest namespace-sym
+(deftest namespace-sym-test
   (is (nil? (misc/namespace-sym nil)))
   (is (= 'unqualified (misc/namespace-sym 'unqualified)))
   (is (= 'qualified (misc/namespace-sym 'qualified/sym))))
 
-(deftest file-ext?
+(deftest file-ext?-test
   (is (misc/file-ext? (.toURL (java.net.URI. "file:/tmp/foo.jar")) ".jar"))
   (is (not (misc/file-ext? (.toURL (java.net.URI. "file:/tmp/foo.war")) ".jar")))
   (is (not (misc/file-ext? (.toURL (java.net.URI. "jar:file:/tmp/foo.jar!/BOOT-INF/lib/test.jar")) ".jar"))))
 
-(deftest directory?
+(deftest directory?-test
   (is (misc/directory? (.toURL (.toURI (java.io.File. ""))))))
 
-(deftest call-when-resolved
+(deftest call-when-resolved-test
   (let [f (misc/call-when-resolved 'clojure.core/identity)]
     (is (= 1 (f 1))))
   (let [f (misc/call-when-resolved 'com.example/unknown)]


### PR DESCRIPTION
All deftests now follow the foo-test convention consistently. Renames test-eldoc, test-infer-maven-coordinates, test-download-sources-jar-using-lein, test-download-sources-jar, colls-stats, macros-suffix-add-remove, name-sym, namespace-sym, file-ext?, directory?, call-when-resolved.