### PR TITLE
Add tests for util.io, java.compatibility and the cljs.meta pure fns

### DIFF
--- a/test/orchard/cljs/meta_test.clj
+++ b/test/orchard/cljs/meta_test.clj
@@ -1,0 +1,54 @@
+(ns orchard.cljs.meta-test
+  "JVM-side tests for the pure normalization functions of `orchard.cljs.meta`.
+  See test-cljs/orchard/cljs/meta_test.cljc for the ClojureScript variant."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [orchard.cljs.meta :as cljs-meta]))
+
+(deftest unquote-1-test
+  (is (= [1 2 3] (cljs-meta/unquote-1 '(quote [1 2 3]))))
+  (is (= [1 2 3] (cljs-meta/unquote-1 [1 2 3])))
+  (is (= nil (cljs-meta/unquote-1 nil))))
+
+(deftest normalize-ns-file-test
+  (testing "takes the file of the first def when present"
+    (is (= "orchard/fake.cljs"
+           (cljs-meta/normalize-ns-file {:defs {'x {:file "orchard/fake.cljs"}}}))))
+  (testing "falls back to the canonical source of the namespace"
+    (is (str/ends-with? (cljs-meta/normalize-ns-file {:name 'orchard.cljs.meta})
+                        "orchard/cljs/meta.cljc"))))
+
+(deftest normalize-ns-meta-test
+  (is (= {:doc "docstring"
+          :author "someone"
+          :file "orchard/fake.cljs"
+          :line 1
+          :name 'orchard.fake
+          :ns 'orchard.fake}
+         (cljs-meta/normalize-ns-meta
+          {:name 'orchard.fake
+           :doc "docstring"
+           :author "someone"
+           :extraneous :key
+           :defs {'x {:file "orchard/fake.cljs"}}}))))
+
+(deftest normalize-var-meta-test
+  (is (= '{:name foo, :arglists ([x] [x y])}
+         (cljs-meta/normalize-var-meta '{:name foo, :arglists (quote ([x] [x y]))}))))
+
+(deftest normalize-macro-meta-test
+  (let [normalized (cljs-meta/normalize-macro-meta
+                    '{:name my-macro
+                      :ns cljs.fake
+                      :file "cljs/fake.cljc"
+                      :arglists (quote ([x]))
+                      :meta {:file "wrong/file.cljc", :doc "docstring"}})]
+    (testing ":file, :ns and :name win over the nested :meta"
+      (is (= "cljs/fake.cljc" (:file normalized)))
+      (is (= 'cljs.fake (:ns normalized)))
+      (is (= 'my-macro (:name normalized))))
+    (testing "the nested :meta map is merged in"
+      (is (= "docstring" (:doc normalized))))
+    (testing "arglists are unquoted"
+      (is (= '([x]) (:arglists normalized))))))

--- a/test/orchard/java/compatibility_test.clj
+++ b/test/orchard/java/compatibility_test.clj
@@ -1,0 +1,44 @@
+(ns orchard.java.compatibility-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [orchard.java.compatibility :as compat]
+   [orchard.misc :as misc])
+  (:import
+   (orchard.java PrivateFieldClass)))
+
+;; The module-system behavior only exists on JDK11+; on JDK8 `module-name`
+;; always returns nil, `is-in-boot-module?` is always falsy and JDK-internal
+;; fields are freely accessible, so those tests are gated.
+
+(when (>= misc/java-api-version 11)
+  (deftest module-name-test
+    (testing "JDK classes report the module they belong to"
+      (is (= "java.base" (compat/module-name String)))
+      (is (= "java.sql" (compat/module-name java.sql.Connection))))
+    (testing "symbols are resolved to classes"
+      (is (= "java.base" (compat/module-name 'java.lang.String))))
+    (testing "classpath classes live in the unnamed module which has no name"
+      (is (nil? (compat/module-name PrivateFieldClass)))
+      (is (nil? (compat/module-name clojure.lang.PersistentVector)))))
+
+  (deftest is-in-boot-module?-test
+    (testing "java.base classes belong to the boot module layer"
+      (is (true? (compat/is-in-boot-module? String)))
+      (is (true? (compat/is-in-boot-module? java.util.List))))
+    (testing "classpath classes don't"
+      (is (false? (compat/is-in-boot-module? PrivateFieldClass)))
+      (is (false? (compat/is-in-boot-module? clojure.lang.PersistentVector)))))
+
+  (deftest access-denied-test
+    (testing "returns ::access-denied for inaccessible JDK internals"
+      (let [field (.getDeclaredField String "value")]
+        (is (= ::compat/access-denied
+               (compat/get-field-value field "hello")))))))
+
+(deftest get-field-value-test
+  (testing "reads private fields of classpath classes"
+    (let [field (.getDeclaredField PrivateFieldClass "age")]
+      (is (= 42 (compat/get-field-value field (PrivateFieldClass. 42))))))
+  (testing "reads accessible public fields"
+    (let [field (.getField Integer "MAX_VALUE")]
+      (is (= Integer/MAX_VALUE (compat/get-field-value field nil))))))

--- a/test/orchard/util/io_test.clj
+++ b/test/orchard/util/io_test.clj
@@ -1,0 +1,83 @@
+(ns orchard.util.io-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [orchard.util.io :as util.io])
+  (:import
+   (java.io File)
+   (java.net URI)))
+
+(def ^File project-file
+  "A file that lives in the project directory (where the tests run)."
+  (.getCanonicalFile (io/file "deps.edn")))
+
+(def ^File temp-file
+  "A file that lives outside of the project directory."
+  (doto (File/createTempFile "orchard-util-io" ".txt")
+    (.deleteOnExit)))
+
+(defn- jar-resource
+  "A resource URL that points inside a jar file."
+  ^java.net.URL []
+  (io/resource "clojure/core.clj"))
+
+(deftest file-in-project?-test
+  (testing "accepts Strings, Files and Paths under the working directory"
+    (is (true? (util.io/file-in-project? project-file)))
+    (is (true? (util.io/file-in-project? (str project-file))))
+    (is (true? (util.io/file-in-project? (.toPath project-file)))))
+  (testing "returns false for files outside of the working directory"
+    (is (false? (util.io/file-in-project? (.getCanonicalFile temp-file))))
+    (is (false? (util.io/file-in-project? (io/file "/"))))))
+
+(deftest relativize-project-path-test
+  (is (= "deps.edn" (util.io/relativize-project-path project-file)))
+  (is (= (str (io/file "src" "orchard" "util" "io.clj"))
+         (util.io/relativize-project-path
+          (.getCanonicalFile (io/file "src/orchard/util/io.clj"))))))
+
+(deftest url-protocol-test
+  (is (= "file" (util.io/url-protocol (io/as-url project-file))))
+  (is (= "jar" (util.io/url-protocol (jar-resource))))
+  (is (= "http" (util.io/url-protocol (.toURL (URI. "http://example.com/"))))))
+
+(deftest direct-url-to-file?-test
+  (is (util.io/direct-url-to-file? (io/as-url project-file)))
+  (is (not (util.io/direct-url-to-file? (jar-resource)))))
+
+(deftest resource-jarfile-test
+  (testing "returns the jar file containing the resource"
+    (let [jar-file (util.io/resource-jarfile (jar-resource))]
+      (is (instance? File jar-file))
+      (is (.exists ^File jar-file))
+      (is (str/ends-with? (str jar-file) ".jar"))))
+  (testing "asserts that the URL uses the jar: protocol"
+    (is (thrown? AssertionError
+                 (util.io/resource-jarfile (io/as-url project-file))))))
+
+(deftest resource-artifact-test
+  (testing "file: URLs return the file itself"
+    (is (= project-file
+           (util.io/resource-artifact (io/as-url project-file)))))
+  (testing "jar: URLs return the containing jar"
+    (let [artifact (util.io/resource-artifact (jar-resource))]
+      (is (.exists ^File artifact))
+      (is (str/ends-with? (str artifact) ".jar"))))
+  (testing "other protocols throw"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"can't be situated on the filesystem"
+                          (util.io/resource-artifact
+                           (.toURL (URI. "http://example.com/")))))))
+
+(deftest last-modified-time-test
+  (testing "Files report their own modification time"
+    (is (= (.lastModified temp-file)
+           (util.io/last-modified-time temp-file)))
+    (is (pos? (util.io/last-modified-time temp-file))))
+  (testing "file: URLs report the modification time of the file"
+    (is (= (.lastModified project-file)
+           (util.io/last-modified-time (io/as-url project-file)))))
+  (testing "jar: URLs report the modification time of the containing jar"
+    (is (= (.lastModified ^File (util.io/resource-jarfile (jar-resource)))
+           (util.io/last-modified-time (jar-resource))))))


### PR DESCRIPTION
These three namespaces had no direct coverage.  The module-system
assertions are gated on JDK11+, since on JDK8 module-name returns nil
and JDK-internal fields are freely accessible.
