### PR TITLE
Fix test suite issues

### DIFF
--- a/test/orchard/apropos_test.clj
+++ b/test/orchard/apropos_test.clj
@@ -76,8 +76,8 @@
     (is+ [some?] (find-symbols {:var-query {:search #"some-random-function"}})
          "Search for specific fn should return it.")
     (doseq [private? [true false]]
-      (is (find-symbols {:var-query {:search #".*"
-                                     :private? private?}})
+      (is (seq (find-symbols {:var-query {:search #".*"
+                                          :private? private?}}))
           "Everything is searchable; it won't throw errors")))
 
   (testing "Types are correct"
@@ -103,12 +103,14 @@
           "Symbol search should return an abbreviated docstring.")))
 
   (testing "Includes special forms when `search-ns` is nil"
-    (is+ (mc/embeds [{:name "if"}]) (find-symbols {:search #"if"})))
+    (is+ (mc/embeds [{:name "if"}])
+         (find-symbols {:var-query {:search #"if"}})))
 
   (testing "Includes special forms when `search-ns` is \"clojure.core\""
     (is+ (mc/embeds [{:name "if"}])
-         (find-symbols {:search #"if"
-                        :ns-query {:exactly [(the-ns 'clojure.core)]}})))
+         (find-symbols {:var-query
+                        {:search #"if"
+                         :ns-query {:exactly [(the-ns 'clojure.core)]}}})))
 
   (testing "Excludes special forms when `search-ns` is some other ns"
     (is+ (mc/mismatch (mc/embeds [{:name "if"}]))

--- a/test/orchard/apropos_test.clj
+++ b/test/orchard/apropos_test.clj
@@ -42,8 +42,6 @@
   (is+ "Test1. Test2. Test3." (var-doc #'public-var))
   (is+ "Test1." (var-doc 1 #'public-var)))
 
-(find-symbols {:ns (find-ns 'orchard.apropos-test)})
-
 (deftest namespaces-test
   (testing "Namespace sort order"
     (is+ (mc/prefix [{:name #"^orchard\.apropos-test/"}])

--- a/test/orchard/java/classpath_test.clj
+++ b/test/orchard/java/classpath_test.clj
@@ -50,7 +50,7 @@
 (deftest classpath-resources-test
   (testing "Iterating classpath resources"
     (testing "returns non-empty lists"
-      ;; The non-existing .jar can get misteriously created (is it Lein?).
+      ;; The non-existing .jar can get mysteriously created (is it Lein?).
       ;; Work around it:
       (-> "does-not-exist.jar" File. .delete)
 

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -27,11 +27,12 @@
 (when jdk11+?
   (deftest parse-java-test
     (testing "Throws an informative exception on invalid code"
-      (try
-        (parse-java (io/resource "orchard/java/InvalidClass.java") nil)
-        (assert false)
-        (catch Exception e
-          (is+ {:out #"illegal start of expression"} (ex-data e)))))))
+      (let [e (try
+                (parse-java (io/resource "orchard/java/InvalidClass.java") nil)
+                nil
+                (catch Exception e e))]
+        (is (some? e) "parse-java should throw on invalid code")
+        (is+ {:out #"illegal start of expression"} (ex-data e)))))))
 
 (when jdk11+?
   (deftest source-info-test

--- a/test/orchard/java/parser_next_test.clj
+++ b/test/orchard/java/parser_next_test.clj
@@ -32,7 +32,7 @@
                 nil
                 (catch Exception e e))]
         (is (some? e) "parse-java should throw on invalid code")
-        (is+ {:out #"illegal start of expression"} (ex-data e)))))))
+        (is+ {:out #"illegal start of expression"} (ex-data e))))))
 
 (when jdk11+?
   (deftest source-info-test

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -44,11 +44,11 @@
   `(do ~@x))
 
 (deftest macroexpand-all-test
-  (is (->> (sut/macroexpand-all '(test-macro ^{:random meta} (hi)))
-           second
-           meta
-           :random
-           (= 'meta))))
+  (is (= 'meta
+         (->> (sut/macroexpand-all '(test-macro ^{:random meta} (hi)))
+              second
+              meta
+              :random))))
 
 (deftest special-sym-meta-test
   (testing "Names are correct for `&`, `catch`, `finally`"

--- a/test/orchard/stacktrace_test.clj
+++ b/test/orchard/stacktrace_test.clj
@@ -306,7 +306,7 @@
                               {:name "clojure.lang.RestFn/invoke"}
                               {:name "don't touch me 2"}
                               {:name "java.lang.Thread/run"}]))
-      "Adds the flag when appropiate, leaving other entries untouched")
+      "Adds the flag when appropriate, leaving other entries untouched")
 
   (let [frames [{:name "don't touch me"}
                 {:name "java.util.concurrent.FutureTask/run"}

--- a/test/orchard/test/util.clj
+++ b/test/orchard/test/util.clj
@@ -29,6 +29,6 @@
    `(is (~'match? ~expected ~actual) ~message)))
 
 (defmacro are*
-  "Like `are` but doesn't wrap test expression is `is`, instead allowing the user to use `is+` or any other assertion code."
+  "Like `are` but doesn't wrap test expression in `is`, instead allowing the user to use `is+` or any other assertion code."
   [argv expr & args]
   `(template/do-template ~argv ~expr ~@args))

--- a/test/orchard/trace_test.clj
+++ b/test/orchard/trace_test.clj
@@ -140,69 +140,6 @@
          (with-out-str-rn (sample-ns/fibo 5))))
 
   (is (= "
-(orchard.trace-test.sample-ns/fibo 5)
-│ 
-│ (orchard.trace-test.sample-ns/fibo 3)
-│ │ 
-│ │ (orchard.trace-test.sample-ns/fibo 1)
-│ │ │ 
-│ │ └─→ 1
-│ │ 
-│ │ (orchard.trace-test.sample-ns/fibo 2)
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 0)
-│ │ │ │ 
-│ │ │ └─→ 1
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 1)
-│ │ │ │ 
-│ │ │ └─→ 1
-│ │ │ 
-│ │ └─→ 2
-│ │ 
-│ └─→ 3
-│ 
-│ (orchard.trace-test.sample-ns/fibo 4)
-│ │ 
-│ │ (orchard.trace-test.sample-ns/fibo 2)
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 0)
-│ │ │ │ 
-│ │ │ └─→ 1
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 1)
-│ │ │ │ 
-│ │ │ └─→ 1
-│ │ │ 
-│ │ └─→ 2
-│ │ 
-│ │ (orchard.trace-test.sample-ns/fibo 3)
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 1)
-│ │ │ │ 
-│ │ │ └─→ 1
-│ │ │ 
-│ │ │ (orchard.trace-test.sample-ns/fibo 2)
-│ │ │ │ 
-│ │ │ │ (orchard.trace-test.sample-ns/fibo 0)
-│ │ │ │ │ 
-│ │ │ │ └─→ 1
-│ │ │ │ 
-│ │ │ │ (orchard.trace-test.sample-ns/fibo 1)
-│ │ │ │ │ 
-│ │ │ │ └─→ 1
-│ │ │ │ 
-│ │ │ └─→ 2
-│ │ │ 
-│ │ └─→ 3
-│ │ 
-│ └─→ 5
-│ 
-└─→ 8
-"
-         (with-out-str-rn (sample-ns/fibo 5))))
-
-  (is (= "
 (orchard.trace-test.sample-ns/fibo2 0 1 10)
 │ 
 │ (orchard.trace-test.sample-ns/fibo2 1 1 9)


### PR DESCRIPTION
Assorted test quality fixes found during a suite-wide audit:

- Replace `assert false` with `is` in parse-java-test (assert can be disabled and doesn't produce proper failure reports)
- Remove duplicate fibo assertion in trace_test (identical call and expected output asserted twice)
- Fix assertion in macroexpand-all-test so failures show expected vs actual instead of just "false"
- Remove orphaned top-level find-symbols call in apropos_test
- Fix typos in are* docstring and stacktrace_test