### PR TITLE
[pp] Keep line accounting intact for multi-line object reprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#413](https://github.com/clojure-emacs/orchard/pull/413): Print: protect against StackOverflow when printing recursive collections.
 - [#416](https://github.com/clojure-emacs/orchard/pull/416): Inspector: add string analytics.
 - [#415](https://github.com/clojure-emacs/orchard/pull/415): Print: honor a custom `print-method` for records and collections instead of traversing them structurally.
+- [#418](https://github.com/clojure-emacs/orchard/pull/418): Pretty-print: keep indentation and line accounting intact for multi-line object representations.
 
 ## 0.44.0 (2026-07-04)
 

--- a/src/orchard/pp.clj
+++ b/src/orchard/pp.clj
@@ -157,6 +157,19 @@
                             (- *print-level* (:level opts 0)))]
     (print/print-str x)))
 
+(defn ^:private write-multiline
+  "Write a pre-rendered, possibly multi-line string, keeping the writer's line
+  accounting correct and indenting continuation lines."
+  [writer ^String s ^String indentation]
+  (if (neg? (.indexOf s "\n"))
+    (write writer s)
+    (let [[line & more] (str/split s #"\n" -1)]
+      (write writer line)
+      (doseq [^String line more]
+        (nl writer)
+        (write writer indentation)
+        (write writer line)))))
+
 (defn ^:private print-mode
   "Given a CountKeepingWriter, a form, and an options map, return a keyword
   indicating a printing mode (:linear or :miser)."
@@ -371,7 +384,9 @@
   (-pprint [this writer opts]
     (if (array? this)
       (-pprint-seq this writer opts)
-      (write writer (print-str-linear this opts)))))
+      ;; The representation may span multiple lines (e.g. a custom
+      ;; print-method rendering a table); keep line accounting intact.
+      (write-multiline writer (print-str-linear this opts) (:indentation opts)))))
 
 (defn pprint
   "Pretty-print an object into `writer` (*out* by default). Options:

--- a/test/orchard/pp_test.clj
+++ b/test/orchard/pp_test.clj
@@ -289,6 +289,18 @@
     (is (= 2003 (count (binding [print/*max-total-length* 2000]
                          (print/print-str orchard.print-test/infinite-map)))))))
 
+;; A type whose print-method renders multiple lines (like a tech.ml.dataset
+;; table). Such representations reach the Object branch of PrettyPrintable.
+(deftype MultilineObject [])
+(defmethod print-method MultilineObject [_ ^java.io.Writer w]
+  (.write w "| :a |\n|----|\n|  1 |"))
+
+(deftest multiline-object-repr-test
+  (testing "multi-line representations keep indentation and line accounting"
+    (is (= "| :a |\n|----|\n|  1 |\n" (pp (MultilineObject.))))
+    (is (= "{:table | :a |\n |----|\n |  1 |, :x 1}\n"
+           (pp {:table (MultilineObject.) :x 1})))))
+
 (deftest short-record-names-test
   (testing "*short-record-names* controls how records are printed"
     (is (= "#TestRecord{:a (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14),


### PR DESCRIPTION
A value whose representation spans multiple lines (e.g. a custom `print-method` rendering a table) was written to the count-keeping writer in one shot. The column counter absorbed the whole string, so everything after it on the parent form was forced into miser mode, and the continuation lines themselves lost their indentation. Writing such representations line by line fixes both.

Split out of #417.