### PR TITLE
[ci] Tune test matrices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
                 name: Running tests (make << parameters.command >>)
                 command: make << parameters.command >>
 
-  test_windows:
+  test-windows:
     description: |
       Run tests on MS-Windows using the system's JDK version and Clojure 1.12.
     executor: win/default
@@ -181,36 +181,47 @@ workflows:
     jobs:
       - test:
           matrix:
-            alias: "test"
+            # Test latest stable Clojure with all supported JDKs.
+            alias: "test-1.12"
             parameters:
-              jdk_version: [jdk8, jdk26]
-              clojure_version: ["1.10", "1.11", "1.12", "1.13"]
-          <<: *run_always
-      - test:
-          matrix:
-            alias: "test-inbetween-jdks"
-            parameters:
-              jdk_version: [jdk11, jdk17, jdk21, jdk25]
+              jdk_version: [jdk8, jdk11, jdk17, jdk21, jdk25, jdk26]
               clojure_version: ["1.12"]
           <<: *run_always
       - test:
           matrix:
-            alias: "test_with_cljs"
+            # Test future Clojure with all JDKs it supports (17+).
+            alias: "test-1.13"
+            parameters:
+              jdk_version: [jdk17, jdk21, jdk25, jdk26]
+              clojure_version: ["1.13"]
+          <<: *run_always
+      - test:
+          matrix:
+            # Test older Clojure versions against min and max supported JDK version.
+            alias: "test-older"
+            parameters:
+              jdk_version: [jdk8, jdk26]
+              clojure_version: ["1.10", "1.11"]
+          <<: *run_always
+      - test:
+          matrix:
+            alias: "test-with-cljs"
             parameters:
               jdk_version: [jdk26]
               clojure_version: ["1.12"]
               command: ["test-with-cljs"]
           <<: *run_always
-      - test_windows:
+      - test-windows:
           <<: *run_always
       - lint:
           <<: *run_always
       - deploy:
           requires:
-            - test
-            - test-inbetween-jdks
-            - test_with_cljs
-            - test_windows
+            - test-1.12
+            - test-1.13
+            - test-older
+            - test-with-cljs
+            - test-windows
             - lint
           filters:
             branches:

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources" "target/classes"]
- :deps {org.clojure/clojure {:mvn/version "1.12.4" :mvn/scope "provided"}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.5" :mvn/scope "provided"}}
 
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
@@ -7,7 +7,7 @@
           :ns-default build.main}
 
   :dev {:extra-paths ["test" "test-resources"]
-        :extra-deps {org.clojure/clojure$sources {:mvn/version "1.12.4"}
+        :extra-deps {org.clojure/clojure$sources {:mvn/version "1.12.5"}
                      io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
                                                            :git/sha "dfb30dd"}
                      nubank/matcher-combinators {:mvn/version "3.9.1"}}}
@@ -18,8 +18,8 @@
                          org.clojure/clojure$sources {:mvn/version "1.11.4"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.5"}
                          org.clojure/clojure$sources {:mvn/version "1.12.5"}}}
-  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha2"}
-                         org.clojure/clojure$sources {:mvn/version "1.13.0-alpha2"}}}
+  :1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha5"}
+                         org.clojure/clojure$sources {:mvn/version "1.13.0-alpha5"}}}
 
   ;; Should be run together with :dev alias.
   :test {:extra-paths ["test-resources/not-a.jar"

--- a/test/orchard/inspect_test.clj
+++ b/test/orchard/inspect_test.clj
@@ -959,11 +959,7 @@
                           "#'clojure.core/restart-agent #'clojure.core/sort-by ...]") pos?]]
 
           "Imports"
-          ["  " [:value #=(str "{Enum java.lang.Enum, "
-                               "InternalError java.lang.InternalError, "
-                               "NullPointerException java.lang.NullPointerException, "
-                               "InheritableThreadLocal java.lang.InheritableThreadLocal, "
-                               "Class java.lang.Class, ...}") pos?]]
+          ["  " [:value #"^\{.*Enum java.lang.Enum.*NullPointerException java.lang.NullPointerException.*" pos?]]
 
           "Interns"
           ["  " [:value #=(str "{ends-with? #'clojure.string/ends-with?, "


### PR DESCRIPTION
Since Clojure 1.13 is now only supported with JDK17+, I've rotated test matrices a bit. Now we have:
- stable Clojure (1.12) tested with all supported JDKs
- alpha Clojure (1.13) tested with jdk17+
- previous Clojure versions sanity-tested with oldest jdk (8) and latest (26).