### PR TITLE
Add protocol-impls and multimethod-dispatch-values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- [#401](https://github.com/clojure-emacs/orchard/pull/401): Add `orchard.xref/protocol-impls` (the types implementing a protocol, including inline `defrecord`/`deftype` implementers, with source locations) and `orchard.xref/multimethod-dispatch-values`.
 - [#400](https://github.com/clojure-emacs/orchard/pull/400): Trace: allow structured trace events to be consumed programmatically via `orchard.trace/add-trace-listener`, with `orchard.trace/set-output-mode!` selecting whether output goes to the REPL (`:repl`, the default), to listeners (`:listeners`), or both.
 
 ## 0.42.0 (2026-06-19)

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -120,3 +120,65 @@
   (let [var (as-var var)
         all-vars (doall (q/vars {:ns-query {:project? true} :private? true}))]
     (filterv (fn [v2] (contains? (fn-deps v2) var)) all-vars)))
+
+;;; Protocol and multimethod implementations
+
+(defn- cached-classes
+  "Return the classes currently held in Clojure's `DynamicClassLoader` cache."
+  []
+  (let [acc (volatile! (transient []))]
+    (.forEach class-cache
+              (reify BiConsumer
+                (accept [_ _k v]
+                  (when-let [c (.get ^Reference v)]
+                    (when (class? c)
+                      (vswap! acc conj! c))))))
+    (persistent! @acc)))
+
+(defn- class->location
+  "Best-effort source location for the Clojure type named `class-name`.
+  Records and types expose a `->Name` factory var that carries :file/:line; we
+  go through it because the class object itself doesn't keep that metadata.
+  Returns a map with :file/:line/:column, or nil for Java classes and the like."
+  [^String class-name]
+  (when-let [dot (str/last-index-of class-name ".")]
+    (let [ns-part (clojure.lang.Compiler/demunge (subs class-name 0 dot))
+          tname (subs class-name (inc dot))
+          factory (try (resolve (symbol ns-part (str "->" tname)))
+                       (catch Throwable _ nil))]
+      (when factory
+        (not-empty (select-keys (meta factory) [:file :line :column]))))))
+
+(defn protocol-impls
+  "Return the implementations of protocol `p` (a protocol var or its value).
+  Covers both `extend`/`extend-type`/`extend-protocol` targets and inline
+  `defrecord`/`deftype` implementers - the latter found by scanning loaded
+  classes for the protocol's generated interface.  Each entry is a map with
+  :name and, when resolvable, :file/:line/:column.  Only loaded code is visible."
+  {:added "0.43"}
+  [p]
+  (let [proto (if (var? p) (deref p) p)
+        ^Class iface (:on-interface proto)
+        extend-names (map #(.getName ^Class %) (extenders proto))
+        inline-names (keep (fn [^Class c]
+                             (let [n (.getName c)]
+                               (when (and (not (identical? c iface))
+                                          (not (str/starts-with? n "compile__stub."))
+                                          ;; skip reify/anonymous classes
+                                          (not (str/includes? n "$"))
+                                          (.isAssignableFrom iface c))
+                                 n)))
+                           (cached-classes))]
+    (->> (distinct (concat extend-names inline-names))
+         (map (fn [n] (merge {:name n} (class->location n))))
+         (sort-by :name)
+         vec)))
+
+(defn multimethod-dispatch-values
+  "Return the dispatch values of multimethod `m` (a var or a `MultiFn`).
+  Each value is rendered with `pr-str`.  Per-`defmethod` source locations are
+  not available at runtime, so none are included."
+  {:added "0.43"}
+  [m]
+  (let [mf (if (var? m) (deref m) m)]
+    (->> (methods mf) keys (map pr-str) sort vec)))

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -108,3 +108,37 @@
   (testing "that usage from inside an anonymous function is found"
     (is+ (mc/embeds [#'orchard.xref-test/dummy-fn])
          (xref/fn-refs #'fn-dep))))
+
+;;; Protocol and multimethod implementations
+
+(defprotocol TestShape
+  (test-area [_]))
+
+(defrecord TestSquare [side]
+  TestShape
+  (test-area [_] (* side side)))
+
+(extend-type String
+  TestShape
+  (test-area [s] (count s)))
+
+(defmulti test-describe :kind)
+(defmethod test-describe :circle [_] "circle")
+(defmethod test-describe :square [_] "square")
+
+(deftest protocol-impls-test
+  (let [impls (xref/protocol-impls #'TestShape)
+        names (set (map :name impls))]
+    (testing "includes extend-type targets"
+      (is (contains? names "java.lang.String")))
+    (testing "includes inline defrecord implementers"
+      (is (contains? names "orchard.xref_test.TestSquare")))
+    (testing "resolves a source location for a record implementer"
+      (is+ {:name "orchard.xref_test.TestSquare"
+            :file string?
+            :line number?}
+           (first (filter #(= "orchard.xref_test.TestSquare" (:name %)) impls))))))
+
+(deftest multimethod-dispatch-values-test
+  (is+ [":circle" ":square"]
+       (xref/multimethod-dispatch-values #'test-describe)))


### PR DESCRIPTION
The foundational piece for a "who-implements" feature in CIDER (clojure-emacs/cider#1969, whose original design sketch called for exactly this middleware).

`orchard.xref/protocol-impls` returns the types implementing a protocol. It covers both `extend`/`extend-type`/`extend-protocol` targets (via `extenders`) and inline `defrecord`/`deftype` implementers - the latter found by scanning the loaded-class cache for the protocol's generated interface (the same `DynamicClassLoader` cache `fn-deps` already uses). Each entry carries a source location when one is resolvable (records/types expose it through their `->Name` factory var; Java targets have none).

`orchard.xref/multimethod-dispatch-values` returns a multimethod's dispatch values.

Only loaded code is visible, consistent with the rest of `orchard.xref`. Per-`defmethod` source locations aren't included - those methods are anonymous fns with no runtime metadata, so they'd need bytecode line-table reading; that's left for a follow-up.