### PR TITLE
[pp] Honor custom print-method for Clojure collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#413](https://github.com/clojure-emacs/orchard/pull/413): Print: protect against StackOverflow when printing recursive collections.
 - [#416](https://github.com/clojure-emacs/orchard/pull/416): Inspector: add string analytics.
 - [#415](https://github.com/clojure-emacs/orchard/pull/415): Print: honor a custom `print-method` for records and collections instead of traversing them structurally.
+- [#417](https://github.com/clojure-emacs/orchard/pull/417): Pretty-print: honor a custom `print-method` for records and collections (follow-up to [#415](https://github.com/clojure-emacs/orchard/pull/415)).
 
 ## 0.44.0 (2026-07-04)
 

--- a/src/orchard/pp.clj
+++ b/src/orchard/pp.clj
@@ -148,14 +148,48 @@
   [level]
   (and (int? *print-level*) (= level *print-level*)))
 
+(defn ^:private descend-print-level
+  "Return the *print-level* value to bind when rendering a whole subform at
+  nesting level (:level opts)."
+  [opts]
+  (when *print-level*
+    (- *print-level* (:level opts 0))))
+
 (defn- print-str-linear
   "Print an object in linear style (without regard to line length) and return as a
   string. Options:
   - :level (long) - the current nesting level."
   ^String [x opts]
-  (binding [*print-level* (when *print-level*
-                            (- *print-level* (:level opts 0)))]
+  (binding [*print-level* (descend-print-level opts)]
     (print/print-str x)))
+
+(defn ^:private write-multiline
+  "Write a pre-rendered, possibly multi-line string, keeping the writer's line
+  accounting correct and indenting continuation lines."
+  [writer ^String s ^String indentation]
+  (if (neg? (.indexOf s "\n"))
+    (write writer s)
+    (let [[line & more] (str/split s #"\n" -1)]
+      (write writer line)
+      (doseq [^String line more]
+        (nl writer)
+        (write writer indentation)
+        (write writer line)))))
+
+(defn ^:private custom-print-str
+  "Render `x` via its custom `print-method` (see
+  `orchard.print/custom-print-method?`), bounded by orchard.print's limits.
+  Return nil if the print-method throws or overflows the stack, so the caller
+  can fall back to structural printing."
+  ^String [x opts]
+  (let [w (TruncatingStringWriter. print/*max-atom-length*
+                                   print/*max-total-length*)]
+    (binding [*print-level* (descend-print-level opts)]
+      (try (print-method x w)
+           (str w)
+           (catch TruncatingStringWriter$TotalLimitExceeded _ (str w))
+           (catch StackOverflowError _ nil)
+           (catch Exception _ nil)))))
 
 (defn ^:private print-mode
   "Given a CountKeepingWriter, a form, and an options map, return a keyword
@@ -334,6 +368,20 @@
       (write writer "#≠")
       (-pprint coll writer (update opts :indentation str "  ")))))
 
+(defn ^:private -pprint-or-custom
+  "Like the structural pretty-printer `f`, but if `this` defines a custom
+  `print-method`, print with that instead (multi-line aware, honoring
+  *print-meta* and *print-level*). Fall back to `f` when the custom
+  print-method fails."
+  [f this writer opts]
+  (if-some [s (when (and (print/custom-print-method? this)
+                         ;; At *print-level*, `f` prints just "#".
+                         (not (meets-print-level? (:level opts))))
+                (custom-print-str this opts))]
+    (do (pprint-meta this writer opts :linear)
+        (write-multiline writer s (:indentation opts)))
+    (f this writer opts)))
+
 (extend-protocol PrettyPrintable
   nil
   (-pprint [_ writer _]
@@ -341,23 +389,23 @@
 
   clojure.lang.AMapEntry
   (-pprint [this writer opts]
-    (-pprint-coll this writer opts))
+    (-pprint-or-custom -pprint-coll this writer opts))
 
   clojure.lang.ISeq
   (-pprint [this writer opts]
-    (-pprint-seq this writer opts))
+    (-pprint-or-custom -pprint-seq this writer opts))
 
   clojure.lang.IPersistentMap
   (-pprint [this writer opts]
-    (-pprint-map this writer opts))
+    (-pprint-or-custom -pprint-map this writer opts))
 
   clojure.lang.IPersistentVector
   (-pprint [this writer opts]
-    (-pprint-coll this writer opts))
+    (-pprint-or-custom -pprint-coll this writer opts))
 
   clojure.lang.IPersistentSet
   (-pprint [this writer opts]
-    (-pprint-coll this writer opts))
+    (-pprint-or-custom -pprint-coll this writer opts))
 
   clojure.lang.PersistentQueue
   (-pprint [this writer opts]
@@ -371,7 +419,9 @@
   (-pprint [this writer opts]
     (if (array? this)
       (-pprint-seq this writer opts)
-      (write writer (print-str-linear this opts)))))
+      ;; Multi-line aware: e.g. a deftype's custom print-method may render
+      ;; a multi-line representation (a tech.ml.dataset table, say).
+      (write-multiline writer (print-str-linear this opts) (:indentation opts)))))
 
 (defn pprint
   "Pretty-print an object into `writer` (*out* by default). Options:

--- a/src/orchard/print.clj
+++ b/src/orchard/print.clj
@@ -57,7 +57,7 @@
                                        structural-print-interfaces)
                                  (ConcurrentHashMap.))))))
 
-(defn- custom-print-method?
+(defn custom-print-method?
   "True if `x` has a `print-method` more specific than the generic collection
   implementations - i.e. a deliberate custom textual representation that orchard
   should use instead of traversing the value's structure.  This keeps records

--- a/test/orchard/pp_test.clj
+++ b/test/orchard/pp_test.clj
@@ -289,6 +289,65 @@
     (is (= 2003 (count (binding [print/*max-total-length* 2000]
                          (print/print-str orchard.print-test/infinite-map)))))))
 
+;; A tech.ml.dataset-shaped type whose print-method renders a multi-line
+;; table, like the real thing.
+(deftype MultilinePrintDataset []
+  java.util.Map
+  clojure.lang.IPersistentMap)
+(defmethod print-method MultilinePrintDataset [_ ^java.io.Writer w]
+  (.write w "| :a |\n|----|\n|  1 |"))
+
+(deftest honor-print-method-test
+  (testing "records with a custom print-method are rendered with it, not structurally"
+    (is (= "#<PrintMethodRecord 1>\n"
+           (pp (orchard.print-test/->PrintMethodRecord 1 nil)))))
+
+  (testing "types implementing both IPersistentMap and java.util.Map honor their print-method (tech.ml.dataset shape)"
+    (is (= "#dataset[5x2]\n" (pp (orchard.print-test/->PrintMethodDataset)))))
+
+  (testing "Clojure vector and set types with a custom print-method are rendered with it"
+    (is (= "#custom-vec[1 2 3]\n"
+           (pp (orchard.print-test/->PrintMethodVector [1 2 3]))))
+    (is (= "#custom-set[1 2 3]\n"
+           (pp (orchard.print-test/->PrintMethodSet (sorted-set 1 2 3))))))
+
+  (testing "custom representations nest in miser mode"
+    (is (= "{:dataset\n #dataset[5x2],\n :other-key\n 42}\n"
+           (pp {:dataset (orchard.print-test/->PrintMethodDataset) :other-key 42}
+               :max-width 12))))
+
+  (testing "multi-line custom representations keep indentation and line accounting"
+    (is (= "| :a |\n|----|\n|  1 |\n" (pp (MultilinePrintDataset.))))
+    (is (= "{:dataset | :a |\n |----|\n |  1 |, :key-2 [1 2 3]}\n"
+           (pp {:dataset (MultilinePrintDataset.) :key-2 [1 2 3]})))
+    (is (= "{:dataset\n | :a |\n |----|\n |  1 |,\n :key-2\n [1 2 3]}\n"
+           (pp {:dataset (MultilinePrintDataset.) :key-2 [1 2 3]} :max-width 10))))
+
+  (testing "*print-level* still truncates custom-printed values"
+    (is (= "{#}\n"
+           (pp {:a (orchard.print-test/->PrintMethodDataset)} :print-level 1))))
+
+  (testing "*print-meta* is still honored for custom-printed values"
+    (is (= "^{:m 1} #<PrintMethodRecord 1>\n"
+           (pp (with-meta (orchard.print-test/->PrintMethodRecord 1 nil) {:m 1})
+               :print-meta true))))
+
+  (testing "a throwing print-method falls back to structural pretty-printing"
+    (is (= "#ThrowingPrintRecord{:id 1}\n"
+           (pp (orchard.print-test/->ThrowingPrintRecord 1))))
+    ;; A wide value still gets wrapped structural output, not one long line.
+    (is (str/starts-with?
+         (pp (orchard.print-test/->ThrowingPrintRecord (vec (range 20))) :max-width 20)
+         "#ThrowingPrintRecord{:id\n")))
+
+  (testing "plain records and collections are still printed structurally"
+    (is (= "#TestRecord{:a 1, :b 2, :c 3, :d 4}\n"
+           (pp (orchard.print-test/->TestRecord 1 2 3 4))))
+    (is (= "{:a 1}\n" (pp {:a 1})))
+    (is (= "[1 2 3]\n" (pp [1 2 3])))
+    (is (= "#{1 2 3}\n" (pp (sorted-set 1 2 3))))
+    (is (= "(1 2 3)\n" (pp '(1 2 3))))))
+
 (deftest short-record-names-test
   (testing "*short-record-names* controls how records are printed"
     (is (= "#TestRecord{:a (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14),


### PR DESCRIPTION
Follow-up to #415. `orchard.pp` has its own structural dispatch (the `PrettyPrintable` protocol), so the pretty-print view still traversed records, datasets and collection deftypes that define their own `print-method`.

Now the collection extensions consult `orchard.print/custom-print-method?` (made public here) and print the custom representation instead. The interesting part is layout: a real `tech.ml.dataset` prints a multi-line table, so the custom output is written line by line to keep the writer's column accounting and indentation intact - the `Object` fallback gets the same treatment. `*print-level*` and `*print-meta*` behave as before, and if a custom `print-method` throws, we fall back to the regular structural pretty-printing.