### PR TITLE
[print] Honor custom print-method for records and Java collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#413](https://github.com/clojure-emacs/orchard/pull/413): Print: protect against StackOverflow when printing recursive collections.
 - [#416](https://github.com/clojure-emacs/orchard/pull/416): Inspector: add string analytics.
+- [#415](https://github.com/clojure-emacs/orchard/pull/415): Print: honor a custom `print-method` for records and collections instead of traversing them structurally.
 
 ## 0.44.0 (2026-07-04)
 

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -16,8 +16,83 @@
                  RT Symbol TaggedLiteral Var)
    (java.io Writer)
    (java.util Iterator List Map Map$Entry)
+   (java.util.concurrent ConcurrentHashMap)
    (mx.cider.orchard TruncatingStringWriter
                      TruncatingStringWriter$TotalLimitExceeded)))
+
+(def ^:private structural-print-interfaces
+  "The generic collection interfaces that orchard prints structurally on its
+  own.  A value whose `print-method` resolves to one of their implementations
+  has no custom representation (see `custom-print-method?`)."
+  [clojure.lang.IPersistentMap clojure.lang.IPersistentSet
+   clojure.lang.IPersistentVector clojure.lang.IRecord clojure.lang.ISeq
+   java.util.List java.util.Map java.util.RandomAccess java.util.Set])
+
+(deftype PrintMethodCache [table prefers structural ^ConcurrentHashMap classes])
+
+(def ^:private print-method-cache
+  "Caches per class whether it has a custom `print-method` (see
+  `custom-print-method?`).  The whole cache is dropped whenever `print-method`
+  gains or loses implementations or preferences, so re-registering a method -
+  e.g. when reloading a namespace - can't leave stale results behind."
+  (atom nil))
+
+(defn- current-print-method-cache
+  "Return the up-to-date cache, rebuilding it if `print-method`'s method or
+  preference tables have changed since it was built."
+  ^PrintMethodCache []
+  (let [table (methods print-method)
+        prefs (prefers print-method)
+        ^PrintMethodCache cache @print-method-cache]
+    (if (and cache
+             (identical? table (.-table cache))
+             (identical? prefs (.-prefers cache)))
+      cache
+      ;; A thread caching into a cache that is being replaced is harmless: it
+      ;; writes into an object that no one will look at again.
+      (reset! print-method-cache
+              (PrintMethodCache. table prefs
+                                 (into #{}
+                                       (keep #(get-method print-method %))
+                                       structural-print-interfaces)
+                                 (ConcurrentHashMap.))))))
+
+(defn- custom-print-method?
+  "True if `x` has a `print-method` more specific than the generic collection
+  implementations - i.e. a deliberate custom textual representation that orchard
+  should use instead of traversing the value's structure.  This keeps records
+  and collections that define their own `print-method` (e.g. `tech.ml.dataset`
+  datasets) rendered as intended, and avoids descending into - and potentially
+  looping on - such objects' internals."
+  [x]
+  (let [c (class x)
+        cache (current-print-method-cache)
+        ^ConcurrentHashMap classes (.-classes cache)
+        cached (.get classes c)]
+    (if (some? cached)
+      cached
+      (let [v (if-let [m (try (get-method print-method c)
+                              ;; get-method throws when several implementations
+                              ;; match `c` and none is preferred.  Print such
+                              ;; values structurally.
+                              (catch Exception _ nil))]
+                (not (contains? (.-structural cache) m))
+                false)]
+        (.put classes c v)
+        v))))
+
+(defn- structural-tag
+  "Return the `print` dispatch value for the collection types that orchard
+  prints structurally, nil for other types.  Clojure maps implement
+  java.util.Map, so the Map clause covers them too.  Don't add an
+  IPersistentMap clause here: the :map printer requires java.util.Map, so
+  IPersistentMap-only types must keep falling through to :default."
+  [x]
+  (cond (instance? IRecord x)           :record
+        (instance? Map x)               :map
+        (instance? IPersistentVector x) :vector
+        (instance? List x)              :list
+        (instance? IPersistentSet x)    :set))
 
 (defmulti print
   (fn [x _]
@@ -30,11 +105,11 @@
       (instance? Number x)            :scalar
       (instance? Symbol x)            :scalar
       (instance? Keyword x)           :keyword
-      (instance? IRecord x)           :record
-      (instance? Map x)               :map
-      (instance? IPersistentVector x) :vector
-      (instance? List x)              :list
-      (instance? IPersistentSet x)    :set
+      ;; Records and collections may define a custom `print-method`; prefer it
+      ;; over structural printing so their intended representation is kept.
+      (structural-tag x)              (if (custom-print-method? x)
+                                        :custom
+                                        (structural-tag x))
       (instance? Eduction x)          :list
       (instance? Var x)               :default
       (.isArray (class x))            :array
@@ -104,7 +179,8 @@
                  (.write w "..."))
                (.write w suffix))
            ;; Special case: collection has zero elements.
-           (print-method x w)))
+           (do (.write w prefix)
+               (.write w suffix))))
        (finally (when-not (nil? level)
                   (set! *print-level* level)))))))
 
@@ -179,6 +255,21 @@
               (.getSimpleName (class x))
               (.getName (class x))))
   (print-map x w))
+
+(defn- print-structurally
+  "Print `x` with orchard's own structural printer even if its type has a
+  custom `print-method`."
+  [x, ^Writer w]
+  ((get-method print (structural-tag x)) x w))
+
+(defmethod print :custom [x, ^Writer w]
+  ;; The value's type defines its own representation - honor it. But a custom
+  ;; print-method is arbitrary user code: if it throws, or overflows the stack
+  ;; on a self-referential value (#412), fall back to structural printing.
+  ;; TotalLimitExceeded extends Error, so it propagates through both catches.
+  (try (print-method x w)
+       (catch StackOverflowError _ (print-structurally x w))
+       (catch Exception _ (print-structurally x w))))
 
 (defmethod print :array [x, ^Writer w]
   (let [ct (.getName (or (.getComponentType (class x)) Object))

--- a/test/orchard/print_test.clj
+++ b/test/orchard/print_test.clj
@@ -40,6 +40,86 @@
 (defrecord TestRecord [a b c d])
 (defrecord EmptyRecord [])
 
+;; A record and a java.util.Map that define their own `print-method` - like
+;; `overtone.at-at`'s RecurringJob (#412) or `tech.ml.dataset` datasets (CIDER
+;; #4088).  Orchard should render them with that method instead of traversing.
+(defrecord PrintMethodRecord [id peer])
+(defmethod print-method PrintMethodRecord [x ^java.io.Writer w]
+  (.write w (str "#<PrintMethodRecord " (:id x) ">")))
+
+;; Only the interfaces matter for these fixtures: values with a custom
+;; print-method are never traversed, so no method bodies are needed.
+(deftype PrintMethodMap []
+  java.util.Map)
+(defmethod print-method PrintMethodMap [_ ^java.io.Writer w]
+  (.write w "#dataset[...]"))
+
+;; The exact shape of a `tech.ml.dataset` dataset: implements both
+;; java.util.Map and IPersistentMap, and defines its own `print-method`.
+(deftype PrintMethodDataset []
+  java.util.Map
+  clojure.lang.IPersistentMap)
+(defmethod print-method PrintMethodDataset [_ ^java.io.Writer w]
+  (.write w "#dataset[5x2]"))
+
+(deftype PrintMethodList []
+  java.util.List)
+(defmethod print-method PrintMethodList [_ ^java.io.Writer w]
+  (.write w "#custom-list[...]"))
+
+;; An IPersistentMap that does NOT implement java.util.Map. Orchard's :map
+;; printer requires java.util.Map, so such types must print via print-method.
+(deftype PurePersistentMap [^clojure.lang.IPersistentMap m]
+  clojure.lang.IPersistentMap
+  (seq [_] (seq m)) (count [_] (count m))
+  (iterator [_] (.iterator ^Iterable m))
+  (valAt [_ k] (get m k)) (valAt [_ k d] (get m k d))
+  (equiv [this that] (identical? this that)))
+
+;; Clojure collection types (not just Java ones) with their own print-method.
+(deftype PrintMethodVector [v]
+  clojure.lang.IPersistentVector)
+(defmethod print-method PrintMethodVector [^PrintMethodVector x ^java.io.Writer w]
+  (.write w (str "#custom-vec" (.-v x))))
+
+(deftype PrintMethodSet [s]
+  clojure.lang.IPersistentSet)
+(defmethod print-method PrintMethodSet [^PrintMethodSet x ^java.io.Writer w]
+  (.write w (str "#custom-set" (vec (.-s x)))))
+
+;; Custom print-methods are arbitrary user code and may misbehave; orchard
+;; must fall back to structural printing instead of crashing.
+(defrecord ThrowingPrintRecord [id])
+(defmethod print-method ThrowingPrintRecord [_ _]
+  (throw (ex-info "boom" {})))
+
+(defrecord RecursivePrintRecord [id peer])
+(defmethod print-method RecursivePrintRecord [x ^java.io.Writer w]
+  ;; Loops forever, like a print-method descending a cyclic value (#412).
+  (print-method x w))
+
+;; A java.util.Map whose print-method resolution is ambiguous (two matching
+;; implementations, no preference). get-method throws for such values, but
+;; printing them must survive that and fall back to structural.
+(definterface AmbiguousPrintA)
+(definterface AmbiguousPrintB)
+(deftype AmbiguousPrintMap [^java.util.Map m]
+  AmbiguousPrintA AmbiguousPrintB
+  java.util.Map
+  (get [_ k] (.get m k)) (size [_] (.size m)) (isEmpty [_] (.isEmpty m))
+  (entrySet [_] (.entrySet m)) (keySet [_] (.keySet m)) (values [_] (.values m))
+  (containsKey [_ k] (.containsKey m k)))
+(defmethod print-method AmbiguousPrintA [_ ^java.io.Writer w] (.write w "A"))
+(defmethod print-method AmbiguousPrintB [_ ^java.io.Writer w] (.write w "B"))
+
+;; Same ambiguity for a List: the empty case takes a different code path
+;; (print-coll delegates empty collections to print-method).
+(deftype AmbiguousPrintList [^java.util.List l]
+  AmbiguousPrintA AmbiguousPrintB
+  java.util.List
+  (size [_] (.size l)) (isEmpty [_] (.isEmpty l))
+  (iterator [_] (.iterator l)))
+
 (defn sample-writer [atom-limit total-limit & strings]
   (let [writer (TruncatingStringWriter. atom-limit total-limit)]
     (try (run! #(.write writer ^String %) strings)
@@ -162,6 +242,62 @@
 (deftest print-custom-print-method
   (is (= "hello"
          (sut/print-str (with-meta (->TestRecord 1 2 3 4) {:type ::custom-rec})))))
+
+(deftest honor-print-method-test
+  (testing "records with a custom print-method are rendered with it, not structurally"
+    (is (= "#<PrintMethodRecord 1>" (sut/print-str (->PrintMethodRecord 1 nil)))))
+
+  (testing "Java collections with a custom print-method are rendered with it (CIDER #4088)"
+    (is (= "#dataset[...]" (sut/print-str (PrintMethodMap.)))))
+
+  (testing "types implementing both IPersistentMap and java.util.Map honor their print-method (tech.ml.dataset shape)"
+    (is (= "#dataset[5x2]" (sut/print-str (PrintMethodDataset.)))))
+
+  (testing "Java lists with a custom print-method are rendered with it"
+    (is (= "#custom-list[...]" (sut/print-str (PrintMethodList.)))))
+
+  (testing "a self-referential value uses its print-method instead of overflowing (#412)"
+    (let [x (->PrintMethodRecord 2 nil)]
+      (is (= "#<PrintMethodRecord 2>" (sut/print-str (assoc x :peer x))))))
+
+  (testing "plain records and collections are still printed structurally"
+    (is (= "#TestRecord{:a 1, :b 2, :c 3, :d 4}" (sut/print-str (->TestRecord 1 2 3 4))))
+    (is (= "{:a 1}" (sut/print-str {:a 1})))
+    (is (= "[1 2 3]" (sut/print-str [1 2 3])))
+    (is (= "{\"a\" 1}" (sut/print-str (java.util.HashMap. {"a" 1}))))
+    (is (= "(1 2 3)" (sut/print-str (java.util.ArrayList. [1 2 3])))))
+
+  (testing "Clojure vector and set types with a custom print-method are rendered with it"
+    (is (= "#custom-vec[1 2 3]" (sut/print-str (PrintMethodVector. [1 2 3]))))
+    (is (= "#custom-set[1 2 3]" (sut/print-str (PrintMethodSet. (sorted-set 1 2 3))))))
+
+  (testing "IPersistentMap-only types still print via their print-method"
+    (is (= "{:a 1}" (sut/print-str (PurePersistentMap. {:a 1})))))
+
+  (testing "a throwing print-method falls back to structural printing"
+    (is (= "#ThrowingPrintRecord{:id 1}" (sut/print-str (->ThrowingPrintRecord 1)))))
+
+  (testing "a print-method that overflows the stack falls back to structural printing (#412)"
+    (is (= "#RecursivePrintRecord{:id 1, :peer nil}"
+           (sut/print-str (->RecursivePrintRecord 1 nil)))))
+
+  (testing "ambiguous print-method implementations don't break printing"
+    (is (= "{\"a\" 1}"
+           (sut/print-str (AmbiguousPrintMap. (java.util.HashMap. {"a" 1})))))
+    (is (= "(1 2 3)"
+           (sut/print-str (AmbiguousPrintList. (java.util.ArrayList. [1 2 3])))))
+    (is (= "()" (sut/print-str (AmbiguousPrintList. (java.util.ArrayList.))))))
+
+  (testing "re-registering a generic print-method doesn't disable structural printing"
+    (let [orig (get-method print-method java.util.Map)]
+      (try
+        ;; Simulates a namespace reload: a fresh fn is registered for the
+        ;; same generic interface.
+        (.addMethod ^clojure.lang.MultiFn print-method java.util.Map
+                    (fn [m w] (orig m w)))
+        (is (= "{\"a\" 1}" (sut/print-str (java.util.HashMap. {"a" 1}))))
+        (finally
+          (.addMethod ^clojure.lang.MultiFn print-method java.util.Map orig))))))
 
 (deftest qualified-keywords-compaction
   (are [kw repr] (= repr (sut/print-str kw))


### PR DESCRIPTION
Fixes #414, and gets at the root cause behind #412 and clojure-emacs/cider#4088.

The printer descends into records and collections structurally, even when the type already knows how to print itself via `print-method`. So a `tech.ml.dataset` dataset comes out as a raw `{...}` dump instead of its table, and at-at's `RecurringJob` (which has a perfectly good `#<RecurringJob ...>` printer) sends us walking into its own cyclic internals until the stack overflows. `pr` and `clojure.pprint` avoid all of this by deferring to `print-method` for such types.

So that is the fix: when a value's `print-method` is more specific than the generic collection one, hand off to it instead of walking the structure. This covers records, Java collections and Clojure collection deftypes alike. Plain maps, vectors and records print exactly as before, so the truncation and print-level limits are untouched; only types that went out of their way to define their own representation are affected.

Two gotchas worth flagging:

- You cannot just hardcode the set of "generic" methods. `ArrayList`, for instance, resolves its `print-method` through `java.util.RandomAccess`, so a hand-picked list ends up flagging plain lists as custom. I derive the set from Clojure's own registrations instead, cache the per-class verdicts, and drop the cache whenever `print-method` gains or loses implementations, so REPL reloads can't confuse it.
- A custom `print-method` is arbitrary user code. If it throws, or overflows the stack on a self-referential value, we fall back to orchard's structural printing instead of crashing the inspector.

#413 already stops the crash by capping the depth; this is the other half, making the output correct and skipping the doomed traversal entirely.

`orchard.pp` has its own dispatch and still prints such values structurally in pretty mode; I'll address that separately.
