### PR TITLE
[inspect] Add support for diffing sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 - [#386](https://github.com/clojure-emacs/orchard/pull/386): Inspector: rename default view mode for unknown objects to `:object`.
+- [#397](https://github.com/clojure-emacs/orchard/pull/397): Inspector: add support for diffing sets.
 
 ## 0.41.0 (2026-04-13)
 

--- a/build/main.clj
+++ b/build/main.clj
@@ -85,4 +85,4 @@
   (b/install opts))
 
 ;; To recompile Java class at runtime:
-;; ((requiring-resolve 'virgil/compile-java) ["src"])
+;; ((requiring-resolve 'virgil/compile-java) ["src" "test"])

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -11,6 +11,7 @@
   (:require
    [clojure.core.protocols :refer [datafy nav]]
    [clojure.reflect :as reflect]
+   [clojure.set :as set]
    [clojure.string :as str]
    [orchard.inspect.analytics :as analytics]
    [orchard.java.compatibility :as compat]
@@ -1258,6 +1259,13 @@
          (assoc :view-mode (first (supported-view-modes inspector)))
          inspect-render))))
 
+(declare diff)
+
+(defn- diff-sequences [s1 s2]
+  (let [n (max (count s1) (count s2))]
+    (mapv #(diff (nth s1 % print/nothing) (nth s2 % print/nothing))
+          (range n))))
+
 (defn diff
   "Perform a recursive diff on two values and return a structure suitable to be
   viewed with the inspector."
@@ -1266,10 +1274,7 @@
         (not= (class d1) (class d2)) (print/->Diff d1 d2)
 
         (and (sequential? d1) (sequential? d2))
-        (let [n (max (count d1) (count d2))]
-          (->> (mapv #(diff (nth d1 % print/nothing) (nth d2 % print/nothing))
-                     (range n))
-               print/->DiffColl))
+        (print/->DiffColl (diff-sequences d1 d2))
 
         (and (map? d1) (map? d2))
         (print/->DiffColl
@@ -1278,5 +1283,13 @@
               (mapv (fn [k]
                       [k (diff (get d1 k print/nothing) (get d2 k print/nothing))]))
               (into {})))
+
+        (and (set? d1) (set? d2))
+        (let [common (set/intersection d1 d2)
+              subset1 (vec (set/difference d1 d2))
+              subset2 (vec (set/difference d2 d1))]
+          (print/->DiffColl
+           (-> (into #{} common) ;; If common is a sorted-set, turn into regular.
+               (into (diff-sequences subset1 subset2)))))
 
         :else (print/->Diff d1 d2)))

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -271,6 +271,7 @@
                                      coll))
         (sequential? coll) (mapv #(if (diff-result? %) % nothing)
                                  coll)
+        (set? coll) (set (filter diff-result? coll))
         :else coll))
 
 (defmethod print DiffColl [^DiffColl x, ^Writer w]

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1794,6 +1794,15 @@
            render
            (section "Diff contents")))
 
+  (testing "diff sets"
+    ;; Complicated regexp is used to match because the order of elements in a
+    ;; set is not predictable.
+    (is+ ["  " [:value ":a" pos?] " = " [:value #"#≠#\{((2|3|#±\[1 ~~ 4\]) ?){3}\}" pos?]]
+         (-> (inspect/diff {:a #{1 2 3}} {:a #{2 3 4}})
+             inspect
+             render
+             (section "Diff contents"))))
+
   (testing "in :only-diff mode, render only differing subvalues"
     (is+ {"Diff contents"
           ["  0. " [:value "#≠{:tea/type #±[\"Jinxuan Oolong\" ~~ \"Jinxuan Wulong\"], :aliases #≠[ #±[\"Jinxuan\" ~~ \"金宣\"] #±[ ~~ \"Jinxuan\"]], :temperature #±[80 ~~ 75]}" pos?] [:newline]


### PR DESCRIPTION
Small improvement to inspect-diffing feature. When the differ encounters two sets, it now separately groups equal elements, and then performs random diffs on mismatching elements. Of course, the mismatching part is stochastic, but at least the matching elements don't get flagged as unequal.

<img width="358" height="111" alt="image" src="https://github.com/user-attachments/assets/9fdd7558-b0dd-47b0-b592-05f054e35322" />

---

- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
