### PR TITLE
[inspector] Truncate wide columns in table mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#406](https://github.com/clojure-emacs/orchard/pull/406): Inspector: remove Datafy section.
 - [#408](https://github.com/clojure-emacs/orchard/pull/408): Inspector: render ARef contents fully.
+- [#409](https://github.com/clojure-emacs/orchard/pull/409): Inspector: truncate wide columns in table mode.
 
 ## 0.43.0 (2026-06-24)
 

--- a/src/mx/cider/orchard/TruncatingStringWriter.java
+++ b/src/mx/cider/orchard/TruncatingStringWriter.java
@@ -19,10 +19,10 @@ public class TruncatingStringWriter extends StringWriter {
 
     public TruncatingStringWriter(int singleWriteLimit, int totalLimit) {
         super();
-        if (singleWriteLimit < 5) {
+        if (singleWriteLimit < 2) {
             throw new IllegalArgumentException("Bad singleWriteLimit: " + singleWriteLimit);
         }
-        if (totalLimit < 10) {
+        if (totalLimit < 5) {
             throw new IllegalArgumentException("Bad totalLimit: " + totalLimit);
         }
         this.singleWriteLimit = singleWriteLimit;
@@ -45,46 +45,43 @@ public class TruncatingStringWriter extends StringWriter {
         }
     }
 
-    @Override
-    public void write(char[] cbuf, int off, int len) {
+    private void superWriteStringOrChars(Object stringOrChars, int off, int len) {
+        if (stringOrChars instanceof String)
+            super.write((String)stringOrChars, off, len);
+        else
+            super.write((char[])stringOrChars, off, len);
+    }
+
+    private void writeStringOrChars(Object stringOrChars, int off, int len) {
         boolean singleTooBig = (len > singleWriteLimit);
         len = Math.min(len, singleWriteLimit);
         if (len <= totalLimit) {
-            super.write(cbuf, off, len);
+            superWriteStringOrChars(stringOrChars, off, len);
             totalLimit -= len;
             if (singleTooBig)
                 writeEllipsis();
         } else {
             if (totalLimit >= 0) {
-                super.write(cbuf, off, totalLimit);
+                superWriteStringOrChars(stringOrChars, off, totalLimit);
                 totalLimit = 0;
                 writeEllipsis();
             }
             throw new TotalLimitExceeded();
         }
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) {
+        writeStringOrChars(cbuf, off, len);
     }
 
     @Override
     public void write(String str) {
-        this.write(str, 0, str.length());
+        writeStringOrChars(str, 0, str.length());
     }
 
     @Override
     public void write(String str, int off, int len) {
-        boolean singleTooBig = (len > singleWriteLimit);
-        len = Math.min(len, singleWriteLimit);
-        if (len <= totalLimit) {
-            super.write(str, off, len);
-            totalLimit -= len;
-            if (singleTooBig)
-                writeEllipsis();
-        } else {
-            if (totalLimit >= 0) {
-                super.write(str, off, totalLimit);
-                totalLimit = 0;
-                writeEllipsis();
-            }
-            throw new TotalLimitExceeded();
-        }
+        writeStringOrChars(str, off, len);
     }
 }

--- a/src/orchard/inspect.clj
+++ b/src/orchard/inspect.clj
@@ -43,6 +43,7 @@
   {:page-size        32      ; = Clojure's default chunked sequences chunk size.
    :max-atom-length  150
    :max-value-length 10000   ; To avoid printing huge graphs and Exceptions.
+   :table-column-width 70
    :max-coll-size    5
    :max-nested-depth nil
    :analytics-size-cutoff  100000
@@ -62,6 +63,10 @@
   [{:keys [indentation pretty-print]} value]
   (if pretty-print
     (pp/pprint-str value {:indentation (or indentation 0)})
+    (print/print-str value)))
+
+(defn- print-str-truncated [value char-limit]
+  (binding [print/*max-total-length* char-limit]
     (print/print-str value)))
 
 (defn- array? [obj]
@@ -493,6 +498,7 @@
 (defn- render-chunk-as-table [inspector chunk idx-starts-from]
   (let [m-i map-indexed
         fst (first chunk)
+        width (:table-column-width inspector)
         ;; If items are maps, use map keys as keys. Otherwise assume items are
         ;; lists/vectors, so we use indices as keys.
         getter (if (map? fst) get nth)
@@ -503,9 +509,8 @@
                       (m-i (fn [i row]
                              (let [i (+ i idx-starts-from)]
                                (into [[i (str i)]]
-                                     (map (fn [k]
-                                            (let [v (getter row k)]
-                                              [v (print/print-str v)])))
+                                     (map #(let [v (getter row %)]
+                                             [v (print-str-truncated v width)]))
                                      ks))))
                       chunk)
         pr-ks (into [["#" "#"]] (map (fn [k] [k (print/print-str k)])) ks)

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -1096,6 +1096,18 @@
              render
              group-sections)))
 
+  (testing "wide columns are truncated"
+    (is+ ["  | " [:value "#" pos?] " |       " [:value ":a" pos?] " |      " [:value ":bb" pos?] " | " [:newline]
+          "  |---+----------+----------|" [:newline]
+          "  | " [:value "0" pos?] " | " [:value "\"aaaa..." pos?] " | " [:value "\"bbbb..." pos?] " | " [:newline]
+          "  | " [:value "1" pos?] " | " [:value "\"aaaa..." pos?] " | " [:value "\"bbbb..." pos?] " | " [:newline]
+          "  | " [:value "2" pos?] " | " [:value "\"aaaa..." pos?] " | " [:value "\"bbbb..." pos?] " | "]
+         (-> (repeat 3 {:a "aaaaaaaaaa", :bb "bbbbbbbbb"})
+             (inspect {:table-column-width 5})
+             (inspect/set-view-mode :table)
+             render
+             (contents-section))))
+
   (testing "in :table view-mode lists of vectors are rendered as tables"
     (is+ {"Contents"
           ["  | " [:value "#" pos?] " |  " [:value "0" pos?] " |     "


### PR DESCRIPTION
Limiting column width in table view-mode improves the usability of the latter. Most of the time, I want the table mode for a list of large maps, and then each row becomes so wide that I don't really have a table.

The value of 70 is arbitrary; in practice, it is easier for me to zoom out the buffer with `C-x C--` than customize the width. For now, I am not adding specialized commands to change this parameter; maybe, in the future, CIDER will have that as a customizable.

Some minor improvements to TSW, nothing big.

---

- [x] You've added tests to cover your changes.
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
