### PR TITLE
Add orchard.meta/classify-symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#386](https://github.com/clojure-emacs/orchard/pull/386): Inspector: rename default view mode for unknown objects to `:object`.
 - [#396](https://github.com/clojure-emacs/orchard/pull/396): Indent: don't crash on `(quote (...))`-wrapped `:arglists` (clojure-emacs/cider#3923).
 - [#397](https://github.com/clojure-emacs/orchard/pull/397): Inspector: add support for diffing sets.
+- [#399](https://github.com/clojure-emacs/orchard/pull/399): Add `orchard.meta/classify-symbol` to classify a symbol as a macro, inline-expandable function, special form, or plain function.
 
 ## 0.41.0 (2026-04-13)
 

--- a/src/orchard/meta.clj
+++ b/src/orchard/meta.clj
@@ -178,6 +178,29 @@
                              (catch Exception _ nil)))
           maybe-add-url))))
 
+(defn classify-symbol
+  "Classify `sym`, resolved in `ns`, by what kind of operator it is.
+  Returns one of:
+
+  * `:macro`    - a macro
+  * `:inline`   - a function carrying an `:inline` expander in its metadata
+  * `:special`  - a special form
+  * `:function` - any other resolved var
+
+  Returns nil for symbols that don't resolve (or that resolve to a class).
+  `ns` and `sym` are both symbols; `sym` may be namespace-qualified or aliased,
+  in which case it is resolved the way it would be in `ns`."
+  [ns sym]
+  (if (special-symbol? sym)
+    :special
+    (when-let [v (resolve-var ns sym)]
+      (when (var? v)
+        (let [m (meta v)]
+          (cond
+            (:macro m) :macro
+            (:inline m) :inline
+            :else :function))))))
+
 (declare var-code)
 
 (defn- merge-meta-for-indirect-var*

--- a/test/orchard/meta_test.clj
+++ b/test/orchard/meta_test.clj
@@ -69,6 +69,34 @@
   (testing "Returns nil for unknown symbol"
     (is (nil? (sut/special-sym-meta 'unknown)))))
 
+(deftest classify-symbol-test
+  (testing "classifies macros"
+    (is (= :macro (sut/classify-symbol 'clojure.core 'when)))
+    (is (= :macro (sut/classify-symbol 'clojure.core 'defn))))
+
+  (testing "classifies inline-expandable functions"
+    (is (= :inline (sut/classify-symbol 'clojure.core '+)))
+    (is (= :inline (sut/classify-symbol 'clojure.core 'inc))))
+
+  (testing "classifies special forms"
+    (is (= :special (sut/classify-symbol 'clojure.core 'if)))
+    (is (= :special (sut/classify-symbol 'clojure.core 'let*)))
+    (is (= :special (sut/classify-symbol 'clojure.core 'quote))))
+
+  (testing "classifies plain functions"
+    (is (= :function (sut/classify-symbol 'clojure.core 'map)))
+    (is (= :function (sut/classify-symbol 'clojure.core 'reduce))))
+
+  (testing "returns nil for unresolvable symbols"
+    (is (nil? (sut/classify-symbol 'clojure.core 'no-such-var-here))))
+
+  (testing "returns nil for symbols that resolve to a class"
+    (is (nil? (sut/classify-symbol 'clojure.core 'String))))
+
+  (testing "resolves namespace-qualified symbols"
+    (is (= :macro (sut/classify-symbol 'clojure.core 'clojure.core/when)))
+    (is (= :function (sut/classify-symbol 'clojure.core 'clojure.string/upper-case)))))
+
 (deftest special-sym-meta-without-see-also-test
   (with-redefs [;; do not load documents
                 docs/load-docs-if-not-loaded! (constantly nil)]


### PR DESCRIPTION
Adds `orchard.meta/classify-symbol`, which resolves a symbol in a namespace and reports what kind of operator it is: `:macro`, `:inline` (an inline-expandable function), `:special` (a special form), or `:function`; nil when the symbol doesn't resolve.

This is the resolution primitive behind a new CIDER feature for classifying the sub-forms of a form, so the editor can highlight and navigate between the heads that are macroexpandable. cider-nrepl will expose it through a `cider/classify-symbols` op.