### PR TITLE
Cap the heap via JAVA_OPTS so JDK 11 stops getting OOM-killed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,11 @@ orbs:
 defaults: &defaults
   working_directory: ~/repo
   environment:
-    JVM_OPTS: -Xmx3200m -Dclojure.main.report=stderr
+    # The Clojure CLI honors JAVA_OPTS, not JVM_OPTS (a Leiningen convention),
+    # so the earlier JVM_OPTS was silently ignored. Without a heap cap JDK 11,
+    # which lacks the cgroup memory-limit detection JDK 17+ have, sizes its
+    # heap off the host's RAM and gets OOM-killed inside the container.
+    JAVA_OPTS: -Xmx2500m -Dclojure.main.report=stderr
 
 # Runners for each major OpenJDK
 


### PR DESCRIPTION
The Clojure CLI reads JAVA_OPTS, not JVM_OPTS, so the heap cap and `clojure.main.report=stderr` were never applied. Without a cap, JDK 11 sizes its heap off the host and gets OOM-killed inside the container, which is what has been killing test-1.12-jdk11 (jobs 74777, 74810, 74918, 75073). Same fix cider-nrepl got in 9427fb86.