### PR TITLE
Keep CHANGELOG concise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ## 0.43.0 (2026-06-24)
 
-- [#402](https://github.com/clojure-emacs/orchard/pull/402): Add `orchard.xref/type-protocols` (the protocols a type implements, both `extend`-style and inline) and `orchard.xref/protocols-with-method` (the protocols declaring a method of a given name).
-- [#401](https://github.com/clojure-emacs/orchard/pull/401): Add `orchard.xref/protocol-impls` (the types implementing a protocol, including inline `defrecord`/`deftype` implementers, with source locations) and `orchard.xref/multimethod-dispatch-values`.
-- [#400](https://github.com/clojure-emacs/orchard/pull/400): Trace: allow structured trace events to be consumed programmatically via `orchard.trace/add-trace-listener`, with `orchard.trace/set-output-mode!` selecting whether output goes to the REPL (`:repl`, the default), to listeners (`:listeners`), or both.
+- [#402](https://github.com/clojure-emacs/orchard/pull/402): Xref: add `orchard.xref/type-protocols` and `orchard.xref/protocols-with-method`.
+- [#401](https://github.com/clojure-emacs/orchard/pull/401): Xref: add `orchard.xref/protocol-impls` and `orchard.xref/multimethod-dispatch-values`.
+- [#400](https://github.com/clojure-emacs/orchard/pull/400): Trace: add structured trace events and API for their consumption.
 
 ## 0.42.0 (2026-06-19)
 


### PR DESCRIPTION
Skimming the changelog becomes very hard with all the AI-generated prose. What do you say we maintain the brevity here? All the details details are in the PR anyway.