### PR TITLE
Indent: unwrap (quote ...) around :arglists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - [#386](https://github.com/clojure-emacs/orchard/pull/386): Inspector: rename default view mode for unknown objects to `:object`.
+- [#396](https://github.com/clojure-emacs/orchard/pull/396): Indent: don't crash on `(quote (...))`-wrapped `:arglists` (clojure-emacs/cider#3923).
 - [#397](https://github.com/clojure-emacs/orchard/pull/397): Inspector: add support for diffing sets.
 
 ## 0.41.0 (2026-04-13)

--- a/src/orchard/indent.clj
+++ b/src/orchard/indent.clj
@@ -148,6 +148,20 @@
              'fntail
              'fn-tail]))))
 
+(defn- normalize-arglists
+  "Unwrap a `(quote ...)` wrapper around `arglists`, if present.
+
+  ClojureScript's analyzer preserves `:arglists` as the raw form when it
+  comes from a macro-written macro (i.e. a macro whose body emits
+  `'([x])` for `:arglists` instead of a bare `([x])`).  Most consumers
+  expect the bare seq of arglist vectors, so peel the `quote` off before
+  processing."
+  [arglists]
+  (if (and (seq? arglists)
+           (= 'quote (first arglists)))
+    (second arglists)
+    arglists))
+
 (defn infer-style-indent
   "Given a `metadata` map obtained from a Clojure var object,
   associates a `:style/indent` value based on inference (rule of thumb) rules:
@@ -161,6 +175,6 @@
 
   `:style/indent` will be not associated if no rule matched."
   [{:keys [name arglists] :as metadata}]
-  (let [result (compute-style-indent (str name) arglists)]
+  (let [result (compute-style-indent (str name) (normalize-arglists arglists))]
     (cond-> metadata
       result (assoc :style/indent result))))

--- a/test/orchard/indent_test.clj
+++ b/test/orchard/indent_test.clj
@@ -85,3 +85,27 @@
     '->>         '[[x & forms]]          nil
     'some->      '[[x & forms]]          nil
     'some->>     '[[x & forms]]          nil))
+
+(deftest infer-style-indent-test
+  (testing "unwraps `(quote ...)`-wrapped arglists"
+    ;; ClojureScript's analyzer preserves `:arglists` as the raw form
+    ;; for macro-written macros, so it shows up as `(quote (...))`
+    ;; rather than `(...)`.  See clojure-emacs/cider#3923.
+    (is+ {:name 'with-ctx
+          :arglists '(quote ([ctx & body]))
+          :style/indent 1}
+         (sut/infer-style-indent
+          {:name 'with-ctx
+           :arglists '(quote ([ctx & body]))})))
+
+  (testing "passes through bare arglists unchanged (regression test for the common path)"
+    (is+ {:name 'with-ctx
+          :arglists '([ctx & body])
+          :style/indent 1}
+         (sut/infer-style-indent
+          {:name 'with-ctx
+           :arglists '([ctx & body])})))
+
+  (testing "doesn't crash on metadata without arglists"
+    (is+ {:name 'foo}
+         (sut/infer-style-indent {:name 'foo}))))


### PR DESCRIPTION
Fixes the orchard side of clojure-emacs/cider#3923.

`infer-style-indent` destructures `:arglists` as a list of arglist vectors. ClojureScript's analyzer doesn't always hand it over that way: when `:arglists` comes from a macro-written macro (one whose body emits `'([x])` rather than a bare `([x])` for the arglists meta), the analyzer preserves the raw form including the `quote`. So the value arrives as `(quote ([ctx & body]))` and the destructuring binds the first element of that, which is the symbol `quote`, not a list. `find-idx` then calls `.indexOf` on a symbol and we get a ClassCastException.

The trace from the original issue:

```
java.lang.ClassCastException: class clojure.lang.Symbol cannot be cast to class java.util.List
        at orchard.indent$find_idx.invokeStatic(indent.clj:107)
        at orchard.indent$compute_style_indent.invokeStatic(indent.clj:120)
        at orchard.indent$infer_style_indent.invokeStatic(indent.clj:164)
        at cider.nrepl.middleware.track_state$ns_state$post_process__64337$fn__64338.invoke(track_state.clj:217)
```

This propagates up through cider-nrepl's track-state middleware and tanks `cider/get-state` for the whole connection, which is the user-visible symptom: affected buffers can't link to their REPL session.

The fix peels the `quote` wrapper off in a small `normalize-arglists` helper applied once at the entry point. No change for the common case (bare arglists, no quote wrapper). Tests cover both the unwrapping path and the pass-through.