### PR TITLE
Allow consuming trace events programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- [#400](https://github.com/clojure-emacs/orchard/pull/400): Trace: allow structured trace events to be consumed programmatically via `orchard.trace/add-trace-listener`, with `orchard.trace/set-output-mode!` selecting whether output goes to the REPL (`:repl`, the default), to listeners (`:listeners`), or both.
+
 ## 0.42.0 (2026-06-19)
 
 - [#386](https://github.com/clojure-emacs/orchard/pull/386): Inspector: rename default view mode for unknown objects to `:object`.

--- a/src/orchard/trace.clj
+++ b/src/orchard/trace.clj
@@ -45,21 +45,70 @@
              print/*max-total-length* 10000]
      ~@body))
 
+(def ^:private listeners
+  "Set of listener fns, each called with a structured trace event map."
+  (atom #{}))
+
+(def ^:private output-mode
+  "How trace output is delivered: `:repl` (println, the default), `:listeners`
+  (structured events to registered listeners) or `:both`."
+  (atom :repl))
+
+(def ^:private call-id
+  "Counter handing each traced invocation a unique id, pairing its call and
+  return events."
+  (atom 0))
+
+(defn- print-to-repl? []
+  (contains? #{:repl :both} @output-mode))
+
+(defn- emit-events? []
+  (and (contains? #{:listeners :both} @output-mode)
+       (seq @listeners)))
+
+(defn- emit [event]
+  (run! (fn [f] (f event)) @listeners))
+
+(def ^:private max-event-args
+  "Most args to include in a structured trace event before truncating."
+  20)
+
+(defn- event-args
+  "Return up to `max-event-args` printed args, with a trailing \"...\" when
+  there are more.  Bounding the count keeps lazy or infinite arglists (e.g.
+  `(apply f (range))`) from being fully realized."
+  [args]
+  (let [shown (into [] (comp (take max-event-args) (map print/print-str)) args)]
+    (cond-> shown
+      (> (bounded-count (inc max-event-args) args) max-event-args)
+      (conj "..."))))
+
 (defn- trace-fn-call [name f args]
   ;; Good defaults for orchard.print.
-  (limit-printing
-   (println (trace-indent))
-   (println
-    (funcall-to-string (str name) (map print/print-str args)
-                       (trace-indent))))
-  (let [value (binding [*depth* (inc *depth*)]
-                (apply f args))
-        res-prefix "└─→ "]
+  (let [repl? (print-to-repl?)
+        events? (emit-events?)
+        id (when events? (swap! call-id inc))
+        depth *depth*
+        sname (str name)]
     (limit-printing
-     (binding [*depth* (inc *depth*)]
-       (println (trace-indent)))
-     (println (str (trace-indent) res-prefix (print/print-str value))))
-    value))
+     (when repl?
+       (println (trace-indent))
+       (println (funcall-to-string sname (map print/print-str args)
+                                   (trace-indent))))
+     (when events?
+       (emit {:id id :phase :call :name sname :depth depth
+              :args (event-args args)})))
+    (let [value (binding [*depth* (inc *depth*)]
+                  (apply f args))]
+      (limit-printing
+       (when repl?
+         (binding [*depth* (inc *depth*)]
+           (println (trace-indent)))
+         (println (str (trace-indent) "└─→ " (print/print-str value))))
+       (when events?
+         (emit {:id id :phase :return :name sname :depth depth
+                :value (print/print-str value)})))
+      value)))
 
 (defn- resolve-var ^clojure.lang.Var [v]
   (if (var? v) v (resolve v)))
@@ -68,6 +117,35 @@
 
 (def ^:private traced-vars (atom #{}))
 (def ^:private traced-nses (atom #{}))
+
+(defn add-trace-listener
+  "Register F to be called with each structured trace event, and return F.
+  An event is a map with keys `:id`, `:phase` (`:call` or `:return`), `:name`,
+  `:depth`, and either `:args` (on `:call`) or `:value` (on `:return`); `:id`
+  pairs a call with its return.  Events are only produced when the output mode
+  includes `:listeners` (see `set-output-mode!`)."
+  [f]
+  (swap! listeners conj f)
+  f)
+
+(defn remove-trace-listener
+  "Remove a previously registered trace listener F."
+  [f]
+  (swap! listeners disj f)
+  nil)
+
+(defn set-output-mode!
+  "Set how trace output is delivered.
+  MODE is `:repl` (println to `*out*`, the default), `:listeners` (structured
+  events to the fns registered with `add-trace-listener`) or `:both`."
+  [mode]
+  {:pre [(contains? #{:repl :listeners :both} mode)]}
+  (reset! output-mode mode))
+
+(defn current-output-mode
+  "Return the current trace output mode."
+  []
+  @output-mode)
 
 (defn traceable?
   "Return true if the given var can be traced."

--- a/test/orchard/trace_test.clj
+++ b/test/orchard/trace_test.clj
@@ -1,7 +1,7 @@
 (ns orchard.trace-test
   (:require
    [clojure.edn]
-   [clojure.test :as t :refer [is are deftest]]
+   [clojure.test :as t :refer [is are deftest testing]]
    [orchard.test.util :refer [with-out-str-rn]]
    [orchard.trace :as sut]
    [orchard.trace-test.sample-ns :as sample-ns]))
@@ -196,3 +196,44 @@
   (sut/trace-var* 'orchard.trace-test/function-that-prints)
   (is (map? (function-that-prints))
       "Map is read back correctly, so it was printed in full."))
+
+(deftest trace-listener-test
+  ;; Earlier tests may leave the sample namespace traced; start from a clean
+  ;; slate so only `bar` is wrapped and exactly its two events show up.
+  (sut/untrace-all)
+  (testing ":listeners mode emits structured events instead of printing"
+    (let [events   (atom [])
+          listener (fn [e] (swap! events conj e))]
+      (sut/set-output-mode! :listeners)
+      (sut/add-trace-listener listener)
+      (sut/trace-var* #'sample-ns/bar)
+      (try
+        (let [out (with-out-str-rn (sample-ns/bar arg1))]
+          (is (= "" out) "nothing is printed in :listeners mode")
+          (is (= 2 (count @events)))
+          (let [[call ret] @events]
+            (is (= :call (:phase call)))
+            (is (= :return (:phase ret)))
+            (is (= "orchard.trace-test.sample-ns/bar" (:name call) (:name ret)))
+            (is (= (:id call) (:id ret)) "call and return share an id")
+            (is (= 0 (:depth call)))
+            (is (= 1 (count (:args call))))
+            (is (every? string? (:args call)))
+            (is (string? (:value ret)))
+            (is (re-find #"hello" (:value ret)))))
+        (finally
+          (sut/remove-trace-listener listener)
+          (sut/untrace-var* #'sample-ns/bar)
+          (sut/set-output-mode! :repl)))))
+
+  (testing "the default :repl mode emits no events"
+    (let [events   (atom [])
+          listener (fn [e] (swap! events conj e))]
+      (sut/add-trace-listener listener)
+      (sut/trace-var* #'sample-ns/bar)
+      (try
+        (sample-ns/bar arg1)
+        (is (empty? @events))
+        (finally
+          (sut/remove-trace-listener listener)
+          (sut/untrace-var* #'sample-ns/bar))))))


### PR DESCRIPTION
First step of giving CIDER a dedicated trace buffer (clojure-emacs/cider, Tier 2 of the enlighten/tracing audit).

Tracing only ever printed a formatted call tree to `*out*`, which is hard to build a UI on. This adds a listener registry so trace events can be consumed programmatically:

- `add-trace-listener`/`remove-trace-listener` - register a fn that gets a structured event per call and per return. Events are paired by `:id` and carry `:name`, `:depth`, and `:args` (on `:call`) or `:value` (on `:return`).
- `set-output-mode!` - choose whether output goes to the REPL (`:repl`, the default), to listeners (`:listeners`), or `:both`.

The REPL path is unchanged and remains the default, so existing tracing behaves exactly as before. Event args are bounded the same way the printed path already bounds them, so tracing a fn called with a lazy/infinite arglist (e.g. `(apply f (range))`) can't blow up the heap.

cider-nrepl will register a listener and stream these events to a `*cider-trace*` buffer once this is released.
