### PR TITLE
Retry dependency resolution, fix the cache key, widen the deploy filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,9 @@ workflows:
           <<: *run_always
       - lint:
           <<: *run_always
+      # Releases, prereleases and snapshots all go through the same gate: the
+      # whole matrix has to be green first. A vX.Y.Z-SNAPSHOT tag is the way
+      # to exercise the full release path without cutting a release.
       - deploy:
           requires:
             - test
@@ -256,4 +259,6 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v\d+\.\d+\.\d+(-alpha\d+)?$/
+              only:
+                - /^v\d+\.\d+\.\d+(-(alpha|beta|rc)\d+)?$/
+                - /^v\d+\.\d+\.\d+-SNAPSHOT$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,40 @@ commands:
             - base-jdk-src.zip
           key: cache2-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
+  prepare_deps:
+    description: |
+      Resolve the dependencies for the build tooling and the given alias
+      groups up front, retrying on failure. Computing a classpath occasionally
+      dies with a ClassCastException from HashMap internals: Maven's model
+      validator caches the coordinates it has validated in an unsynchronized
+      HashSet, and tools.deps resolves on several threads at once. It strikes
+      whenever .cpcache misses, and a retry is all it takes.
+    parameters:
+      aliases:
+        description: |
+          Space-separated alias groups to prepare, e.g. ":1.12:dev:test :kondo"
+        type: string
+    steps:
+      - run:
+          name: Preparing dependencies
+          command: |
+            prepare() {
+              clojure -P -T:build || return 1
+              for aliases in << parameters.aliases >>; do
+                clojure -P -M"$aliases" || return 1
+              done
+            }
+            attempt=1
+            until prepare; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "Giving up after $attempt attempts."
+                exit 1
+              fi
+              attempt=$((attempt + 1))
+              echo "Resolving dependencies failed, retrying..."
+              sleep 5
+            done
+
   setup-windows:
     steps:
       - checkout
@@ -106,6 +140,8 @@ jobs:
       - with_cache:
           cache_version: "lint_v3_<< parameters.clojure_version >>"
           steps:
+            - prepare_deps:
+                aliases: ":cljfmt :kondo :eastwood"
             - run:
                 name: Running cljfmt
                 command: make cljfmt
@@ -138,6 +174,10 @@ jobs:
       clojure_version:
         description: Version of Clojure to test against
         type: string
+      extra_aliases:
+        description: Extra aliases the command's tests need, e.g. ":+cljs"
+        type: string
+        default: ""
     executor: << parameters.jdk_version >>
     environment:
       CLOJURE_VERSION: << parameters.clojure_version >>
@@ -146,6 +186,8 @@ jobs:
       - with_cache:
           cache_version: "test_v3_<< parameters.clojure_version >>_<< parameters.jdk_version >>_<< parameters.command >>"
           steps:
+            - prepare_deps:
+                aliases: ":<< parameters.clojure_version >>:dev:test<< parameters.extra_aliases >>"
             - run:
                 name: Running tests (make << parameters.command >>)
                 command: make << parameters.command >>
@@ -200,6 +242,7 @@ workflows:
               jdk_version: [jdk26]
               clojure_version: ["1.12"]
               command: ["test-with-cljs"]
+              extra_aliases: [":+cljs"]
           <<: *run_always
       - test_windows:
           <<: *run_always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,7 @@ commands:
       - run:
           name: Generate Cache Checksum
           command: |
-            for file in << parameters.files >>
-            do
-              find . -name $file -exec cat {} +
-            done | sha256sum | awk '{print $1}' > /tmp/clojure_cache_seed
+            cat << parameters.files >> | sha256sum | awk '{print $1}' > /tmp/clojure_cache_seed
       - restore_cache:
           key: cache2-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
       - steps: << parameters.steps >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,15 +113,6 @@ commands:
               sleep 5
             done
 
-  setup-windows:
-    steps:
-      - checkout
-      - run:
-          name: Install Clojure CLI
-          command: |
-            Invoke-WebRequest -Uri https://github.com/clojure/brew-install/releases/latest/download/win-install.ps1 -OutFile win-install.ps1
-            powershell -File win-install.ps1
-
 jobs:
 
   lint:
@@ -191,16 +182,32 @@ jobs:
 
   test_windows:
     description: |
-      Run tests on MS-Windows using the system's JDK version and Clojure 1.12.
+      Run tests on MS-Windows with Temurin JDK 21 and Clojure 1.12.
     executor: win/default
     steps:
-      - setup-windows
+      - checkout
+      - run:
+          name: Install the JDK and the Clojure CLI
+          command: |
+            choco install temurin21 --no-progress -y; if(-not $?){exit 9}
+            Invoke-WebRequest -Uri https://github.com/clojure/brew-install/releases/latest/download/win-install.ps1 -OutFile win-install.ps1
+            powershell -File win-install.ps1
+      - restore_cache:
+          key: windows-cache-1-{{ checksum "deps.edn" }}
       - run:
           name: Running tests on Windows
           command: |
+            $env:JAVA_HOME = (Get-ChildItem 'C:\Program Files\Eclipse Adoptium\jdk-21*' | Select-Object -First 1).FullName
+            if (-not $env:JAVA_HOME) { Write-Error "Temurin JDK 21 not found"; exit 9 }
+            $env:Path = "$env:JAVA_HOME\bin;$env:Path"
             java -version; if(-not $?){exit 9}
             clojure -T:build javac :with-tests true; if(-not $?){exit 9}
             clojure -X:1.12:dev:test:+cljs; if(-not $?){exit 9}
+      - save_cache:
+          key: windows-cache-1-{{ checksum "deps.edn" }}
+          paths:
+            - C:\Users\circleci\.m2
+            - .cpcache
 
 # The ci-test-matrix does the following:
 #

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ git push --tags
 git push
 ```
 
+A `vX.Y.Z-SNAPSHOT` tag runs the same pipeline, tests included, and deploys a
+snapshot, which is a cheap way to exercise the whole release path first.
+
 ### Tests and formatting
 
 To run the CI tasks locally use:


### PR DESCRIPTION
Same set of changes as nrepl/nrepl#479, since the config is the same template. Resolving the classpath occasionally dies inside Maven's model validator (job 75145 here), so dependencies are now resolved in a retried step first. The cache key never included build/main.clj, because `find -name` doesn't match paths. The deploy filter now takes -beta/-rc and vX.Y.Z-SNAPSHOT tags through the same gated job. And the Windows job installs Temurin 21 and caches its dependencies instead of running on the image's JDK of the day.

This overlaps with #420 on the matrix section, so whichever lands second needs a rebase.