### PR TITLE
Point the pom's scm tag at the actual git tag

### DIFF
--- a/build/main.clj
+++ b/build/main.clj
@@ -13,7 +13,7 @@
     {;; Pom section
      :lib lib
      :version version
-     :scm {:url url, :tag version}
+     :scm {:url url, :tag (str "v" version)}
      :pom-data [[:description "A fertile ground for Clojure tooling"]
                 [:url url]
                 [:licenses


### PR DESCRIPTION
cljdoc reads the pom's scm tag verbatim, and ours has been the bare version since the move to tools.build while the git tags carry a `v`, so the docs for 0.43.0 and 0.44.0 never built ("No Git repository found for library"). Leiningen used to write the commit sha there, which is why the older versions are fine. Same fix as nrepl/nrepl#473.