### PR TITLE
Tidy up the Makefile and the Java build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test: download-jdk-src javac-test
 test-with-cljs: download-jdk-src javac-test
 	clojure -X:$(CLOJURE_VERSION):dev:test:+cljs
 
-eastwood: clean javac-test
+eastwood: javac-test
 	clojure -M:eastwood
 
 cljfmt:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-.PHONY: test eastwood cljfmt kondo install deploy clean lint copy-sources-to-jdk javac javac-test
+.PHONY: test test-with-cljs eastwood cljfmt kondo install deploy clean lint download-jdk-src javac javac-test check-env check-install-env
 .DEFAULT_GOAL := install
 
 # Set bash instead of sh for the @if [[ conditions,
 # and use the usual safety flags:
 SHELL = /bin/bash -Ee
 
-HOME=$(shell echo $$HOME)
 CLOJURE_VERSION ?= 1.12
 
 resources/clojuredocs/export.edn:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-with-cljs eastwood cljfmt kondo install deploy clean lint download-jdk-src javac javac-test check-env check-install-env
+.PHONY: test test-with-cljs eastwood cljfmt kondo install deploy clean lint download-jdk-src javac javac-test check-env
 .DEFAULT_GOAL := install
 
 # Set bash instead of sh for the @if [[ conditions,
@@ -6,6 +6,8 @@
 SHELL = /bin/bash -Ee
 
 CLOJURE_VERSION ?= 1.12
+# The version local installs get. Releases take theirs from the git tag.
+PROJECT_VERSION ?= 99.99
 
 resources/clojuredocs/export.edn:
 	curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
@@ -53,8 +55,8 @@ deploy: check-env
 	export PROJECT_VERSION=$$(echo "$(CIRCLE_TAG)" | sed 's/^v//'); \
 	clojure -T:build deploy :version "\"$$PROJECT_VERSION\""
 
-# Usage: PROJECT_VERSION=99.99 make install
-install: check-install-env clean
+# Usage: make install (or PROJECT_VERSION=1.2.3 make install)
+install:
 	clojure -T:build install :version '"$(PROJECT_VERSION)"'
 
 clean:
@@ -69,9 +71,4 @@ ifndef CLOJARS_PASSWORD
 endif
 ifndef CIRCLE_TAG
 	$(error CIRCLE_TAG is undefined. Please only perform deployments by publishing git tags. CI will do the rest.)
-endif
-
-check-install-env:
-ifndef PROJECT_VERSION
-	$(error Please set PROJECT_VERSION as an env var beforehand.)
 endif

--- a/README.md
+++ b/README.md
@@ -201,8 +201,11 @@ classpath, it just need to exist in the distribution.
 You can install Orchard locally like this:
 
 ```shell
-PROJECT_VERSION=99.99 make install
+make install
 ```
+
+That installs it as version `99.99` into your local Maven repository; set
+`PROJECT_VERSION` to pick another one.
 
 For releasing to [Clojars](https://clojars.org/):
 

--- a/build/main.clj
+++ b/build/main.clj
@@ -41,12 +41,25 @@
 
 (defcmd clean [opts] (b/delete {:path (:target opts)}))
 
+(defn- javac-opts
+  "Compile for Java 8, the oldest version Orchard supports. `--release` also
+  checks API usage against the Java 8 class library, so a JDK 9+ API slipping
+  in fails on every JDK rather than only on the JDK 8 CI jobs, but the flag
+  itself only exists on JDK 9+. Newer JDKs warn that 8 is obsolete; targeting
+  it is the whole point here, so that lint category is switched off."
+  []
+  (let [spec (System/getProperty "java.specification.version")
+        major (if (.startsWith ^String spec "1.") 8 (Integer/parseInt spec))]
+    (if (>= major 9)
+      ["--release" "8" "-Xlint:-options"]
+      ["-source" "8" "-target" "8"])))
+
 (defcmd javac [{:keys [with-tests] :as opts}]
   (b/javac (assoc opts
                   :src-dirs (if with-tests
                               ["src" "test"]
                               ["src"])
-                  :javac-opts ["-source" "8" "-target" "8"])))
+                  :javac-opts (javac-opts))))
 
 (defcmd download-jdk-src [opts]
   (let [base-file (io/file "base-jdk-src.zip")


### PR DESCRIPTION
Java now compiles with `--release 8` on JDK 9+, which checks API usage against the Java 8 class library on every job instead of only the JDK 8 ones, and stops the obsolete-source warnings. `make install` (and a bare `make`, since install is the default goal) works without `PROJECT_VERSION`, as the README now says, `make eastwood` no longer wipes target/ first, and the phony list matches the targets that exist. Same as nrepl/nrepl#481.