### PR TITLE
Add type-protocols and protocols-with-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+- [#402](https://github.com/clojure-emacs/orchard/pull/402): Add `orchard.xref/type-protocols` (the protocols a type implements, both `extend`-style and inline) and `orchard.xref/protocols-with-method` (the protocols declaring a method of a given name).
 - [#401](https://github.com/clojure-emacs/orchard/pull/401): Add `orchard.xref/protocol-impls` (the types implementing a protocol, including inline `defrecord`/`deftype` implementers, with source locations) and `orchard.xref/multimethod-dispatch-values`.
 - [#400](https://github.com/clojure-emacs/orchard/pull/400): Trace: allow structured trace events to be consumed programmatically via `orchard.trace/add-trace-listener`, with `orchard.trace/set-output-mode!` selecting whether output goes to the REPL (`:repl`, the default), to listeners (`:listeners`), or both.
 

--- a/src/orchard/xref.clj
+++ b/src/orchard/xref.clj
@@ -182,3 +182,41 @@
   [m]
   (let [mf (if (var? m) (deref m) m)]
     (->> (methods mf) keys (map pr-str) sort vec)))
+
+(defn- protocol-map?
+  "True when `val` is a protocol map.
+  Defensive: a keyword lookup on a sorted map with non-keyword keys throws, so
+  guard the access - any var in any loaded namespace can hold such a value."
+  [val]
+  (boolean (and (map? val)
+                (try (:on-interface val) (catch Throwable _ nil)))))
+
+(defn- loaded-protocols
+  "Return a seq of [protocol-var protocol-map] for every loaded protocol."
+  []
+  (for [ns (all-ns)
+        [_ v] (ns-publics ns)
+        :let [val (try (deref v) (catch Throwable _ nil))]
+        :when (protocol-map? val)]
+    [v val]))
+
+(defn type-protocols
+  "Return the protocol vars implemented by class `c`.
+  Covers both `extend`/`extend-type`/`extend-protocol` and inline
+  `defrecord`/`deftype` implementations.  Only loaded code is visible."
+  {:added "0.43"}
+  [c]
+  (when (class? c)
+    (vec (for [[v proto] (loaded-protocols)
+               :when (or (extends? proto c)
+                         (.isAssignableFrom ^Class (:on-interface proto) ^Class c))]
+           v))))
+
+(defn protocols-with-method
+  "Return the protocol vars declaring a method named `method-name` (a string).
+  Only loaded code is visible."
+  {:added "0.43"}
+  [method-name]
+  (vec (for [[v proto] (loaded-protocols)
+             :when (some #(= method-name (name %)) (keys (:sigs proto)))]
+         v)))

--- a/test/orchard/xref_test.clj
+++ b/test/orchard/xref_test.clj
@@ -142,3 +142,17 @@
 (deftest multimethod-dispatch-values-test
   (is+ [":circle" ":square"]
        (xref/multimethod-dispatch-values #'test-describe)))
+
+(deftest type-protocols-test
+  (testing "finds a protocol implemented inline by a defrecord"
+    (is (contains? (set (xref/type-protocols TestSquare)) #'TestShape)))
+  (testing "finds a protocol extended onto an existing class"
+    (is (contains? (set (xref/type-protocols String)) #'TestShape)))
+  (testing "returns nil for a non-class argument"
+    (is (nil? (xref/type-protocols nil)))))
+
+(deftest protocols-with-method-test
+  (testing "finds protocols declaring a method of the given name"
+    (is (contains? (set (xref/protocols-with-method "test-area")) #'TestShape)))
+  (testing "returns an empty result for an unknown method name"
+    (is (empty? (xref/protocols-with-method "no-such-method-xyzzy")))))


### PR DESCRIPTION
Follow-on to #401, backing the reverse-lookup and method-search protocol commands in CIDER.

- `orchard.xref/type-protocols` returns the protocols a class implements - both `extend`/`extend-type`/`extend-protocol` and inline `defrecord`/`deftype` (found by testing each loaded protocol's interface).
- `orchard.xref/protocols-with-method` returns the protocols whose `:sigs` declare a method of the given name.

Both scan the loaded protocols, so only loaded code is visible - consistent with the rest of `orchard.xref`.